### PR TITLE
Categorize planned polling centers as open/closed

### DIFF
--- a/data/2014_president_election/polling-center-locations/runoff/iec_runoff_polling_centers_en_feb2015
+++ b/data/2014_president_election/polling-center-locations/runoff/iec_runoff_polling_centers_en_feb2015
@@ -1,0 +1,6366 @@
+pc_code,lon,lat,ps_male,pc_name,province,ps_planned,district,ps_female,pc_location,iec_prov_id,map_accuracy,iec_district_id,open,closed,is_open
+101001,69.18066344,34.50867443,3,Ashuqan-O-Arifan High School,Kabul,6,Kabul-D01,3,Achekzai Street,1,Building,1,6,0,TRUE
+101002,69.18442421,34.51014871,3,Molla Muhmod Mosque,Kabul,6,Kabul-D01,3,Shur Bazar,1,Building,1,6,0,TRUE
+101003,69.19297741,34.51460898,2,Akhir Jadah Mosque,Kabul,4,Kabul-D01,2,Maiwand Avenue,1,Building,1,4,0,TRUE
+101004,69.18444624,34.50713492,3,Ashuqan-O-Arifan Secondary School,Kabul,6,Kabul-D01,3,Say Dukan Chendawol,1,Building,1,6,0,TRUE
+101005,69.1559968,34.52654977,2,Pakhta Froshi Mosque,Kabul,5,Kabul-D01,3,Pakhta Froshi Street,1,Building,1,5,0,TRUE
+101006,69.18721595,34.51322974,3,Daqiqi Balkhi Secondary School,Kabul,6,Kabul-D01,3,"Saraji, Ahangari Street",1,Building,1,6,0,TRUE
+101007,69.17832659,34.51254542,3,Mastori Ghori Secondary School,Kabul,6,Kabul-D01,3,Babaie Khudi,1,Building,1,6,0,TRUE
+101008,69.19059729,34.51803438,3,Eidgah Mosque,Kabul,6,Kabul-D01,3,Eidgah,1,Building,1,6,0,TRUE
+101009,69.17740327,34.50990147,2,Bagh-E- Qazi Fateha Khana,Kabul,4,Kabul-D01,2,Bagh-E-Qazi,1,Building,1,4,0,TRUE
+101010,69.17588565,34.5173705,3,Aiesha Durani High School,Kabul,5,Kabul-D01,2,Pul-E-Bagh Umomi,1,Building,1,5,0,TRUE
+101011,69.1744511,34.5124781,2,Bibi Sedeqa Mosque,Kabul,3,Kabul-D01,1,Chendawol,1,Building,1,3,0,TRUE
+101012,69.18836426,34.50472507,1,Sar-E-Gardana Mosque,Kabul,2,Kabul-D01,1,Sar-E-Gardana,1,Building,1,2,0,TRUE
+101013,69.17511911,34.5108701,3,Takya Khana-E-Umomi,Kabul,5,Kabul-D01,2,Chendawol,1,Building,1,5,0,TRUE
+101014,69.178974,34.507042,1,Khwaja Safa Mosque,Kabul,2,Kabul-D01,1,Balajoie Ashuqan-O-Arifan,1,Village,1,2,0,TRUE
+101015,69.17436746,34.51429598,2,Baghban Kucha Mosque,Kabul,3,Kabul-D01,1,Baghban Kucha,1,Building,1,3,0,TRUE
+101016,69.18972,34.52555,3,Ansori Balkhi School,Kabul,5,Kabul-D01,2,Bagh-E-Ali Mardan,1,Village,1,5,0,TRUE
+101017,69.16803187,34.51050534,2,Imam-E-Baqir Mosque,Kabul,3,Kabul-D01,1,Hazara Ha Village,1,Building,1,3,0,TRUE
+101018,69.17562,34.50754,2,Bala Qala Mosque,Kabul,3,Kabul-D01,1,Bala Qala Ashuqan-O-Arifan,1,Building,1,3,0,TRUE
+101019,69.13249395,34.53320897,2,Abdullah Ibn Masood Mosque,Kabul,5,Kabul-D02,3,Bagh-E-Bala,1,Building,1,5,0,TRUE
+101020,69.17273524,34.51999583,1,Ranga Mosque,Kabul,3,Kabul-D02,2,Deh Afghanan,1,Building,1,3,0,TRUE
+101021,69.16985512,34.51573382,4,Ansari High School,Kabul,8,Kabul-D02,4,Joy Sher,1,Building,1,8,0,TRUE
+101022,69.1707,34.5335,4,Parsa Primary School,Kabul,8,Kabul-D02,4,Joy Sher,1,Village,1,8,0,TRUE
+101023,69.1669005,34.51561099,3,Qari Abdullah School,Kabul,6,Kabul-D02,3,"Joy Sher, Deh Afghanan",1,Building,1,6,0,TRUE
+101024,69.14558569,34.53128825,3,Haji Mir Ahmad Mosque,Kabul,6,Kabul-D02,3,Baharistan Cinema,1,Building,1,6,0,TRUE
+101025,69.15212507,34.52765121,4,Zabihullah Shaheed High School,Kabul,7,Kabul-D02,3,Kart-E-Ariana,1,Building,1,7,0,TRUE
+101026,69.14018007,34.52858527,1,Maaz Ibn Jabal Mosque,Kabul,2,Kabul-D02,1,Kart-E-Parwan,1,Building,1,2,0,TRUE
+101027,69.1405393,34.53089081,1,Omar Farooq Mosque,Kabul,2,Kabul-D02,1,Kart-E-Parwan,1,Building,1,2,0,TRUE
+101028,69.17595515,34.52292459,4,Istiqlal High School,Kabul,7,Kabul-D02,3,Istiqlal High School,1,Building,1,7,0,TRUE
+101029,69.17189444,34.51685277,3,Shah-E- Du Shamshera High School,Kabul,5,Kabul-D02,2,Shah-E-Du Shamshera,1,Building,1,5,0,TRUE
+101030,69.16155862,34.52592819,2,Naieb Salar Mosque,Kabul,3,Kabul-D02,1,Qul-E-Aab Chakan,1,Building,1,3,0,TRUE
+101031,69.1828319,34.52294102,2,Office Of Administrative Affairs (Oaa),Kabul,4,Kabul-D02,2,Murad Khani,1,Building,1,0,4,FALSE
+101032,69.12581024,34.51713683,3,Sofi Islam School,Kabul,7,Kabul-D03,4,Kabul University Last Bus Station,1,Building,1,7,0,TRUE
+101033,69.12347369,34.51146029,4,Mahmood Hotaki High School,Kabul,8,Kabul-D03,4,Deh Bori,1,Building,1,9,0,TRUE
+101034,69.13980015,34.50811323,4,Sayed Jamaluddin Secondary School,Kabul,8,Kabul-D03,4,Kart-E-Chahar,1,Building,1,8,0,TRUE
+101035,69.14361111,34.51583333,4,Jamal Menah 13Th Number Secondary School,Kabul,9,Kabul-D03,5,Jamal Menah,1,Building,1,9,0,TRUE
+101036,69.14007834,34.52230063,4,Jamal Menah 13Th Number Secondary School,Kabul,8,Kabul-D03,4,Kart-E-Sakhi,1,Building,1,8,0,TRUE
+101037,69.15368074,34.51396862,3,Hanzala Mosque,Kabul,6,Kabul-D03,3,Dehmazang,1,Village,1,6,0,TRUE
+101038,69.13203963,34.51087045,3,Sayed Jamalluddin Teacher Training School,Kabul,5,Kabul-D03,2,Sarai Ghazni,1,Building,1,5,0,TRUE
+101039,69.15775104,34.51050182,3,Amir Dust Mohammad Khan School,Kabul,5,Kabul-D03,2,Dehmazang,1,Building,1,5,0,TRUE
+101040,69.15076,34.51251,3,Amir Hamza Secondary School,Kabul,5,Kabul-D03,2,"Naw Abad, Dehmazang",1,Building,1,5,0,TRUE
+101041,69.15388888,34.50138888,2,Guzargah Girls Secondary School,Kabul,5,Kabul-D03,3,Hesa-E-Duwom,1,Building,1,5,0,TRUE
+101042,69.12254129,34.51962291,1,Sang Kashan Mosque,Kabul,2,Kabul-D03,1,Silo Road,1,Building,1,3,0,TRUE
+101043,69.14723,34.5137,2,Mohammadia Mosque,Kabul,3,Kabul-D03,1,First Road,1,Building,1,3,0,TRUE
+101044,69.12319795,34.53038389,3,Karte Mamorin Mosque,Kabul,5,Kabul-D03,2,Kart-E-Mamorin,1,Building,1,5,0,TRUE
+101045,69.13283364,34.518027,3,Law Faculty,Kabul,5,Kabul-D03,2,Kabul University,1,Building,1,5,0,TRUE
+101046,69.13766994,34.51221788,3,Ministry Of Higher Education,Kabul,6,Kabul-D03,3,Kart-E-Chahar,1,Building,1,6,0,TRUE
+101047,69.14718442,34.50859433,3,Rabia Balkhi High School,Kabul,5,Kabul-D03,2,Kart-E-Chahar,1,Building,1,5,0,TRUE
+101048,69.137,34.5366,3,Ghazi Mohammad Ayub First Number School,Kabul,6,Kabul-D04,3,Bagh-E-Bala,1,Village,1,6,0,TRUE
+101049,69.16766974,34.52662325,2,Malalai Girls High School,Kabul,7,Kabul-D04,5,Sedarat Square,1,Building,1,7,0,TRUE
+101050,69.14191589,34.55047465,3,Tajwar Sultana Girls High School,Kabul,9,Kabul-D04,6,Taimani Square,1,Building,1,9,0,TRUE
+101051,69.14602162,34.55327142,4,Jomat Khana-E- Ismailia,Kabul,7,Kabul-D04,3,Taimani Square,1,Building,1,7,0,TRUE
+101052,69.146885,34.546578,2,Musa Kalimullah Mosque,Kabul,5,Kabul-D04,3,Taimani Square,1,Building,1,5,0,TRUE
+101053,69.14712215,34.54820577,4,Naser Khusraw Balkh School,Kabul,9,Kabul-D04,5,Taimani Square,1,Building,1,9,0,TRUE
+101054,69.1420652,34.54261502,4,Rabia High School,Kabul,8,Kabul-D04,4,Kart-E-Parwan,1,Building,1,8,0,TRUE
+101055,69.1433601,34.53468429,3,Amir Shir Ali Khan Secondary School,Kabul,6,Kabul-D04,3,Kart-E-Parwan,1,Building,1,6,0,TRUE
+101056,69.14578,34.53278,3,Wazir Mohammad Akbar Khan Secondary School,Kabul,6,Kabul-D04,3,Kart-E-Parwan,1,Village,1,6,0,TRUE
+101057,69.1354,34.5343,4,Baba Nanak High School,Kabul,7,Kabul-D04,3,Kart-E-Parwan,1,Village,1,7,0,TRUE
+101058,69.14022635,34.53454481,4,Naderia High School,Kabul,7,Kabul-D04,3,Kart-E-Parwan,1,Building,1,7,0,TRUE
+101059,69.15720675,34.53907627,3,Imam Reza E Ghareeb Mosque,Kabul,6,Kabul-D04,3,Kolula Pushta,1,Building,1,6,0,TRUE
+101060,69.12468,34.544457,3,Dehkepak Girls High School,Kabul,8,Kabul-D04,5,Naw Abad Dehkepak,1,Building,1,8,0,TRUE
+101061,69.15716011,34.56059124,2,Number One Kindergarten,Kabul,4,Kabul-D04,2,Proja-E- Wazir Abad,1,Building,1,4,0,TRUE
+101062,69.15769124,34.55963754,5,Malika Soraia Girls High School,Kabul,9,Kabul-D04,4,Proja-E-Taimani,1,Building,1,9,0,TRUE
+101063,69.16601283,34.52560419,4,Jamhuriat High School,Kabul,7,Kabul-D04,3,Salang Watt,1,Building,1,7,0,TRUE
+101064,69.13854338,34.56054913,4,Mohmmad Sediq Farhang School,Kabul,7,Kabul-D04,3,Shahrak Police,1,Building,1,7,0,TRUE
+101065,69.15840707,34.53419224,4,Mohammad Alam Faizzad High School,Kabul,7,Kabul-D04,3,Shahrara,1,Building,1,7,0,TRUE
+101066,69.14606012,34.53765247,3,Haji Ghulam Dastager Mosque,Kabul,5,Kabul-D04,2,Shahrara,1,Building,1,5,0,TRUE
+101067,69.171544,34.533344,2,Khwaja Ali Muafaq Mosque,Kabul,4,Kabul-D04,2,Shahr-E-Now,1,Building,1,4,0,TRUE
+101068,69.14923509,34.55014995,2,Haji Mohammad Dad Mosque,Kabul,5,Kabul-D04,3,Taimani,1,Building,1,5,0,TRUE
+101069,69.16828073,34.53170514,2,Khwaja Abdullah Ansari Mosque,Kabul,3,Kabul-D04,1,Shahr-E-Naw Pump Station,1,Building,1,3,0,TRUE
+101070,69.06673574,34.52063282,3,Fazel Baik Secondary School,Kabul,7,Kabul-D05,4,Aab Rasani,1,Building,1,9,0,TRUE
+101071,69.10594347,34.53827877,2,Jaghori Ha Mosque,Kabul,4,Kabul-D05,2,Afshar-E-Selo,1,Building,1,4,0,TRUE
+101072,69.11041247,34.52980931,2,Sahib-E- Zaman Mosque,Kabul,4,Kabul-D05,2,Afshar-E-Selo,1,Building,1,4,0,TRUE
+101073,69.05411655,34.52486973,3,Qala- E- Kashif High School,Kabul,7,Kabul-D05,4,Bazar Company,1,Building,1,9,0,TRUE
+101074,69.08231375,34.53486556,4,Abu Zar Ghafari High School,Kabul,8,Kabul-D05,4,Chahar Rahi-E-Qambar,1,Building,1,8,0,TRUE
+101075,69.10171383,34.51777853,3,Imam-E-Hussain Mosque,Kabul,5,Kabul-D05,2,Dewan Begi,1,Building,1,5,0,TRUE
+101076,69.07425211,34.53045618,1,Ayub Saber Mosque,Kabul,3,Kabul-D05,2,"Naw Abad, Qargha",1,Building,1,4,0,TRUE
+101077,69.11647081,34.53235808,3,Poly Technique Mosque,Kabul,6,Kabul-D05,3,Poly Technique,1,Building,1,6,0,TRUE
+101078,69.04553716,34.52540692,3,Hazrat Bilal Mosque,Kabul,7,Kabul-D05,4,Qala-E-Kashif,1,Building,1,8,0,TRUE
+101079,69.08491043,34.52250632,2,Itifaq Mosque,Kabul,3,Kabul-D05,1,Qala-E-Tufan,1,Building,1,4,0,TRUE
+101080,69.11053547,34.51562708,2,Paghmaneha Mohammadia Mosque,Kabul,3,Kabul-D05,1,Qala-E-Wahid,1,Building,1,3,0,TRUE
+101081,69.05418727,34.54291778,2,Shah-E- Awlia Mosque,Kabul,3,Kabul-D05,1,Qargha,1,Building,1,3,0,TRUE
+101082,69.06001089,34.54230956,3,Deh Araban School,Kabul,6,Kabul-D05,3,Qargha,1,Building,1,7,0,TRUE
+101083,69.06156214,34.52305511,2,Hazrat Usman Mosque,Kabul,3,Kabul-D05,1,Fazal Big Village,1,Building,1,3,0,TRUE
+101084,69.0926424,34.51934421,1,Haji Yaqoob Mosque,Kabul,3,Kabul-D05,2,Niaz Big Village,1,Building,1,4,0,TRUE
+101085,69.058329,34.52865732,1,Shaheed Mosque,Kabul,2,Kabul-D05,1,Wardakeha Village,1,Building,1,3,1,TRUE
+101086,69.112452,34.524206,4,Hazrat Shamsul Mashayakh High School,Kabul,8,Kabul-D05,4,Phase A Of Khush-Hal Mina,1,Village,1,8,0,TRUE
+101087,69.11678567,34.51863114,3,Spin Kalai Girls High School,Kabul,9,Kabul-D05,6,Phase A Of Khush-Hal Mina,1,Building,1,9,0,TRUE
+101088,69.10020872,34.52813283,3,Mohammad Ismail Hassanzai High School,Kabul,5,Kabul-D05,2,Phase B Of Khush-Hal Mina,1,Building,1,5,0,TRUE
+101089,69.0942032,34.52472385,4,Naheed Shaheed High School,Kabul,8,Kabul-D05,4,Phase B Of Khush-Hal Mina,1,Building,1,8,1,TRUE
+101090,69.1053621,34.5221298,1,Mohammadia Darul Hefaz Mosque,Kabul,2,Kabul-D05,1,Phase B Of Khush-Hal Mina,1,Building,1,3,0,TRUE
+101091,69.1175937,34.52875088,4,Professor Rasool Amin High School,Kabul,7,Kabul-D05,3,Phase B Of Khush-Hal Mina,1,Building,1,7,0,TRUE
+101092,69.08319975,34.53525295,4,Hazrat Yousuf Mosque,Kabul,6,Kabul-D05,2,Rahmat Abad,1,Building,1,7,0,TRUE
+101093,69.10758998,34.51452243,2,Mohammad Qayam Khan Primary School,Kabul,3,Kabul-D05,1,Sarai Heratiha,1,Building,1,3,0,TRUE
+101094,69.10530277,34.52456944,5,Mir Ghulam Ghubar High School,Kabul,9,Kabul-D05,4,Spin Kalai,1,Building,1,9,0,TRUE
+101095,69.1107471,34.48831938,4,Char Qala High School,Kabul,8,Kabul-D06,4,Chahar Qala,1,Building,1,8,0,TRUE
+101096,69.11019392,34.5053098,3,Imam-E-Hussain Mujtaba Mosque,Kabul,6,Kabul-D06,3,Telegraph Center,1,Building,1,6,0,TRUE
+101097,69.10449717,34.50416285,4,Khatamul Anbia Madrassa,Kabul,9,Kabul-D06,5,Qala-E-Nazer,1,Building,1,9,0,TRUE
+101098,69.10605555,34.50561111,4,Mohammad Asif Mayel High School,Kabul,9,Kabul-D06,5,Qala-E-Nazer,1,Building,1,9,0,TRUE
+101099,69.09900221,34.49875184,2,Ali Naqi Mosque,Kabul,4,Kabul-D06,2,Deh Qabil Village,1,Building,1,4,0,TRUE
+101100,69.10191908,34.50072303,7,Gulkhana Secondary School,Kabul,13,Kabul-D06,6,Deh Qabil Village,1,Building,1,13,0,TRUE
+101101,69.11462845,34.49449026,3,Ahmadi Mosque,Kabul,5,Kabul-D06,2,Dash Hai Haji Hussain,1,Building,1,5,0,TRUE
+101102,69.098436116,34.48606017,2,Sarwar-E- Kaienat Mosque,Kabul,3,Kabul-D06,1,Qala-E-Mohammad Hayat,1,Building,1,3,0,TRUE
+101103,69.10551258,34.47832963,3,Salman-E- Farsi Mosque,Kabul,6,Kabul-D06,3,Qala-E-Abbas Quli,1,Building,1,6,1,TRUE
+101104,69.1143885,34.47169386,4,Qala-E-Bakhtiar High School,Kabul,8,Kabul-D06,4,Naw Abade Qala-E-Bakhtiar,1,Building,1,8,0,TRUE
+101105,69.11072483,34.46565378,2,Shah Wolayat Maab Mosque,Kabul,3,Kabul-D06,1,Afshar-E-Darul Aman,1,Building,1,3,0,TRUE
+101106,69.08526003,34.48106548,3,Qaeem Al-E- Mohammad Mosque,Kabul,5,Kabul-D06,2,Naw Abad Qala-E-Jabar Khan,1,Building,1,5,1,TRUE
+101107,69.07927777,34.485,3,Hazrat Rasool Mosque,Kabul,5,Kabul-D06,2,Naw Abad Qala-E-Jabar Khan,1,Building,1,6,1,TRUE
+101108,69.12801439,34.46065834,4,Sar Asiab Girls High School,Kabul,10,Kabul-D06,6,Sar Asiab,1,Building,1,10,0,TRUE
+101109,69.12285103,34.47927016,6,Financial And Economics Institute,Kabul,11,Kabul-D06,5,Darul Aman,1,Building,1,11,2,TRUE
+101110,69.11516112,34.47999743,2,Ali Shir-E-Khuda Mosque,Kabul,4,Kabul-D06,2,Qala-E-Ali Mardan,1,Building,1,4,0,TRUE
+101111,69.12888888,34.48891666,3,Jafaria Mosque,Kabul,5,Kabul-D06,2,Allawoudin,1,Building,1,5,0,TRUE
+101112,69.11796337,34.47610459,3,Tubercloses Institute,Kabul,6,Kabul-D06,3,Darul Aman,1,Building,1,8,0,TRUE
+101113,69.11399479,34.48586544,3,Baqerul Ulum Madrassa,Kabul,6,Kabul-D06,3,Qala-E-Ainullah,1,Building,1,6,0,TRUE
+101114,69.11760886,34.50436297,3,Abu Zar Ghafari Mosque,Kabul,5,Kabul-D06,2,Pul-E-Sukhta,1,Building,1,5,0,TRUE
+101115,69.11778594,34.5043839,3,Jamia Islam Madrassa,Kabul,5,Kabul-D06,2,Pul-E-Sukhta,1,Building,1,5,0,TRUE
+101116,69.12549942,34.50421021,2,Wahdat Mosque,Kabul,5,Kabul-D06,3,Pul-E-Wahdat,1,Building,1,5,0,TRUE
+101117,69.12557806,34.50269632,2,Takia Khana-E-Wahdat,Kabul,4,Kabul-D06,2,Pul-E-Wahdat,1,Building,1,4,0,TRUE
+101118,69.12148858,34.50246264,4,Ummulbanin High School,Kabul,9,Kabul-D06,5,Qala-E-Shahada,1,Building,1,9,0,TRUE
+101119,69.1363485,34.50307616,3,6Th Nahia Center,Kabul,5,Kabul-D06,2,6Th Nahia Center,1,Building,1,5,0,TRUE
+101120,69.13978599,34.49985152,4,Abdul Ghani Mustaghni High School,Kabul,8,Kabul-D06,4,Kart-E-Say,1,Building,1,8,0,TRUE
+101121,69.08042523,34.47718065,3,Nabi Akram Mosque,Kabul,7,Kabul-D06,4,Phase Iii Of Haji Nabi Township,1,Building,1,7,0,TRUE
+101122,69.13705316,34.49522114,3,Mohammadia Mosque,Kabul,5,Kabul-D06,2,Kart-E-3,1,Building,1,5,0,TRUE
+101123,69.13194054,34.499387,3,Resalat Madrassa,Kabul,6,Kabul-D06,3,Qala-E-Wazir,1,Building,1,6,0,TRUE
+101124,69.12361663,34.49259015,4,Safid Mosque,Kabul,7,Kabul-D06,3,Qala-E-Wazir,1,Building,1,7,0,TRUE
+101125,69.15752941,34.49944178,4,Khushhal Khan High School,Kabul,9,Kabul-D07,5,Chehel Seton Road,1,Building,1,9,0,TRUE
+101126,69.14036366,34.4708282,4,Mehrabuddin High School,Kabul,9,Kabul-D07,5,Chehel Seton Road-Deh Dana,1,Building,1,11,0,TRUE
+101127,69.16461727,34.47810792,4,Technical Institute,Kabul,8,Kabul-D07,4,Tani Kot,1,Building,1,8,0,TRUE
+101128,69.137721625,34.476871651,5,Ataullah Faizani Secondary School,Kabul,10,Kabul-D07,5,Se Rahi Allawoudin,1,Building,1,10,0,TRUE
+101129,69.16026531,34.47308684,3,Ghazi Adi Girls High School,Kabul,9,Kabul-D07,6,Tani Kot,1,Building,1,9,0,TRUE
+101130,69.15713866,34.49059366,3,Sultan Razia Girls High School,Kabul,10,Kabul-D07,7,Bagh-E-Raees,1,Building,1,10,0,TRUE
+101131,69.13631605,34.43177569,3,Family Haie Reshkhur High School,Kabul,6,Kabul-D07,3,Family Haie Reshkhur,1,Building,1,6,0,TRUE
+101132,69.1483955,34.50219857,4,Habibia High School,Kabul,7,Kabul-D07,3,Darul Aman Road,1,Building,1,7,0,TRUE
+101133,69.146603,34.498043,2,Ayub Khan Mosque,Kabul,3,Kabul-D07,1,Ayub Khan Mina,1,Building,1,3,0,TRUE
+101134,69.1327312,34.44527506,4,Ghazi Abdullah High School,Kabul,7,Kabul-D07,3,Qala-E-Asfandiar,1,Building,1,7,0,TRUE
+101135,69.15175143,34.46296749,2,Chehal Suton Girls High School,Kabul,5,Kabul-D07,3,Noh Burje Chehel Seton,1,Building,1,7,0,TRUE
+101136,69.1596948,34.48706725,2,Hazrat Nabawi Mosque,Kabul,3,Kabul-D07,1,Wasil Abad,1,Building,1,5,0,TRUE
+101137,69.13011433,34.43364156,3,Lais Bin-E-Qais Mosque,Kabul,5,Kabul-D07,2,Reshkhure Sufla,1,Building,1,5,0,TRUE
+101138,69.153,34.5051,3,Guzargah Girls High School,Kabul,7,Kabul-D07,4,Guzargah,1,Village,1,7,0,TRUE
+101139,69.16557078,34.48385439,4,Omra Khan High School,Kabul,7,Kabul-D07,3,Wasil Abad,1,Building,1,7,0,TRUE
+101140,69.15565308,34.49720856,3,Imini Girls High School,Kabul,6,Kabul-D07,3,Jangalak,1,Building,1,6,0,TRUE
+101141,69.13353,34.4696,2,Deh Dana Girls High School,Kabul,6,Kabul-D07,4,Deh Dana,1,Village,1,8,0,TRUE
+101142,69.16075904,34.46201827,2,Eidgah Mosque,Kabul,3,Kabul-D07,1,Chehel Seton,1,Building,1,3,0,TRUE
+101143,69.15498,34.48033,3,Aqa Ali Shams High School,Kabul,7,Kabul-D07,4,"Aqa Ali Shams, Chehel Seton",1,Building,1,7,0,TRUE
+101144,69.1608163,34.46201736,3,Ibrahim Khalil Mosque,Kabul,4,Kabul-D07,1,Dugh Abad Shashdarak,1,Village,1,4,0,TRUE
+101145,69.13652891,34.48039873,3,Mohammadia Mosque,Kabul,4,Kabul-D07,1,Jaie Raies,1,Building,1,4,0,TRUE
+101146,69.21367488,34.4911606,3,Abdul Hai Habibi High School,Kabul,7,Kabul-D08,4,Qalacha,1,Building,1,6,1,TRUE
+101147,69.22757214,34.51260057,3,Sayed Noor Mohammad Shah Mina Girls High School,Kabul,9,Kabul-D08,6,Sar-E-Tapa Kart-E-Naw,1,Building,1,9,0,TRUE
+101148,69.18859319,34.50042111,4,Qala-E-Hashmat Khan High School,Kabul,8,Kabul-D08,4,Baghcha-E-Said,1,Building,1,8,0,TRUE
+101149,69.22439147,34.50700583,4,Sayed Noor Muhammad Shah Mina Boys High School,Kabul,6,Kabul-D08,2,"Hesa-E-Alef, Sarak Se Kart-E-Naw",1,Building,1,6,0,TRUE
+101150,69.23135913,34.51272514,3,Tottia High School,Kabul,7,Kabul-D08,4,"Sarak-E- 13, Kart-E-Naw",1,Building,1,7,0,TRUE
+101151,69.22431463,34.48634441,4,Zabihullah Esmati High School,Kabul,8,Kabul-D08,4,200 Family,1,Building,1,12,0,TRUE
+101152,69.22413322,34.48591427,4,Abdul Rahman Pazhwak High School,Kabul,5,Kabul-D08,1,Proja-E-Rahman Mina,1,Building,1,6,0,TRUE
+101153,69.224282,34.506806,3,Mohammad Hashim Maiwandwal High School,Kabul,5,Kabul-D08,2,Sarak-E-3 Rahman Mina,1,Building,1,5,0,TRUE
+101154,69.21789959,34.51318195,3,Shahrak-E-Talaie Mosque,Kabul,5,Kabul-D08,2,Shahrak Talaie,1,Building,1,5,0,TRUE
+101155,69.20667875,34.50522254,3,Amina Fidawi Girls High School,Kabul,6,Kabul-D08,3,Itifaq Mosque,1,Building,1,6,0,TRUE
+101156,69.20136176,34.51379585,3,Ustad Betab High School,Kabul,6,Kabul-D08,3,"Shah Shaheed, First Road",1,Building,1,6,0,TRUE
+101157,69.23200021,34.51012161,3,Sayed Noor Mohammad Shah Mohammadia Mosque,Kabul,4,Kabul-D08,1,Kart-E-Naw,1,Building,1,4,0,TRUE
+101158,69.23463786,34.50590043,3,Ahmadi Mosque,Kabul,5,Kabul-D08,2,Kart-E-Naw,1,Building,1,5,0,TRUE
+101159,69.24466047,34.49680241,3,Zakhel And Mohmand Mosque,Kabul,5,Kabul-D08,2,Kart-E-Naw,1,Building,1,5,1,TRUE
+101160,69.2342,34.5,3,Usman Ghani Mosque,Kabul,5,Kabul-D08,2,Kart-E-Naw,1,Building,1,5,0,TRUE
+101161,69.23216671,34.50328595,4,Omar Farooq Mosque,Kabul,5,Kabul-D08,1,"Tapa-E-Dostikhel, Kart-E-Naw",1,Building,1,5,0,TRUE
+101162,69.225044,34.509681,3,Shah Pacha Mosque,Kabul,5,Kabul-D08,2,"First Road Of Rahman Mina, Behind Of Asphalt Factory",1,Village,1,5,0,TRUE
+101163,69.189002,34.499132,3,Kandari Ha Mosque,Kabul,5,Kabul-D08,2,Qala-E-Hashmat Khan,1,Village,1,5,0,TRUE
+101164,69.206565,34.502488,3,Sayed Shahda Mosque,Kabul,5,Kabul-D08,2,Qalacha Khumdan,1,Village,1,5,0,TRUE
+101165,69.24231537,34.50908947,3,Ghaws Azam Dastger Mosque,Kabul,5,Kabul-D08,2,Aab Rasani,1,Building,1,5,0,TRUE
+101166,69.2089,34.5062,3,Itifaq Mosque,Kabul,4,Kabul-D08,1,Itifaq Mosque,1,Building,1,4,0,TRUE
+101167,69.20221872,34.5097743,2,Tap-E- Balkh Mosque,Kabul,5,Kabul-D08,3,Shah Shaheed,1,Building,1,4,1,TRUE
+101168,69.23491421,34.51316083,4,Abdul Qader Jilani Mosque,Kabul,5,Kabul-D08,1,"Sar-E-Tapa, Market",1,Building,1,6,0,TRUE
+101169,69.21171,34.50951,3,Rahman Mina Kindergarten,Kabul,6,Kabul-D08,3,Motasel Naqlia Sia Sang,1,Building,1,6,0,TRUE
+101170,69.22478,34.50689,2,Rahman Mina Girls High School,Kabul,6,Kabul-D08,4,"Project A, Road 3 Of Rahman Mina",1,Building,1,6,0,TRUE
+101171,69.20062856,34.51086587,3,Shah Shaheed Khas Secondary School,Kabul,5,Kabul-D08,2,Shah Shaheed Khas,1,Building,1,5,0,TRUE
+101172,69.22567452,34.51140048,3,Hakim Sanie Mosque,Kabul,4,Kabul-D08,1,3Rd Road Of Kart-E-Naw,1,Building,1,4,0,TRUE
+101173,69.21166872,34.49350317,2,Ranga Mosque,Kabul,3,Kabul-D08,1,Qalacha,1,Building,1,3,0,TRUE
+101174,69.22210894,34.50292905,1,Shaikh Najmuddin Akhundzada Mosque,Kabul,2,Kabul-D08,1,"Rahman Mina, Phase B",1,Building,1,3,0,TRUE
+101175,69.21474903,34.50582706,3,Usman Ghani Mosque,Kabul,4,Kabul-D08,1,"New 60 Meter Road, Rahman Mina",1,Building,1,4,0,TRUE
+101176,69.26068431,34.53831843,5,Ali Ahmad Khan Popal High School,Kabul,9,Kabul-D09,4,Hodkhel,1,Building,1,14,0,TRUE
+101177,69.22315492,34.55352545,3,Khwaja Rawash Secondary School,Kabul,6,Kabul-D09,3,Khwaja Rawash,1,Building,1,6,0,TRUE
+101178,69.20610318,34.53627426,3,Hazrat Mohammad Mustafa Mosque,Kabul,5,Kabul-D09,2,Makrorian,1,Building,1,5,0,TRUE
+101179,69.20891602,34.53801586,3,Reyasat Banaye,Kabul,5,Kabul-D09,2,Near To Radio Training Center,1,Building,1,5,0,TRUE
+101180,69.19735547,34.54158814,3,Bi Bi Mahru Boys High School,Kabul,5,Kabul-D09,2,3Rd Makrorian,1,Building,1,5,0,TRUE
+101181,69.20279402,34.53989118,3,Haji Abdul Qadir High School,Kabul,7,Kabul-D09,4,3Rd Makrorian,1,Building,1,7,0,TRUE
+101182,69.20139129,34.53786616,3,Alfath High School,Kabul,6,Kabul-D09,3,3Rd Makrorian,1,Building,1,7,0,TRUE
+101183,69.20102822,34.54156532,3,Abul Qasim Ferdawsi High School,Kabul,5,Kabul-D09,2,3Rd Makrorian,1,Building,1,5,0,TRUE
+101184,69.19632692,34.53782191,3,Abdul Hadi Dawi High School,Kabul,6,Kabul-D09,3,3Rd Makrorian,1,Building,1,6,0,TRUE
+101185,69.35952294,34.55672744,3,Pul-E-Charkhi High School,Kabul,7,Kabul-D09,4,Pul-E-Charkhi,1,Building,1,9,0,TRUE
+101186,69.23340488,34.54707338,3,Qabil Bai High School,Kabul,4,Kabul-D09,1,Qabil Bai,1,Building,1,6,0,TRUE
+101187,69.20722222,34.55055555,2,Mansoor Helaj Mosque,Kabul,3,Kabul-D09,1,Qala-E-Wakil,1,Building,1,3,0,TRUE
+101188,69.21343894,34.5548863,3,1St Block Of Reyasat Hawa Shanasi,Kabul,6,Kabul-D09,3,Airport Road,1,Building,1,6,0,TRUE
+101189,69.29404624,34.54264474,4,Paktia Kot Secondary School,Kabul,6,Kabul-D09,2,Pul-E-Charkhi Road,1,Building,1,8,0,TRUE
+101190,69.19100512,34.52285652,1,Shah Darak Estern Mosque,Kabul,2,Kabul-D09,1,Shashdarak,1,Building,1,2,0,TRUE
+101191,69.1901566,34.52576152,2,Setara High School,Kabul,5,Kabul-D09,3,Shashdarak,1,Building,1,5,0,TRUE
+101192,69.219162,34.54435,2,Laghmani Ha Mosque,Kabul,3,Kabul-D09,1,Yaka Toot,1,Village,1,4,0,TRUE
+101193,69.16928216,34.55845046,1,Imam-E- Abu Hanifa Mosque,Kabul,3,Kabul-D10,2,End Of Taimani,1,Building,1,4,0,TRUE
+101194,69.19984432,34.55186548,3,Aziza Afghan Secondary School,Kabul,6,Kabul-D10,3,Bolak Haie Sharwali,1,Building,1,6,0,TRUE
+101195,69.19629,34.54209,1,Bibi Mahru Maidan Mosque,Kabul,3,Kabul-D10,2,Bi Bi Mahro,1,Building,1,3,0,TRUE
+101196,69.1873,34.5371,1,Khwaja Parsa-E-Wali,Kabul,4,Kabul-D10,3,Chahar Qala,1,Building,1,4,0,TRUE
+101197,69.18202951,34.55020827,3,Mustafawi Mosque,Kabul,5,Kabul-D10,2,Chahar Qala,1,Building,1,5,0,TRUE
+101198,69.17536697,34.56037592,2,Mohammadia Mosque,Kabul,4,Kabul-D10,2,Chahar Qala,1,Building,1,5,0,TRUE
+101199,69.16987809,34.56087391,2,Bibi Ruqia Mosque,Kabul,4,Kabul-D10,2,Chahar Qala,1,Building,1,4,0,TRUE
+101200,69.211286,34.537322,2,Sayed Nizam Mosque,Kabul,5,Kabul-D10,3,Chahar Qala,1,Village,1,5,0,TRUE
+101201,69.17451313,34.55622685,1,Hazrat Yousuf Mosque,Kabul,3,Kabul-D10,2,Chahar Qala,1,Building,1,4,0,TRUE
+101202,69.18422215,34.55779288,3,Chahar Qala-E-Wazirabad Secondary School,Kabul,6,Kabul-D10,3,Chahar Qala,1,Building,1,6,0,TRUE
+101203,69.17704578,34.54887811,2,Yadgar Mosque,Kabul,3,Kabul-D10,1,Chahar Qala,1,Building,1,3,0,TRUE
+101204,69.18559475,34.55408497,2,Shebari Ha Mosque,Kabul,3,Kabul-D10,1,Chahar Qala,1,Building,1,4,0,TRUE
+101205,69.1824,34.5357,2,Ahmadkhel Mosque,Kabul,4,Kabul-D10,2,Chahar Qala,1,Building,1,4,0,TRUE
+101206,69.16982966,34.54213852,1,Hazrat Omer Farooq Mosque,Kabul,3,Kabul-D10,2,Naw Abad Chahar Qala,1,Building,1,4,0,TRUE
+101207,69.17197204,34.54941507,1,Astana Mosque,Kabul,2,Kabul-D10,1,Naw Abad Chahar Qala,1,Building,1,2,0,TRUE
+101208,69.163624,34.552197,2,Post Office Infront Of Clinic,Kabul,4,Kabul-D10,2,Qala-E-Fathullah,1,Building,1,4,0,TRUE
+101209,69.20135397,34.55616635,1,Hazrat Dawod Mosque,Kabul,2,Kabul-D10,1,Qala-E-Chaman,1,Building,1,2,0,TRUE
+101210,69.19660922,34.55925163,1,Qala E Chaman Mosque,Kabul,2,Kabul-D10,1,Qala-E-Chaman,1,Building,1,3,0,TRUE
+101211,69.16929489,34.54167844,3,Zarghona Girls High School,Kabul,7,Kabul-D10,4,Qala-E-Fathullah,1,Building,1,7,0,TRUE
+101212,69.191178,34.537165,2,Ibrahim Khalilullah Mosque,Kabul,3,Kabul-D10,1,Qala-E-Fathullah,1,Building,1,3,0,TRUE
+101213,69.17151227,34.54594068,2,Fatimia Mosque,Kabul,4,Kabul-D10,2,Qala-E-Fathullah,1,Building,1,4,0,TRUE
+101214,69.16593309,34.54569498,1,Sarak-E-Chahar Mosque,Kabul,2,Kabul-D10,1,Qala-E-Fathullah,1,Building,1,2,0,TRUE
+101215,69.15388894,34.55364899,3,Ustad Misbah Secondary School,Kabul,5,Kabul-D10,2,"2Nd Road, Taimani",1,Building,1,5,0,TRUE
+101216,69.16830183,34.54908528,4,Husainia Mosque,Kabul,7,Kabul-D10,3,Qala-E-Fathullah,1,Building,1,7,0,TRUE
+101217,69.18978298,34.54684968,1,Jafari Mosque,Kabul,2,Kabul-D10,1,Qala-E-Khatir,1,Building,1,3,0,TRUE
+101218,69.19785094,34.54416071,2,Haji Qasim Mosque,Kabul,3,Kabul-D10,1,Sarak-E-Bi Bi Mahro,1,Building,1,3,0,TRUE
+101219,69.20001902,34.54655347,2,Bibi Mahru Girls High School,Kabul,6,Kabul-D10,4,Airport Road,1,Building,1,7,0,TRUE
+101220,69.164003,34.551864,2,Medical Institute,Kabul,3,Kabul-D10,1,"3Rd Road, Qala-E-Fathullah",1,Village,1,3,0,TRUE
+101221,69.170479,34.547859,2,Masood Saad Secondary School,Kabul,4,Kabul-D10,2,"5Th Road, Qala-E-Fathullah",1,Village,1,4,0,TRUE
+101222,69.17337316,34.53343192,3,Ministry Of Women Affairs,Kabul,5,Kabul-D10,2,Shahr-E-Naw,1,Building,1,5,0,TRUE
+101223,69.16349298,34.54778771,4,Ahmad Shah Masood High School,Kabul,7,Kabul-D10,3,Shahr-E-Naw,1,Building,1,7,0,TRUE
+101224,69.1757975,34.53257823,2,Moenyat Sewad Aamozi,Kabul,5,Kabul-D10,3,Shahr-E-Naw,1,Building,1,5,0,TRUE
+101225,69.16638775,34.55540223,2,Aljawad Mosque,Kabul,3,Kabul-D10,1,Wazir Abad,1,Building,1,3,0,TRUE
+101226,69.18348744,34.52932787,3,Amani High School,Kabul,5,Kabul-D10,2,Wazir Akbar Khan,1,Building,1,5,0,TRUE
+101227,69.18246111,34.53561388,2,Wazir Akbar Khan Mosque,Kabul,3,Kabul-D10,1,Wazir Akbar Khan,1,Building,1,5,0,TRUE
+101228,69.18089722,34.53975555,2,Ahmad Mujtaba Mosque,Kabul,3,Kabul-D10,1,Wazir Akbar Khan,1,Building,1,3,0,TRUE
+101229,69.12035277,34.58888055,3,Hazara Baghal Secondary School,Kabul,6,Kabul-D11,3,Hazara Baghal,1,Building,1,6,0,TRUE
+101230,69.12119444,34.56612222,3,Sharkat Naqleya Affsotar,Kabul,7,Kabul-D11,4,Deh Kepak,1,Building,1,7,0,TRUE
+101231,69.14376666,34.57199722,2,Khair Khana Cinema,Kabul,4,Kabul-D11,2,Golaye-E-Cinama,1,Building,1,4,0,TRUE
+101232,69.11994444,34.57159444,3,Bibi Hawa Secondary School,Kabul,7,Kabul-D11,4,Golaye-E-Park,1,Building,1,7,0,TRUE
+101233,69.14124054,34.57929672,3,Makhfi Badakhshi High School,Kabul,7,Kabul-D11,4,"Hesa-E-Awal, Khair Khana",1,Building,1,7,0,TRUE
+101234,69.123225,34.58050277,3,Khalilullah Khalili High School,Kabul,6,Kabul-D11,3,"Hesa-E-Awal, Khair Khana",1,Building,1,6,0,TRUE
+101235,69.12109776,34.57442641,3,Fatiha Khana Zanana,Kabul,5,Kabul-D11,2,"Hesa-E-Awal, Khair Khana",1,Building,1,5,0,TRUE
+101236,69.14265277,34.56478611,3,Sayedul Naseri Girls High School,Kabul,7,Kabul-D11,4,"Hesa-E-Duwom, Khair Khana",1,Building,1,7,0,TRUE
+101237,69.13585256,34.5765601,4,Abdul Ghafor Nadim High School,Kabul,7,Kabul-D11,3,Khair Khana Kindergarten,1,Building,1,7,0,TRUE
+101238,69.14429722,34.56518055,2,Hazrat Yousuf Mosque,Kabul,6,Kabul-D11,4,Lab Jar,1,Building,1,6,0,TRUE
+101239,69.13763888,34.57969444,4,Ghulam Haider Khan High School,Kabul,7,Kabul-D11,3,Lesay Mariam,1,Building,1,7,0,TRUE
+101240,69.13253611,34.594275,4,Baba Adam Safiullah Mosque,Kabul,9,Kabul-D11,5,"Naw Abad, Proja 5 Khair Khana",1,Building,1,9,0,TRUE
+101241,69.13911731,34.58920671,5,Abdul Qader Bedil High School,Kabul,10,Kabul-D11,5,Proja-E-Jadid,1,Building,1,11,1,TRUE
+101242,69.12265277,34.59296944,4,Proja High School,Kabul,7,Kabul-D11,3,Proja 5 Khair Khana,1,Building,1,7,0,TRUE
+101243,69.131333763,34.574988214,3,Public Helthe Workshop,Kabul,5,Kabul-D11,2,Qala-E-Najarha,1,Building,1,5,0,TRUE
+101244,69.13307222,34.5695,4,No.16Th Secondary School,Kabul,7,Kabul-D11,3,Qala-E-Najarha,1,Building,1,7,0,TRUE
+101245,69.13266388,34.57273333,3,Imam-E-Zaman Mosque,Kabul,6,Kabul-D11,3,Qala-E-Najarha,1,Building,1,6,0,TRUE
+101246,69.12531388,34.56725277,3,Azad Khan High School,Kabul,6,Kabul-D11,3,Sarak-E-Awal Khair Khana,1,Building,1,6,0,TRUE
+101247,69.12056977,34.57102108,3,Bi Bi Sarwari Sangari High School,Kabul,6,Kabul-D11,3,Sarak-E-Awal Khair Khana,1,Building,1,6,0,TRUE
+101248,69.149183,34.591459,2,500 Family Mosque,Kabul,3,Kabul-D11,1,Sarak-E-500 Family,1,Village,1,3,0,TRUE
+101249,69.3362317,34.52576239,4,Ustad Ibrahim Khwakhwagi Secondary School,Kabul,8,Kabul-D12,4,Ahmad Shah Baba Mina,1,Building,1,11,0,TRUE
+101250,69.31241814,34.51437267,5,Hazrat Ibrahim Khalilullah High School,Kabul,10,Kabul-D12,5,Ahmad Shah Baba Mina,1,Building,1,10,0,TRUE
+101251,69.3183494,34.51214122,3,Bi Bi Aisha Sediqa High School,Kabul,7,Kabul-D12,4,Ahmad Shah Baba Mina,1,Building,1,8,0,TRUE
+101252,69.33204505,34.529871982,3,Qeyamuddin Khadim High School,Kabul,7,Kabul-D12,4,Ahmad Shah Baba Mina,1,Building,1,9,0,TRUE
+101253,69.329191535,34.525888651,3,Ghulam Mohammad Farhad High School,Kabul,7,Kabul-D12,4,Ahmad Shah Baba Mina,1,Building,1,9,0,TRUE
+101254,69.32494247,34.511639523,3,Educational Center,Kabul,6,Kabul-D12,3,"9Th Block, Arzan Qemat",1,Building,1,6,0,TRUE
+101255,69.30698581,34.50213221,3,Zan Abad Mosque,Kabul,5,Kabul-D12,2,Zan Abad,1,Building,1,5,0,TRUE
+101256,69.07528489,34.50404519,4,Itehad Mosque,Kabul,6,Kabul-D13,2,Behind Barchi Pump Station,1,Building,1,6,0,TRUE
+101257,69.06990089,34.50474088,1,Imam Mohammad Taqi Mosque,Kabul,3,Kabul-D13,2,Bagh-E-Khan,1,Building,1,3,0,TRUE
+101258,69.07752777,34.49613888,6,Abdur Rahim Shaheed High School,Kabul,12,Kabul-D13,6,Dasht-E-Best Hazari,1,Building,1,12,0,TRUE
+101259,69.08290154,34.49524977,4,Kazimia Mosque,Kabul,6,Kabul-D13,2,Dasht-E-Best Hazari,1,Building,1,6,1,TRUE
+101260,69.09801223,34.49676374,2,Sanaie Mosque,Kabul,4,Kabul-D13,2,Deh Qabil Village,1,Building,1,4,0,TRUE
+101261,69.09380967,34.49737401,3,Sajadi Mosque,Kabul,5,Kabul-D13,2,Deh Qabil Village,1,Building,1,5,0,TRUE
+101262,69.06700537,34.48731744,1,Musa Ibne Jafar Mosque,Kabul,3,Kabul-D13,2,Naw Abad Dogh Abad,1,Building,1,4,0,TRUE
+101263,69.05467935,34.49991778,5,Marefat High School,Kabul,9,Kabul-D13,4,Guzar-E-Gulistan,1,Building,1,9,0,TRUE
+101264,69.07157168,34.49992221,3,Mahdawia Madrassa,Kabul,5,Kabul-D13,2,Guzar-E-Mahdawia,1,Building,1,5,0,TRUE
+101265,69.06829533,34.49933816,2,Itifaq Mosque,Kabul,4,Kabul-D13,2,Guzar-E-Itifaq,1,Building,1,4,0,TRUE
+101266,69.07323205,34.49348514,3,Imam Zaman Mosque,Kabul,5,Kabul-D13,2,Hesa-E-Awal Dogh Abad,1,Building,1,5,0,TRUE
+101267,69.06973773,34.49382462,4,Abuzar Ghafari Mosque,Kabul,7,Kabul-D13,3,Hesa-E-Duwom Dogh Abad,1,Building,1,7,0,TRUE
+101268,69.0716933,34.48557125,3,Baqerul Ulum Mosque,Kabul,6,Kabul-D13,3,Hesa-E-Sewom Dogh Abad,1,Building,1,6,0,TRUE
+101269,69.09640458,34.50458658,2,Mahdawia Mosque,Kabul,5,Kabul-D13,3,Mahtab Qala,1,Building,1,5,0,TRUE
+101270,69.09096804,34.49468804,3,Husainia Mosque,Kabul,5,Kabul-D13,2,Maidan Tolo,1,Building,1,5,0,TRUE
+101271,69.0807,34.5038,4,Imam Khumaini Mosque,Kabul,6,Kabul-D13,2,Naqash,1,Building,1,6,0,TRUE
+101272,69.08069444,34.50383333,2,Mohammadia Mosque,Kabul,4,Kabul-D13,2,Shahrak-E-Mahdia,1,Building,1,5,0,TRUE
+101273,69.05797222,34.49361111,6,Homayoon Shaheed Mosque,Kabul,12,Kabul-D13,6,Pul-E-Khushk,1,Building,1,12,0,TRUE
+101274,69.06250361,34.5027074,1,Babul Hawaiej Mosque,Kabul,3,Kabul-D13,2,Pul-E-Khushk,1,Building,1,3,0,TRUE
+101275,69.06145047,34.49518902,2,Imam Baqer Mosque,Kabul,5,Kabul-D13,3,Pul-E-Khushk,1,Building,1,5,0,TRUE
+101276,69.06811956,34.49591444,2,Hanefi Mosque,Kabul,3,Kabul-D13,1,Qala-E-Dogh Abad,1,Building,1,3,0,TRUE
+101277,69.04636615,34.50470743,3,Malik Ashtar Mosque,Kabul,6,Kabul-D13,3,Qala-E-Muhib,1,Building,1,6,0,TRUE
+101278,69.0345657,34.50344095,4,Sayedul Shuhada High School,Kabul,8,Kabul-D13,4,Qala-E-Muhib,1,Building,1,8,0,TRUE
+101279,69.04832473,34.48435784,4,Qala-E-Qazi High School,Kabul,8,Kabul-D13,4,Qala-E-Qazi,1,Building,1,8,0,TRUE
+101280,69.08699278,34.49747357,2,Mir Sayed Ali Yakhsuz Mosque,Kabul,4,Kabul-D13,2,Qala-E-Sultan Jan,1,Building,1,4,0,TRUE
+101281,69.07121792,34.51018311,4,Sarwar-E-Kaienat Mosque,Kabul,6,Kabul-D13,2,Reg Reshan,1,Building,1,6,0,TRUE
+101282,69.08269444,34.50372222,4,Talash Private School,Kabul,6,Kabul-D13,2,Sari Pul-E-Barchi,1,Building,1,6,0,TRUE
+101283,69.05826928,34.51161445,4,Baqyatullah Mosque,Kabul,7,Kabul-D13,3,Shahrak-E-Safa,1,Building,1,8,0,TRUE
+101284,69.07423824,34.49928434,2,Amirul Mominin Mosque,Kabul,4,Kabul-D13,2,Barchi Fuel Pump Station,1,Building,1,4,0,TRUE
+101285,69.09861944,34.50866055,2,Imam-E- Zaman Mosque,Kabul,4,Kabul-D13,2,Qala-E-Wahid,1,Building,1,4,0,TRUE
+101286,68.9571575,34.58715636,2,Agha Sahib Mosque,Kabul,5,Kabul-D14,3,Chandal Boi,1,Village,1,5,0,TRUE
+101287,68.94104971,34.604166218,2,Sayed Karim Secondary School,Kabul,5,Kabul-D14,3,Bagh-E-Wazir,1,Building,1,5,0,TRUE
+101288,68.95595618,34.592564,3,14Th Nahia Office,Kabul,6,Kabul-D14,3,Parachi,1,Building,1,6,0,TRUE
+101289,69.17333333,34.58055555,4,Imam-E-Tahawi Mosque,Kabul,8,Kabul-D15,4,Behind Airport,1,Building,1,8,0,TRUE
+101290,69.16649623,34.58387525,3,Qatebia Mosque,Kabul,6,Kabul-D15,3,Du Jampa-E-Khwaja Bughra,1,Building,1,6,0,TRUE
+101291,69.159334,34.582873,3,Parwareshgah Fresht-E-Nejat,Kabul,7,Kabul-D15,4,Khwaja Bughra Squre,1,Village,1,7,0,TRUE
+101292,69.14805555,34.565,3,Hazrat-E-Kheder Mosque,Kabul,6,Kabul-D15,3,Hesa Sewom-E-Khair Khana,1,Building,1,6,0,TRUE
+101293,69.15691199,34.57974199,5,Mohammad Faqer Ferozi High School,Kabul,9,Kabul-D15,4,Hesa Sewom-E-Khair Khana,1,Building,1,9,0,TRUE
+101294,69.15306092,34.57394572,4,Bi Bi Sara High School,Kabul,9,Kabul-D15,5,Hesa Sewom-E-Khair Khana,1,Building,1,9,0,TRUE
+101295,69.12444444,34.57388888,3,Sarwar-E-Kaienat Mosque,Kabul,6,Kabul-D15,3,Hesa Sewom-E-Khair Khana,1,Building,1,6,0,TRUE
+101296,69.1625,34.56944444,4,Khwaja Bughra No.2 Secondary School,Kabul,8,Kabul-D15,4,Khair Khana Electricity Junction,1,Building,1,8,0,TRUE
+101297,69.1600897,34.57230417,3,Kheder Mosque,Kabul,6,Kabul-D15,3,Khwaja Bughra,1,Building,1,6,0,TRUE
+101298,69.15604659,34.56799148,4,Fire Department,Kabul,7,Kabul-D15,3,Khwaja Bughra,1,Building,1,7,0,TRUE
+101299,69.16222222,34.57305555,2,Khwaja Mahiuddin Chashti Mosque,Kabul,4,Kabul-D15,2,Khwaja Bughra,1,Building,1,4,0,TRUE
+101300,69.16055555,34.57472222,2,Khatimul Anbeya Mosque,Kabul,4,Kabul-D15,2,Khwaja Bughra,1,Building,1,4,0,TRUE
+101301,69.15495179,34.56569667,4,Hazrat-E-Khairul Bashar Mosque,Kabul,5,Kabul-D15,1,Lab-E-Jar,1,Building,1,5,0,TRUE
+101302,69.15124166,34.56755277,3,Saad Ibne Weqas Mosque,Kabul,5,Kabul-D15,2,Lab-E-Jar,1,Building,1,5,0,TRUE
+101303,69.153872187,34.588321375,4,Mohammad Anwer Bismel High School,Kabul,8,Kabul-D15,4,500 Family,1,Building,1,8,0,TRUE
+101304,69.157910511,34.589477723,3,Bi Bi Fatima Zahra Talemul Quran Madrassa,Kabul,5,Kabul-D15,2,Posta-E-Kachalu,1,Building,1,5,0,TRUE
+101305,69.1604455,34.59348139,2,Shah-E-Awlia Mosque,Kabul,4,Kabul-D15,2,Posta-E-Kachalu,1,Building,1,4,0,TRUE
+101306,69.21478194,34.58018374,3,Abdul Ahmad Jawed High School,Kabul,7,Kabul-D15,4,Qasaba-E-Khana Sazi,1,Building,1,7,0,TRUE
+101307,69.15864816,34.58369616,2,Hazrat-E- Noh Mosque,Kabul,4,Kabul-D15,2,Sari Pul-E-Khwaja Bughra,1,Building,1,4,0,TRUE
+101308,69.16,34.5853,2,Hazrat-E-Yousuf Mosque,Kabul,4,Kabul-D15,2,Sari Pule Khaja Bughra,1,Building,1,4,0,TRUE
+101309,69.159805,34.572101,2,Mohammadia Mosque,Kabul,4,Kabul-D15,2,Sari Pule Khaja Bughra,1,Village,1,4,0,TRUE
+101310,69.14911166,34.59143493,2,Panjsad Family Shuhada Mosque,Kabul,4,Kabul-D15,2,Tapa-E- 500 Families,1,Building,1,4,0,TRUE
+101311,69.165482,34.57568,2,Zaid Bine Sabit Mosque,Kabul,4,Kabul-D15,2,Ziarat-E-Khwaja Bughra,1,Building,1,4,0,TRUE
+101312,69.21256781,34.52757393,5,Qala Zaman Khan Secondary School,Kabul,9,Kabul-D16,4,Qala-E-Zaman Khan,1,Building,1,9,0,TRUE
+101313,69.26938616,34.52997563,4,Halo Khel Secondary School,Kabul,7,Kabul-D16,3,Halo Khel,1,Building,1,7,0,TRUE
+101314,69.24462049,34.51922019,5,Shahrak-E-Khurasan High School,Kabul,9,Kabul-D16,4,Shahrak-E-Khurasan,1,Building,1,9,0,TRUE
+101315,69.21194444,34.53222222,2,Hazrat-E-Bilal Mosque,Kabul,4,Kabul-D16,2,Qala-E-Zaman Khan,1,Building,1,4,0,TRUE
+101316,69.22966737,34.53024072,3,Ghafor Ahmadi High School,Kabul,6,Kabul-D16,3,Deh Khudaidad,1,Building,1,6,0,TRUE
+101317,69.20262789,34.52693254,4,Lama Shaheed High School,Kabul,7,Kabul-D16,3,First Makroryan,1,Building,1,7,0,TRUE
+101318,69.25796513,34.50942778,4,Qala-E-Ahmad Khan Boys Secondary School,Kabul,7,Kabul-D16,3,Qala-E-Ahmad Khan,1,Building,1,7,0,TRUE
+101319,69.20209908,34.52961219,4,Nazo Ana Secondary School,Kabul,7,Kabul-D16,3,First Makroryan,1,Building,1,7,0,TRUE
+101320,69.21393159,34.53500356,1,Abu Ayub Ansari Mosque,Kabul,3,Kabul-D16,2,Qala-E-Zaman Khan,1,Building,1,3,0,TRUE
+101321,69.21954949,34.52956888,3,Hazrat-E-Bilal Mosque,Kabul,5,Kabul-D16,2,Qala-E-Zaman Khan,1,Village,1,5,0,TRUE
+101322,69.23029036,34.52263065,1,Usman Ghani Mosque,Kabul,2,Kabul-D16,1,Deh Khudaidad,1,Village,1,2,0,TRUE
+101323,69.2035272,34.52196833,2,Building Of 16Th District,Kabul,4,Kabul-D16,2,First Makroryan,1,Village,1,4,0,TRUE
+101324,69.224529,34.536474,1,Nomania Mosque,Kabul,3,Kabul-D16,2,Qala-E-Shura,1,Village,1,3,0,TRUE
+101325,69.21695455,34.52987236,2,Abu Obaida Mosque,Kabul,4,Kabul-D16,2,Qala-E-Zaman Khan,1,Building,1,5,0,TRUE
+101326,69.10862965,34.56912519,5,Azadi High School,Kabul,9,Kabul-D17,4,Chashma-E-Kotal,1,Building,1,10,1,TRUE
+101327,69.08769271,34.58477133,7,17Th Nahia Office,Kabul,13,Kabul-D17,6,Sar-E-Kotal Khair Khana,1,Building,1,15,0,TRUE
+101328,69.1284643,34.55314627,4,Qari Naik Mohammad High School,Kabul,8,Kabul-D17,4,Tahya-E-Maskan,1,Building,1,9,0,TRUE
+101329,69.28198072,34.61200925,4,Mohammad Jan Khan High School,Kabul,7,Kabul-D18,3,Bakhtyaran,1,Building,1,7,0,TRUE
+101331,69.36598705,34.54390576,4,Haji Satar Khan Shah Mohammad Khel Mosque,Kabul,8,Kabul-D21,4,"Nahia 21, Proja",1,Building,1,11,0,TRUE
+101332,69.37583333,34.55027777,4,Haji Gul Wali Mosque,Kabul,7,Kabul-D21,3,"Nahia 21, Proja",1,Village,1,9,0,TRUE
+101430,69.19258758,34.49134022,4,Noman Ibne Sabit Mosque,Kabul,9,Kabul-D08,5,Nahia 9,1,Building,1,9,0,TRUE
+101448,69.37305555,34.53277777,3,Haji Senator Janat Gul School,Kabul,7,Kabul-D21,4,Dasht-E-Khak Jabar,1,Building,1,8,0,TRUE
+101449,69.39611111,34.48944444,2,Talib Jan Mosque,Kabul,5,Kabul-D21,3,Janat Gul Mina,1,Building,1,7,0,TRUE
+101473,69.36416666,34.54472222,3,Kochian Religious Madrassa,Kabul,6,Kabul-D21,3,Religious Madrassa Of Senator Janat Gul,1,Building,1,11,0,TRUE
+101488,69.18311633,34.51864487,1,Ziarat Abu Alfazal,Kabul,2,Kabul-D02,1,Murad Khani,1,Building,1,2,1,TRUE
+101489,69.14384251,34.44036957,3,Ahmadia Qala-E- Fotoh Mosque,Kabul,6,Kabul-D07,3,Qala-E-Fatoh,1,Building,1,6,0,TRUE
+101490,69.137403122,34.484589711,2,Sardar Kabuli Girls High School,Kabul,6,Kabul-D07,4,Se Rahi Allawoudin,1,Building,1,8,0,TRUE
+101491,69.215,34.50083333,2,Abu Baker Sediq Mosque,Kabul,3,Kabul-D08,1,Jadid Abad Village,1,Building,1,3,0,TRUE
+101492,69.198091659,34.502619877,3,Ashab-E- Keram Mosque,Kabul,5,Kabul-D08,2,Tank-E-Logar,1,Building,1,5,0,TRUE
+101493,69.20562875,34.54319726,2,Sohel Ibne Omer Mosque,Kabul,4,Kabul-D09,2,4Th Makrorian,1,Building,1,5,0,TRUE
+101495,69.14793611,34.58788611,3,Panj Peeran Mosque,Kabul,4,Kabul-D11,1,Proja-E-315,1,Building,1,4,0,TRUE
+101496,69.129,34.4891,2,Emam Jafar Mosque,Kabul,3,Kabul-D11,1,"Imam-E-Jafar Mosque, Tapa-E-Sadat",1,Building,1,3,0,TRUE
+101497,69.32208695,34.50332662,3,Mohammad Musa Shafiq High School,Kabul,6,Kabul-D12,3,Block 12,1,Building,1,8,0,TRUE
+101498,69.32536897,34.51862371,3,Ahmad Shah Baba Girls High School,Kabul,6,Kabul-D12,3,"Block 8, Ahmad Shah Baba Mina",1,Building,1,8,0,TRUE
+101499,69.06793094,34.47818413,3,Imam-E-Mehdi Mosque,Kabul,5,Kabul-D13,2,Shahrak-E-Mahdia,1,Building,1,7,0,TRUE
+101500,69.09035006,34.50266465,4,Quran O Utrat Mosque,Kabul,7,Kabul-D13,3,"Onchi, Hospital Bus Stop",1,Building,1,7,0,TRUE
+101501,69.04374149,34.5031939,4,Qamar Bani Hashim Mosque,Kabul,7,Kabul-D13,3,Shahrak-E-Jafaria,1,Building,1,7,0,TRUE
+101502,69.00799757,34.56840891,1,Doda Mast Village Mosque,Kabul,3,Kabul-D14,2,Doda Mast Village,1,Building,1,3,0,TRUE
+101503,69.17083333,34.57472222,3,Hazrat-E-Omer Farooq Mosque,Kabul,5,Kabul-D15,2,Tapa-E- Khwaja Bughra,1,Building,1,5,0,TRUE
+101504,69.14592666,34.5935326,3,Im-E-Zafra Mosque,Kabul,5,Kabul-D15,2,"Family, Sar-E-Tapa-E-Shohada 500",1,Building,1,5,0,TRUE
+101505,69.23216305,34.52200297,2,Shaheedan Secondary School,Kabul,4,Kabul-D16,2,Deh Khudaidad,1,Village,1,4,0,TRUE
+101506,69.22727218,34.52980252,1,Deh Khudaidad Girls High School,Kabul,2,Kabul-D16,1,Deh Khudaidad,1,Building,1,2,1,TRUE
+101507,69.12470211,34.56099865,2,Now Abad Dehkapak Girls High School,Kabul,5,Kabul-D17,3,Deh Kepak,1,Village,1,5,0,TRUE
+101508,69.272798717,34.663543852,2,Shahrak-E-Mohammadia High School,Kabul,5,Kabul-D18,3,Shahrak-E-Mohammadia,1,Building,1,5,0,TRUE
+101509,69.40074647,34.56362527,3,Sharif Gul Said Khan Mosque,Kabul,7,Kabul-D21,4,Malwari Ghundi,1,Building,1,7,0,TRUE
+101510,69.354248472,34.504543213,2,Sharif Qul Bahu Mosque,Kabul,5,Kabul-D21,3,Bot Khak,1,Building,1,5,0,TRUE
+101511,69.39277311,34.55262745,4,Spen Ghar Secondary School,Kabul,8,Kabul-D21,4,Speen Ghar Village,1,Building,1,8,0,TRUE
+101512,69.350479,34.518352,5,Haji Baz Mosque,Kabul,11,Kabul-D09,6,Pul-E-Charkhi Prison,1,Building,1,11,0,TRUE
+101513,69.279753675,34.563049951,3,Wazir Gul Mosque,Kabul,6,Kabul-D09,3,Gardi Khel,1,Building,1,6,0,TRUE
+101514,69.361289,34.545629,2,Ahmad Jan Mosque,Kabul,5,Kabul-D09,3,"Naw Abad, Pul-E-Charkhi",1,Village,1,6,1,TRUE
+101519,69.220688632,34.513031493,2,Sarak Awal Mosque,Kabul,3,Nahia_08,1,Noor Muhammad Sha Mina,1,Building,1,3,0,TRUE
+101520,69.242327555,34.50909961,2,Hzor Hazrat Nabi Mosque,Kabul,3,Nahia_08,1,Behaind Of Cokakola Industary,1,Building,1,3,0,TRUE
+101521,69.29869885,34.549534929,2,Noor Muhammad Mosque,Kabul,4,Nahia_09,2,District_09,1,District,1,4,1,TRUE
+101522,69.12527292,34.582739281,2,Abo Horaira,Kabul,3,Nahia_11,1,Hesa Awal Hell,1,Building,1,3,0,TRUE
+101523,69.110767549,34.571819868,2,Yaqob Mosque,Kabul,3,Nahia_11,1,Behaind Lwai 16,1,Building,1,3,0,TRUE
+101524,69.334773429,34.517598796,2,Ghulam Sedeq High School,Kabul,3,Nahia_12,1,Arzan Qimat 10Th Block,1,Building,1,6,0,TRUE
+101525,69.335241564,34.50585351,2,Sedeq Ullah Risghteen High School,Kabul,3,Nahia_12,1,Arzan Qimat 13Th Block,1,Building,1,5,0,TRUE
+101526,69.157064037,34.579743637,2,Aqsa Mosque,Kabul,3,Nahia_15,1,District-15,1,Building,1,4,0,TRUE
+101527,69.171113296,34.569572838,2,Al Muhammad Mosque,Kabul,3,Nahia_15,1,District-15,1,Building,1,3,0,TRUE
+101528,69.169276122,34.577129423,2,Muhammad Hanifa Ghazi Mosque,Kabul,3,Nahia_15,1,District-15,1,Building,1,3,0,TRUE
+101529,69.160067815,34.572254345,2,Prozha Khurasan Mosque,Kabul,3,Nahia_15,1,District-15,1,Building,1,3,0,TRUE
+101530,69.1636212,34.581793968,2,Khoja Bughra Mosque,Kabul,3,Nahia_15,1,Pawar Station Street,1,Building,1,3,0,TRUE
+101531,69.068285149,34.606757086,3,Sedeq Akbar High School,Kabul,5,Nahia_17,2,Nejat Town,1,Building,1,6,0,TRUE
+101532,69.409831603,34.527282135,2,Abdul Wahab Mosque,Kabul,3,Nahia_21,1,Deh Sabz_District_21,1,Building,1,3,0,TRUE
+101534,69.081970476,34.607128282,4,Shahrak Tlaie High School,Kabul,6,Nahia_17,2,Shahrak Tlaie Town,1,Building,1,7,0,TRUE
+101535,69.397763303,34.534410934,2,Hamza Mosque,Kabul,3,Nahia_21,1,Deh Sabz_District_21,1,District,1,3,0,TRUE
+101553,69.024026484,34.500556898,2,Emam Hadi Mosque,Kabul,3,District_13,1,Etifaq Town,1,Building,1,5,0,TRUE
+101554,69.038751628,34.490755669,2,Sahrak Mohamadia Secondary School,Kabul,3,District_13,1,Qala Naw,1,Building,1,5,0,TRUE
+101555,69.059941315,34.506223663,2,Qhraman Karbala Mosque,Kabul,4,District_13,2,Regression,1,Building,1,6,0,TRUE
+101556,69.037971659,34.479220207,2,Qambar Bin Hashem Mosque,Kabul,4,District_13,2,Kor Kariz,1,Building,1,4,0,TRUE
+101557,69.092356819,34.489318265,2,Shahrak High School,Kabul,3,District_13,1,Shrak Dwazda Emamy,1,Building,1,4,0,TRUE
+102398,69.00005546,34.59551923,4,Abdullah Ibne Abbas High School,Kabul,6,Paghman,2,Ala Bala,1,Village,2,6,0,TRUE
+102399,68.94712462,34.51095742,4,Hazrat-E-Omer Farooq Secondary School,Kabul,7,Paghman,3,Arghanda-E-Payen,1,Building,2,7,0,TRUE
+102400,68.94885838,34.48934239,4,Hasanul Basri School,Kabul,6,Paghman,2,Arghanda-E-Bala,1,Village,2,6,0,TRUE
+102401,68.95370379,34.59879716,2,Dawra Mosque,Kabul,3,Paghman,1,Parachi,1,Building,2,3,0,TRUE
+102402,68.95723563,34.58711887,3,Paghman District Office,Kabul,5,Paghman,2,Chandal Boi,1,Village,2,5,0,TRUE
+102403,68.94998469,34.59452364,2,Abdullah Ibne Omer Secondary School,Kabul,4,Paghman,2,Parachi,1,Building,2,4,0,TRUE
+102404,68.98927054,34.52959486,3,Cheheltan High School,Kabul,4,Paghman,1,Cheheltan,1,Village,2,4,0,TRUE
+102405,68.95739059,34.59023388,3,12 Imam Clinic,Kabul,4,Paghman,1,Dara-E-Pashaye,1,Building,2,4,0,TRUE
+102406,68.96768913,34.59115548,3,Hazrat-E-Usman Secondary School,Kabul,4,Paghman,1,Dara-E-Zargar,1,Building,2,4,0,TRUE
+102407,69.008644896,34.565157544,2,Paghman-E-Qashang Secondary School,Kabul,4,Paghman,2,Deh Dast,1,Building,2,5,0,TRUE
+102408,68.98920501,34.50463474,3,Hazrat-E-Abubakr-E-Sedeq School,Kabul,5,Paghman,2,Qala-E-Haider Khan,1,Building,2,5,0,TRUE
+102409,68.98042099,34.53315146,2,Hazrat-E-Khalid Ibne Walid High School,Kabul,4,Paghman,2,Karezak,1,Building,2,4,0,TRUE
+102410,69.02276031,34.54175817,2,Keshkak Primary School,Kabul,3,Paghman,1,Kashkak,1,Village,2,4,0,TRUE
+102411,68.9958082,34.55159256,3,Khwaja Musafer High School,Kabul,4,Paghman,1,Khwaja Musafer,1,Building,2,4,0,TRUE
+102412,68.97264524,34.55183655,2,Khaldari Mosque,Kabul,3,Paghman,1,Khaldari,1,Building,2,4,0,TRUE
+102413,68.949127936,34.558485458,2,Khwaja Lakan High School,Kabul,3,Paghman,1,Khwaja Lakan,1,Building,2,3,0,TRUE
+102414,68.97982614,34.48791841,4,Qala-E-Yaqoub Khel Mosque,Kabul,6,Paghman,2,Murgh Geran,1,Building,2,6,0,TRUE
+102415,68.982774245,34.574313836,2,Qala-E-Malik Mosque,Kabul,3,Paghman,1,Qala-E-Malak,1,Village,2,3,0,TRUE
+102416,69.0001064,34.6146081,2,Sumuchak Primary School,Kabul,3,Paghman,1,Smochak Village,1,Building,2,3,0,TRUE
+102417,68.964355,34.54277991,2,Orya Khel Secondary School,Kabul,4,Paghman,2,Orya Khel,1,Building,2,4,0,TRUE
+102418,68.94906596,34.48005115,2,Saha-E-Kuchiha,Kabul,3,Paghman,1,Chawk Arghandi,1,Village,2,3,0,TRUE
+103419,69.12422885,34.37821165,4,Chehel Dukhtaran Mosque,Kabul,5,Chahar Asyab,1,Chel Dukhtaran,1,Village,3,5,0,TRUE
+103420,69.173538576,34.417730648,3,Jami Khair Abad,Kabul,4,Chahar Asyab,1,Khair Abad,1,Village,3,4,0,TRUE
+103421,69.12147378,34.40566585,3,Qala Luqman Primary School,Kabul,5,Chahar Asyab,2,Qala-E-Loqman,1,Building,3,5,0,TRUE
+103422,69.1171451,34.35229222,2,Malik Khani House,Kabul,3,Chahar Asyab,1,Nowniaz,1,Village,3,3,0,TRUE
+103423,69.14518153,34.41689761,2,Chahar Asyab Boys High School,Kabul,3,Chahar Asyab,1,Bala Qala,1,Building,3,3,0,TRUE
+103424,69.14319523,34.39521939,1,Elyas Khel Mosque,Kabul,2,Chahar Asyab,1,Qala-E-Ghafar,1,Building,3,2,0,TRUE
+103425,69.16389905,34.39655462,2,Malalai Shaheed High School,Kabul,5,Chahar Asyab,3,Qala-E-Naim,1,Building,3,5,0,TRUE
+103426,69.01176294,34.39535748,1,Malik Reza Khan Mosque,Kabul,2,Chahar Asyab,1,Lalandar Shutor Parida,1,Building,3,2,0,TRUE
+103427,69.15812847,34.40907796,1,Charsawq Mosque,Kabul,2,Chahar Asyab,1,Charsoq,1,Building,3,2,0,TRUE
+103428,69.16576935,34.41090442,1,Charsawq Karez Mosque,Kabul,2,Chahar Asyab,1,Karez Charsoq,1,Village,3,2,0,TRUE
+103429,69.108072609,34.416879761,2,Tangi Saiedan Girls High School,Kabul,3,Chahar Asyab,1,Tangi Sayedan,1,Building,3,5,0,TRUE
+103494,69.12548831,34.42428806,3,Reshkhur-E-Ulya Primary School,Kabul,4,Chahar Asyab,1,Reshkhur,1,Building,3,4,0,TRUE
+103536,69.110809475,34.375832763,2,Liwan Khil Mosque,Kabul,3,Charasiab,1,Mia Khil,1,Building,3,3,0,TRUE
+103537,69.159593482,34.38711341,2,Haji Marjan Mosque,Kabul,3,Charasiab,1,Ghazi Abad,1,Building,3,3,0,TRUE
+104450,69.29416694,34.52027233,3,Sheena Boys High School,Kabul,4,Bagrami,1,Sheena Village,1,Building,4,4,0,TRUE
+104451,69.29454058,34.52301801,1,Sheena Girls High School,Kabul,4,Bagrami,3,Sheena Village,1,Village,4,4,0,TRUE
+104452,69.22585478,34.46498775,3,Shewaki Boys High School,Kabul,4,Bagrami,1,Shewaki,1,Building,4,4,0,TRUE
+104453,69.26061786,34.50457189,1,Qala-E-Ahmad Khan Girls High School,Kabul,3,Bagrami,2,Qala-E-Ahmad Khan,1,Building,4,4,0,TRUE
+104454,69.35136285,34.49971974,2,But Khak Boys High School,Kabul,4,Bagrami,2,Bot Khak,1,Building,4,4,0,TRUE
+104455,69.3028819,34.48934664,2,Hussain Khel High School,Kabul,4,Bagrami,2,Hossain Khel,1,Village,4,7,0,TRUE
+104456,69.29635517,34.49542936,3,Abdul Shakur Reshad High School,Kabul,5,Bagrami,2,Bagrami,1,Building,4,6,0,TRUE
+104457,69.2813096,34.47283862,3,Kamari Girls High School,Kabul,4,Bagrami,1,Kamari,1,Building,4,4,0,TRUE
+104458,69.21648167,34.47300619,2,Qala-E-Wazir Girls High School,Kabul,3,Bagrami,1,Qala-E-Wazir,1,Building,4,3,0,TRUE
+104459,69.200684062,34.470105212,2,Shaheed Mohammad Arif Zarif Secondary School,Kabul,4,Bagrami,2,Valayati,1,Building,4,4,0,TRUE
+104460,69.31333333,34.4675,2,Kariz Bakr Primary School,Kabul,3,Bagrami,1,Karez Bakr Village,1,Building,4,3,0,TRUE
+104461,69.31059484,34.46685639,1,Ahmadzai Mosque,Kabul,2,Bagrami,1,Karez Bakr Village,1,Village,4,5,0,TRUE
+104462,69.22615256,34.44950023,3,Sahak Boys High School,Kabul,4,Bagrami,1,Sahag Village,1,Building,4,4,0,TRUE
+104538,69.257856843,34.455030928,2,Shaheed Malik Gul Rahman High School,Kabul,3,Bagrami,1,Mamozai,1,Building,4,3,0,TRUE
+104539,69.248404801,34.466101132,2,Qala Hasan Khan Mosque,Kabul,3,Bagrami,1,Qalai Hasan Khan Sufla,1,Building,4,3,0,TRUE
+104540,69.31229847,34.492235239,2,Mehtarlam Baba Mosque,Kabul,3,Bagrami,1,Hasan Khil Village_Said Jamaludin Second Part,1,Building,4,5,0,TRUE
+105330,69.29931696,34.55597475,4,Tara Khel Girls High School,Kabul,7,Dehsabz,3,Tarakhel,1,Village,5,7,0,TRUE
+105463,69.216924475,34.604160897,5,Pacha Sahib Boys School,Kabul,8,Dehsabz,3,Pacha Sahib,1,Building,5,8,0,TRUE
+105464,69.23406426,34.64693603,3,Khwaja Chesht High School,Kabul,6,Dehsabz,3,Khwaja Chasht,1,Building,5,6,0,TRUE
+105465,69.36496192,34.67767902,2,Baba Qashqar Mosque,Kabul,4,Dehsabz,2,Baba Qashqar,1,Building,5,4,0,TRUE
+105466,69.23632106,34.59919574,2,Deh Yahya High School,Kabul,3,Dehsabz,1,Deh Yahya,1,Building,5,3,0,TRUE
+105467,69.24315187,34.72896002,3,Shekho Secondary School,Kabul,5,Dehsabz,2,Bandi Khana,1,Building,5,5,0,TRUE
+105468,69.35916305,34.54769658,5,Safid Mosque,Kabul,8,Dehsabz,3,Pul-E-Charkhi,1,Building,5,10,0,TRUE
+105469,69.35737539,34.54490705,3,Mehtar Lam Baba Mosque,Kabul,4,Dehsabz,1,Pul-E-Charkhi,1,Building,5,4,0,TRUE
+105470,69.39915005,34.57290983,3,Sulh High School,Kabul,5,Dehsabz,2,Pul-E-Charkhi 2,1,Building,5,5,0,TRUE
+105471,69.37369088,34.63373293,4,Faiz Alquran Madrasa,Kabul,6,Dehsabz,2,Ali Khel,1,Building,5,6,0,TRUE
+105472,69.394542176,34.646100641,1,Deh Sabz-E-Khas Girls High School,Kabul,2,Dehsabz,1,Deh Sabz Khas,1,Building,5,2,0,TRUE
+105474,69.26238547,34.60836995,2,Haji Ahmad Shah Mosque,Kabul,4,Dehsabz,2,Qala-E-Zarin,1,Building,5,4,0,TRUE
+105475,69.19571545,34.630605043,2,Malik Zar Gul Mosque,Kabul,4,Dehsabz,2,Zera Ghundi,1,Building,5,4,0,TRUE
+105533,69.390961368,34.56682518,2,Haji Abdullah Khan Mosque,Kabul,3,Dehsabz,1,Torkham Transportation Station,1,Building,5,3,0,TRUE
+105541,69.372638397,34.603846217,2,Qais Wa Lang Mosque,Kabul,3,Dehsabz,1,Jeeran,1,Village,5,3,0,TRUE
+106386,69.0351322,34.62307238,3,Bala Kariz Secondary School,Kabul,4,Shakar Dara,1,Bala Karez Village,1,Building,6,4,0,TRUE
+106387,69.03930845,34.70510406,4,Behzadi Clinic,Kabul,6,Shakar Dara,2,Behzadi,1,Building,6,6,0,TRUE
+106388,69.06167496,34.69991077,3,Boya Zar High School,Kabul,6,Shakar Dara,3,Deh Boya Zar,1,Building,6,6,0,TRUE
+106389,69.13703188,34.66307758,3,Danishmand High School,Kabul,5,Shakar Dara,2,Danishmand,1,Building,6,5,0,TRUE
+106390,69.04891022,34.65301333,4,Wazir Gul Shaheed Secondary School,Kabul,6,Shakar Dara,2,Dowlana,1,Building,6,6,0,TRUE
+106391,69.01550379,34.6435962,2,Ghaza High School,Kabul,4,Shakar Dara,2,Ghaza Village,1,Building,6,4,0,TRUE
+106392,69.08612997,34.68219723,3,Haji Paik Primary School,Kabul,5,Shakar Dara,2,Haji Paik,1,Building,6,5,0,TRUE
+106393,69.08967865,34.65916757,3,Mohammad Hassan Khan High School,Kabul,6,Shakar Dara,3,Qala-E-Dasht,1,Building,6,6,0,TRUE
+106394,69.03443985,34.68545039,4,Dara-E-Shakar Dara High School,Kabul,7,Shakar Dara,3,Qala-E-Wazir,1,Building,6,7,0,TRUE
+106395,69.07541514,34.66741061,3,Qala-E-Murad Big High School,Kabul,6,Shakar Dara,3,Qala-E-Murad Big,1,Building,6,6,0,TRUE
+106396,69.05845173,34.63698074,4,Hazrat-E-Usman High School,Kabul,5,Shakar Dara,1,Karez Mir-E-Payan,1,Building,6,5,0,TRUE
+106397,69.03545918,34.68148881,4,Shakar Dara High School,Kabul,7,Shakar Dara,3,Shah-E-Mardan,1,Building,6,7,0,TRUE
+106542,69.1692788,34.617692925,2,Shahrak Alghawi Mosque,Kabul,3,Shakar Dara,1,Alghawi Town,1,Building,6,3,0,TRUE
+106543,69.065739805,34.6980502,2,Mosque,Kabul,3,Shakar Dara,1,Asad Abad,1,District,6,3,0,TRUE
+107431,69.22710172,34.39277839,2,Qeshlaq Secondary School,Kabul,4,Musahi,2,Saied Khel Muien Khel,1,Village,7,4,0,TRUE
+107432,69.23329817,34.36985162,1,Shenkai Village Mosque,Kabul,4,Musahi,3,Dashtak,1,Village,7,4,0,TRUE
+107433,69.17518441,34.32876836,3,Musahi Ulya High School,Kabul,6,Musahi,3,Deh Kalan,1,Village,7,6,0,TRUE
+107434,69.17141395,34.33383787,1,Hussain Khel Deh Kalan Mosque,Kabul,2,Musahi,1,"Hasan Khel Village, Deh Kalan",1,Village,7,3,0,TRUE
+107435,69.17569377,34.3546893,1,Qala-E- Janan Mosque,Kabul,3,Musahi,2,"Qala-E-Janan, Deh Kalan",1,Village,7,3,0,TRUE
+107436,69.1914329,34.34184904,2,Khanan Khel Mosque,Kabul,3,Musahi,1,Khanan Khel,1,Building,7,3,0,TRUE
+107437,69.21086922,34.35709853,2,Musahi Girls Primary School,Kabul,3,Musahi,1,Char Sowq,1,Building,7,3,0,TRUE
+107438,69.2019022,34.42003749,2,Abbas Quli Mosque,Kabul,3,Musahi,1,Qala-E-Abbas Quli,1,Building,7,3,0,TRUE
+108333,69.14417109,34.74313263,3,Aabchakan Secondary School,Kabul,5,Mir Bacha Kot,2,Aabchakan,1,Building,8,5,0,TRUE
+108334,69.12814946,34.75067637,2,Mareki Mosque,Kabul,3,Mir Bacha Kot,1,Mariki,1,Village,8,3,0,TRUE
+108335,69.10091216,34.76619333,1,Mashwani School,Kabul,2,Mir Bacha Kot,1,Mashwani,1,Building,8,2,0,TRUE
+108336,69.121033712,34.730616918,2,Shaikan Secondary School,Kabul,4,Mir Bacha Kot,2,Shaikhan,1,Building,8,4,0,TRUE
+108337,69.10733235,34.71223166,2,Mir Hameedullah School,Kabul,4,Mir Bacha Kot,2,Guzar Village,1,Building,8,4,0,TRUE
+108338,69.093598807,34.697990767,2,Pul-E-Sofian School,Kabul,3,Mir Bacha Kot,1,Sofian,1,Building,8,3,0,TRUE
+108339,69.09684781,34.72767363,3,Dako Secondary School,Kabul,4,Mir Bacha Kot,1,Markaz-E-Dako,1,Building,8,4,0,TRUE
+108340,69.12336046,34.74903065,2,Mir Bacha Khan No.2 High School,Kabul,4,Mir Bacha Kot,2,Sarai-E-Khwaja,1,Building,8,4,0,TRUE
+108341,69.1179676,34.75089672,2,Mir Bacha Kot School,Kabul,4,Mir Bacha Kot,2,District Compound,1,Building,8,4,0,TRUE
+108342,69.09957101,34.74355063,3,Baba Qashqar Mosque,Kabul,5,Mir Bacha Kot,2,Baba Qushqar,1,Building,8,5,0,TRUE
+108343,69.114758448,34.768079361,2,Qalam Chaaq Mosque,Kabul,3,Mir Bacha Kot,1,Qalam Chaq,1,Building,8,3,0,TRUE
+108344,69.12138053,34.76374152,2,Dasht School,Kabul,3,Mir Bacha Kot,1,Mirza Khel Village,1,Village,8,3,0,TRUE
+109439,69.41265419,34.30750437,2,Ghezgai Primary School,Kabul,3,Khak-E-Jabar,1,Ghizgi,1,Building,9,3,0,TRUE
+109440,69.39779486,34.31643447,2,Wali Khan House,Kabul,3,Khak-E-Jabar,1,Ghizgi,1,Village,9,3,0,TRUE
+109441,69.40306692,34.35659404,1,Bar Malang Mosque,Kabul,2,Khak-E-Jabar,1,Bar Malang,1,Building,9,2,0,TRUE
+109442,69.39503963,34.36510111,2,Shah Rasool House,Kabul,3,Khak-E-Jabar,1,Malang,1,Village,9,3,0,TRUE
+109443,69.40964845,34.35167141,1,Mohammad Nazir House,Kabul,2,Khak-E-Jabar,1,Malang,1,Village,9,2,0,TRUE
+109444,69.43472107,34.34630622,2,Chakari Boys High School,Kabul,3,Khak-E-Jabar,1,Chakari,1,Building,9,3,0,TRUE
+109445,69.42253445,34.36873804,2,Wali Khan Secondary School,Kabul,4,Khak-E-Jabar,2,Zendan,1,Building,9,4,0,TRUE
+109446,69.47987391,34.51257261,1,Chenar Primary School,Kabul,2,Khak-E-Jabar,1,Shenwar,1,Building,9,2,0,TRUE
+109447,69.38449497,34.386197,2,Khurd Kabul Mosque,Kabul,3,Khak-E-Jabar,1,Khurd Kabul,1,Building,9,3,0,TRUE
+110352,69.14562904,34.78806916,4,Amir Habibullah Shaheed High School,Kabul,6,Kalakan,2,Markaz-E-Kalakan,1,Building,10,6,0,TRUE
+110353,69.12792085,34.79359619,2,Sawad Hayati School,Kabul,3,Kalakan,1,Saied Abad,1,Building,10,3,0,TRUE
+110354,69.12058296,34.7786309,2,Qachi High School,Kabul,4,Kalakan,2,Qachi,1,Building,10,4,0,TRUE
+110355,69.15883167,34.76995575,2,Mashwani Clinic,Kabul,4,Kalakan,2,Mashwani,1,Building,10,4,0,TRUE
+110356,69.18374177,34.77997574,2,Aqa Sarai School,Kabul,3,Kalakan,1,Aqa Sarai Village,1,Building,10,3,0,TRUE
+110357,69.19057958,34.72913166,3,Zama Secondary School,Kabul,4,Kalakan,1,Zama Naw Village,1,Building,10,4,0,TRUE
+110358,69.14567051,34.75636743,1,Karenda Mosque,Kabul,2,Kalakan,1,Karenda,1,Building,10,2,0,TRUE
+110544,69.164118577,34.796639446,2,Moqawmat Secondary School,Kabul,3,Kalakan,1,Bazari Village,1,Building,10,3,0,TRUE
+111381,69.06174396,34.73626715,3,Dasht-E-Naseri Mosque,Kabul,5,Guldara,2,Dasht-E-Naseri,1,Building,11,5,0,TRUE
+111382,69.02394607,34.7458341,3,Gudara Mosque,Kabul,4,Guldara,1,Gudra Village,1,Building,11,4,0,TRUE
+111383,69.044748199,34.74282501,3,Payam-E-Azadi High School,Kabul,5,Guldara,2,Deh Naw,1,Building,11,5,0,TRUE
+111384,69.07041274,34.73997226,3,Malik Agha Mosque,Kabul,5,Guldara,2,Deh Bala,1,Building,11,5,0,TRUE
+111385,69.02829419,34.74867006,2,Deh-E-Araban Mosque,Kabul,4,Guldara,2,Deh Araban,1,Building,11,4,0,TRUE
+111545,69.04473323,34.730287551,2,Qul Afghan Primary School,Kabul,3,Guldara,1,Qul  Afghan,1,Building,11,3,0,TRUE
+112345,69.06167295,34.79461964,3,Farza Boys High School,Kabul,5,Farza,2,Payan Deh,1,Building,12,5,0,TRUE
+112346,69.07012269,34.78352733,3,Hasan Khel Mosque,Kabul,4,Farza,1,Hasan Khel,1,Building,12,4,0,TRUE
+112347,69.06306869,34.80033355,1,Mir Afghan Mosque,Kabul,2,Farza,1,Qala-E-Mir Afghan,1,Building,12,4,0,TRUE
+112348,69.04113635,34.78876975,1,Sarkhan Khel Mosque,Kabul,2,Farza,1,Sar Khan Khel,1,Building,12,2,0,TRUE
+112349,69.03787235,34.79576142,2,Qala-E-Chinar Mosque,Kabul,4,Farza,2,Qala-E-Chinar,1,Building,12,4,0,TRUE
+112350,69.0581366,34.78865753,1,Zargaran Mosque,Kabul,2,Farza,1,Zargaran,1,Building,12,2,0,TRUE
+112351,69.0215014,34.79021669,2,Sar-E-Joy Mosque,Kabul,3,Farza,1,Qala-E-Saleem Khan,1,Building,12,3,0,TRUE
+112546,69.067483461,34.776825995,2,Qala Muqareb Mosque,Kabul,3,Farza,1,Bostan,1,Village,12,3,0,TRUE
+113374,69.10266037,34.81844216,2,Khwaja Hassan Primary School,Kabul,3,Estalef,1,Khwaja Hassan Village,1,Building,13,3,0,TRUE
+113375,69.08759042,34.82095706,2,Shaheed Ahmad Shah Masoud High School,Kabul,3,Estalef,1,Qabr Malak,1,Building,13,3,0,TRUE
+113376,69.09446702,34.83823757,2,Mawlawi Mohammad Yaqoub Shah High School,Kabul,4,Estalef,2,Tangi Miana,1,Building,13,4,0,TRUE
+113377,69.04986755,34.84252108,2,Badal Shah Khel High School,Kabul,4,Estalef,2,Dara-E-Badal Shah Khel,1,Village,13,4,0,TRUE
+113378,69.09478073,34.82498755,1,Noor Alam Mosque,Kabul,2,Estalef,1,Noor Alam Village,1,Building,13,2,0,TRUE
+113379,69.07419775,34.82830668,1,Educational Department,Kabul,2,Estalef,1,Istalif Bazar,1,Building,13,2,0,TRUE
+113380,69.07388293,34.8297635,4,Estalif High School,Kabul,7,Estalef,3,Istalif District Capital,1,Building,13,7,0,TRUE
+114359,69.17097601,34.86884415,2,Aka Khel Madrassa,Kabul,4,Qara Bagh,2,Aka Khel Village,1,Village,14,4,0,TRUE
+114360,69.17405266,34.87006481,4,Aka Khel Secondary School,Kabul,7,Qara Bagh,3,Aka Khel,1,Building,14,7,0,TRUE
+114361,69.16085449,34.81786617,1,Bagh-E-Ariq Secondary School,Kabul,2,Qara Bagh,1,Bagh-E-Ariq,1,Village,14,2,0,TRUE
+114362,69.20371125,34.85042398,2,Mir Alam Khan High School,Kabul,4,Qara Bagh,2,Bagh-E-Zaghan,1,Village,14,2,2,TRUE
+114363,69.22212366,34.87807939,2,Bagh-E-Alam High School,Kabul,3,Qara Bagh,1,Bagh-E-Alam,1,Building,14,3,0,TRUE
+114364,69.24119935,34.8822942,3,Chawni Mosque,Kabul,5,Qara Bagh,2,Chawni,1,Village,14,5,0,TRUE
+114365,69.17453914,34.82300042,2,Dowod Zai High School,Kabul,4,Qara Bagh,2,Dawod Zai,1,Building,14,4,0,TRUE
+114366,69.18468964,34.86588865,2,Abdul Rahman Ba Ba Secondary School,Kabul,4,Qara Bagh,2,Denar Khel,1,Building,14,4,0,TRUE
+114367,69.15720909,34.84395674,3,Abdul Wakil Shaheed High School,Kabul,5,Qara Bagh,2,District Capital,1,Building,14,5,0,TRUE
+114368,69.15712595,34.84278944,2,Qara Bagh Teacher Training Institute,Kabul,3,Qara Bagh,1,District Capital,1,Building,14,3,0,TRUE
+114369,69.09526801,34.86788489,3,Isterghuch High School,Kabul,5,Qara Bagh,2,Isterghuch,1,Building,14,5,0,TRUE
+114370,69.18955338,34.85154344,2,Kariz Mir Mosque,Kabul,3,Qara Bagh,1,Kariz Mir,1,Building,14,3,0,TRUE
+114371,69.199618587,34.820920682,3,Langar High School,Kabul,6,Qara Bagh,3,Langar,1,Building,14,6,0,TRUE
+114372,69.16816667,34.85446225,2,Langar Secondary School,Kabul,4,Qara Bagh,2,Qarabagh Bazar,1,Building,14,4,0,TRUE
+114373,69.14499885,34.81478304,3,Sabz Sang High School,Kabul,6,Qara Bagh,3,Sabz Sang,1,Building,14,6,0,TRUE
+114547,69.250474309,34.823929213,2,Alas Ghan High School,Kabul,3,Qarabagh,1,Barik Ab Town,1,Building,14,3,0,TRUE
+114548,69.199825777,34.878948239,2,Jar Chi Secondary School,Kabul,3,Qarabagh,1,Jar Chi,1,Village,14,3,0,TRUE
+114549,69.14901622,34.830226025,2,Qala Haji Secondary School,Kabul,3,Qarabagh,1,Qala Haji,1,Village,14,3,0,TRUE
+115476,69.73560063,34.57699678,3,Dar-E-Hesara Mosque,Kabul,4,Surubi,1,Dara-E-Hesar,1,Building,15,4,0,TRUE
+115477,69.74284256,34.58856114,4,Hud Khel-E-Bala High School,Kabul,6,Surubi,2,Hudkhel Bala,1,Building,15,6,0,TRUE
+115478,69.76419382,34.43916542,2,Jegdalak School,Kabul,3,Surubi,1,Jegdalak,1,Building,15,3,0,TRUE
+115479,69.71990075,34.56868747,2,Yar Del Orya Khel Mosque,Kabul,3,Surubi,1,Loy Kalai,1,Building,15,3,0,TRUE
+115480,69.57981103,34.36484157,2,Tezen-E-Khas Primary School,Kabul,3,Surubi,1,Loy Kalai,1,Building,15,3,0,TRUE
+115481,69.7162556,34.63015173,3,Naghlu Primary School,Kabul,4,Surubi,1,Naghlo,1,Building,15,4,0,TRUE
+115482,69.7190229,34.5649729,2,Qala-E-Kalan Mosque,Kabul,4,Surubi,2,Qala-E-Kalan,1,Building,15,4,0,TRUE
+115483,69.72876684,34.58315495,3,Surubi Clinic,Kabul,6,Surubi,3,Shahrak,1,Building,15,6,0,TRUE
+115484,69.7547645,34.59035135,3,Shahrak Primary School,Kabul,4,Surubi,1,Shahrak,1,Building,15,6,0,TRUE
+115485,69.73407601,34.58610998,2,Hudkhel Girls Secondary School,Kabul,3,Surubi,1,Hudkhel,1,Building,15,3,0,TRUE
+115486,69.89896613,34.79685812,2,Bam Dare Mosque,Kabul,4,Surubi,2,Bam Darai,1,Village,15,4,0,TRUE
+115487,69.84314337,34.77523912,2,Gaz-E-Ulya Mosque,Kabul,5,Surubi,3,"Gaz-E-Ulya, Wazbin",1,Building,15,5,0,TRUE
+115515,69.65600199,34.5976205,1,Sher Khan Kach Mosque,Kabul,2,Surubi,1,Sher Khan Kech,1,Building,15,2,0,TRUE
+115516,69.652999678,34.485516212,1,Turkanai School,Kabul,2,Surubi,1,Turkani,1,Building,15,2,0,TRUE
+115517,69.59578261,34.57776629,1,Guga Manda School,Kabul,2,Surubi,1,Guga Manda,1,Building,15,2,0,TRUE
+115518,69.83624382,34.66239124,1,Sperkundi School,Kabul,2,Surubi,1,Sper Kundi,1,Building,15,2,0,TRUE
+115550,69.844140517,34.731187849,2,Rod Bar School,Kabul,3,Surbi,1,Rod Bar,1,Building,15,3,0,TRUE
+115551,69.619369598,34.357571765,2,Tahzin Am Jarobe High School,Kabul,3,Surbi,1,Jarobi,1,Building,15,3,0,TRUE
+115552,69.75989099,34.637660835,2,Waka Khas School,Kabul,3,Surbi,1,Waka Khas,1,Building,15,3,0,TRUE
+201001,69.37345481,35.0065484,5,Boys School,Kapisa,7,Mahmudi Raqi,2,Heroki,2,Building,1,7,0,TRUE
+201002,69.32120978,35.0249455,4,Hazrat Musuab High School,Kapisa,6,Mahmudi Raqi,2,Dawod Khel,2,Building,1,6,0,TRUE
+201003,69.36258447,35.0487917,4,Reg Rawan Girls School,Kapisa,5,Mahmudi Raqi,1,Regerawan,2,Building,1,5,0,TRUE
+201004,69.43067519,34.94620006,3,Allah Mohammad Shukhi High School,Kapisa,5,Mahmudi Raqi,2,Shukhi,2,Building,1,5,0,TRUE
+201005,69.34541031,35.02914148,4,Qala-E-Safid Mosque,Kapisa,5,Mahmudi Raqi,1,Qala-E-Safid,2,Building,1,5,0,TRUE
+201006,69.38553445,35.0702291,4,Khal Mohammad High School,Kapisa,5,Mahmudi Raqi,1,Now Abad,2,Building,1,5,0,TRUE
+201007,69.37047394,35.03855431,4,Girls High School,Kapisa,6,Mahmudi Raqi,2,Karataz,2,Building,1,6,0,TRUE
+201008,69.29947765,35.01664767,3,Mawlawi Ghulam Eshan House,Kapisa,5,Mahmudi Raqi,2,Deh Babi,2,Building,1,5,0,TRUE
+201009,69.33934859,35.04799706,4,Mahmood Raqi Boys High School,Kapisa,6,Mahmudi Raqi,2,Bazar De Baba Ali,2,Building,1,7,0,TRUE
+201010,69.33120096,35.04519495,3,Mahmood Raqi Girls High School,Kapisa,5,Mahmudi Raqi,2,Rahman Khel,2,Building,1,5,0,TRUE
+201011,69.35390894,35.02080631,3,Ali Khail Girls School,Kapisa,4,Mahmudi Raqi,1,Ali Khel,2,Building,1,4,0,TRUE
+201012,69.38150758,35.01573513,2,Zaraut Mosque,Kapisa,4,Mahmudi Raqi,2,Zaraut,2,Building,1,4,0,TRUE
+201013,69.34715295,35.02265834,2,Abdul Malik Mosque,Kapisa,3,Mahmudi Raqi,1,Kakari,2,Building,1,3,0,TRUE
+201014,69.43060205,34.94605873,2,Allah Mohammad Shukhi High School (Kuchi),Kapisa,4,Mahmudi Raqi,2,Shukhi,2,Building,1,4,0,TRUE
+201015,69.42087244,35.0510089,2,Haji Ajab Gul House,Kapisa,4,Mahmudi Raqi,2,Naw Abad,2,Building,1,4,0,TRUE
+201016,69.367602986,35.035103734,1,Haji Sana Gul House,Kapisa,3,Mahmudi Raqi,2,Karataz,2,Village,1,3,0,TRUE
+201017,69.38140706,35.01552883,1,Raees Dada House,Kapisa,3,Mahmudi Raqi,2,Zaraut,2,Building,1,3,0,TRUE
+201018,69.348210279,35.036984936,1,Azizurahman House,Kapisa,3,Mahmudi Raqi,2,Qorotak,2,Building,1,3,0,TRUE
+202019,69.30514688,35.06957087,4,Faiz Mohammad Shaheed Primary School,Kapisa,5,Hissa-E-Duwumi Kohistan,1,Jamal Agha,2,Building,2,5,0,TRUE
+202020,69.28726114,35.0395381,3,Jalaluddin Shaheed Primary School,Kapisa,4,Hissa-E-Duwumi Kohistan,1,Kalota,2,Building,2,4,0,TRUE
+202021,69.2938754,35.05696403,2,Zabit Sattar House,Kapisa,4,Hissa-E-Duwumi Kohistan,2,Jamal Agha Payen,2,Building,2,4,0,TRUE
+202022,69.34020765,35.07909983,2,Enayatullah Shaheed Primary School,Kapisa,3,Hissa-E-Duwumi Kohistan,1,Qazaq,2,Building,2,3,0,TRUE
+202023,69.35782903,35.08899811,3,Mohammad Tahir Shaheed School,Kapisa,4,Hissa-E-Duwumi Kohistan,1,Qala-E-Now,2,Building,2,4,0,TRUE
+202024,69.33859314,35.06981595,3,Kham Roba Mosque,Kapisa,4,Hissa-E-Duwumi Kohistan,1,Kham Roba,2,Village,2,4,0,TRUE
+202025,69.31289609,35.05502975,2,Dukan Haye Bazar Murad Khwaja,Kapisa,3,Hissa-E-Duwumi Kohistan,1,Bazar Murad Khwaja,2,Building,2,3,0,TRUE
+203067,69.4366597,35.09754828,3,Bolaghen Girls High School,Kapisa,4,Koh Band,1,Arab Khel,2,Building,3,4,0,TRUE
+203068,69.41014102,35.11632865,1,Mohammad Omarkhel Mosque,Kapisa,2,Koh Band,1,Aram Kot,2,Building,3,2,0,TRUE
+203069,69.48966689,35.06212134,2,Habib Khel Mosque,Kapisa,3,Koh Band,1,Darnama,2,Building,3,0,3,FALSE
+203070,69.45005701,35.10788908,1,Kotali Secondary School,Kapisa,2,Koh Band,1,Kutali,2,Building,3,2,0,TRUE
+203071,69.47339845,35.08776526,3,Lalbik Khel Mosque,Kapisa,4,Koh Band,1,Malker,2,Building,3,4,0,TRUE
+203072,69.49825669,35.06741217,3,Hazaro Khel Mosque,Kapisa,4,Koh Band,1,Darnama,2,Building,3,0,4,FALSE
+203073,69.366068122,35.100262006,3,Pul-E-Mirwis Mosque,Kapisa,5,Koh Band,2,Sar Joy Nahr-E-Khwaja,2,Building,3,5,0,TRUE
+203074,69.45125694,35.11851576,2,Abdul Baqi Shaheed High School,Kapisa,3,Koh Band,1,Shawrq Bolghen,2,Building,3,3,0,TRUE
+203075,69.459271809,35.053094796,2,Sar Joy-E-Nahre Khwaja Mosque,Kapisa,3,Koh Band,1,Naw Abad,2,Building,3,3,0,TRUE
+204026,69.30215961,35.14840169,4,Alberuni University,Kapisa,6,Hissa-E-Awali Kohistan,2,Shash Sad Kuti,2,Building,4,6,0,TRUE
+204027,69.29911904,35.09926287,3,Mer Masjidi Khan High School,Kapisa,5,Hissa-E-Awali Kohistan,2,Ashtar Geram,2,Building,4,6,0,TRUE
+204028,69.33619663,35.10208251,3,Mohammad Omar Shaheed High School,Kapisa,5,Hissa-E-Awali Kohistan,2,Qur Sayedi,2,Building,4,5,0,TRUE
+204029,69.30141235,35.13000096,4,Nasaji Gulbahar Girls High School,Kapisa,6,Hissa-E-Awali Kohistan,2,Penjah Kuti,2,Building,4,6,0,TRUE
+204030,69.30946768,35.10346213,2,Ashtargeram Girls High School,Kapisa,4,Hissa-E-Awali Kohistan,2,Ashtar Geram,2,Building,4,4,0,TRUE
+204031,69.31329806,35.10111235,3,Jaldak Secondary School,Kapisa,5,Hissa-E-Awali Kohistan,2,Jaldak Village,2,Building,4,5,0,TRUE
+204032,69.29664393,35.08073544,3,Ezed Yar Shaheed High School,Kapisa,5,Hissa-E-Awali Kohistan,2,Tughak,2,Building,4,5,0,TRUE
+204033,69.29739847,35.13943457,3,Sheer Khan Khel Haqania Madrasa,Kapisa,4,Hissa-E-Awali Kohistan,1,Sheer Khan Khel,2,Building,4,4,0,TRUE
+204034,69.29293364,35.14744245,3,Namaz Jay Girls High School,Kapisa,5,Hissa-E-Awali Kohistan,2,Namaz Jay,2,Building,4,5,0,TRUE
+204035,69.3467326,35.11146436,2,Haqbin Shaheed Secondry School,Kapisa,3,Hissa-E-Awali Kohistan,1,Baghcha Lalo,2,Building,4,3,0,TRUE
+204036,69.36406602,35.14257667,2,Sanjan Primary School,Kapisa,3,Hissa-E-Awali Kohistan,1,Sanjan,2,Building,4,3,0,TRUE
+204037,69.32830197,35.0904472,2,Molla Khalil Mosque,Kapisa,3,Hissa-E-Awali Kohistan,1,Molla Khalil,2,Building,4,3,0,TRUE
+204038,69.30459088,35.12314019,2,Saloon Khwaja Mirkhel,Kapisa,3,Hissa-E-Awali Kohistan,1,Khwaja Mir Khel,2,Building,4,3,0,TRUE
+205039,69.59841878,34.95213325,1,Qazi Abdul Jamil  School,Kapisa,4,Nijrab,3,Afghania,2,Building,5,4,0,TRUE
+205041,69.68367932,34.99662751,1,Mohammad Ayoub Secondary School,Kapisa,2,Nijrab,1,Husain Khel,2,Village,5,2,0,TRUE
+205042,69.61120458,35.04962804,1,Ruzakhel  Secondary School,Kapisa,2,Nijrab,1,Ruza Khel,2,Building,5,2,0,TRUE
+205043,69.51813185,35.02755755,2,Geyawa School,Kapisa,4,Nijrab,2,Geyawa,2,Building,5,4,0,TRUE
+205044,69.6068898,35.07408495,2,Ibrahim Khel School,Kapisa,3,Nijrab,1,Dara-E-Kalan,2,Building,5,3,0,TRUE
+205045,69.59121167,35.06315071,1,Dara-E-Farakhsha Girls Secondary School,Kapisa,2,Nijrab,1,Haidar Khel,2,Building,5,2,0,TRUE
+205046,69.55872818,35.09026509,1,Mirza Abdul Rahman Shaheed School,Kapisa,2,Nijrab,1,Bibi Khel,2,Building,5,2,0,TRUE
+205047,69.60919913,35.0306173,1,Badakhshi Girls School,Kapisa,2,Nijrab,1,Badakhshi,2,Building,5,2,0,TRUE
+205048,69.62730128,35.04574752,2,Ghulam Jelani Shaheed School,Kapisa,3,Nijrab,1,Chinar-E-Qazi,2,Building,5,3,0,TRUE
+205049,69.64631668,35.07564126,1,Ziaulhaq Shaheed High School,Kapisa,2,Nijrab,1,Deh Khuri Dar-E-Ghous,2,Building,5,2,0,TRUE
+205050,69.61897003,35.1180095,1,Open Space,Kapisa,2,Nijrab,1,Ghachulan,2,Building,5,2,0,TRUE
+205051,69.6436933,35.03827152,2,Bagh Aman Dara-E-Pata,Kapisa,3,Nijrab,1,Baghi Aman Dara-E-Pata,2,Building,5,3,0,TRUE
+205052,69.67228703,35.05087591,1,Madrasa Khrustan Dara-E-Pata,Kapisa,2,Nijrab,1,Khrustan Dara-E-Pata,2,Building,5,2,0,TRUE
+205053,69.60459899,34.99778484,2,Yasenzaye School,Kapisa,3,Nijrab,1,Yasen Zaye,2,Village,5,4,0,TRUE
+205054,69.59627643,35.01515059,2,District Mosque,Kapisa,3,Nijrab,1,"Sheerwani, District Compound",2,Building,5,3,0,TRUE
+205055,69.7157024,35.02287267,1,Do Qowmi,Kapisa,2,Nijrab,1,Puchghan,2,Village,5,2,0,TRUE
+205056,69.69200911,35.06141193,2,Abdul Ghafar Shaheed High School,Kapisa,3,Nijrab,1,Eskini Dara-E-Pata,2,Building,5,3,0,TRUE
+205057,69.66443641,35.05038965,1,Tajikan Boys High School,Kapisa,2,Nijrab,1,Tajikan Dara-E-Pata,2,Building,5,2,0,TRUE
+205058,69.7245412,35.02936484,1,Zekria,Kapisa,3,Nijrab,2,Puchghan,2,Village,5,3,0,TRUE
+205059,69.65785207,35.10419222,1,Saranwal Habib Rahman Shaheed School,Kapisa,2,Nijrab,1,Loqman Dara-E-Ghous,2,Building,5,2,0,TRUE
+205060,69.57895968,34.9675417,1,Zarshoy Girls School,Kapisa,2,Nijrab,1,Zarshoy,2,Building,5,2,0,TRUE
+205061,69.60049916,35.01154821,1,Open Space,Kapisa,2,Nijrab,1,Sheerwani,2,Building,5,2,0,TRUE
+205062,69.61286596,35.03846834,1,Malik Rozakhel House,Kapisa,2,Nijrab,1,Rozakhel,2,Building,5,2,0,TRUE
+205064,69.68356018,34.9966139,1,Mohammad Ayoub Secondary School (Kuchi),Kapisa,2,Nijrab,1,Husain Khel,2,Village,5,2,0,TRUE
+205065,69.57887605,34.96741907,1,Zarshoy Girls School( Kuchi),Kapisa,2,Nijrab,1,Zarshoy,2,Building,5,2,0,TRUE
+205066,69.59877979,34.97864184,1,Sayed Akbar House,Kapisa,2,Nijrab,1,Sabat,2,Building,5,2,0,TRUE
+206076,69.6436784,34.87143264,2,Muqam Khel Mosque,Kapisa,4,Tagab,2,Joy Bar,2,Building,6,4,0,TRUE
+206078,69.64536943,34.85358832,4,Ghazi Usman High School,Kapisa,4,Tagab,0,District Compound,2,Building,6,4,0,TRUE
+206080,69.6722155,34.87987783,2,Tater Khel Mosque,Kapisa,3,Tagab,1,Tater Khel,2,Village,6,0,3,FALSE
+206081,69.63858987,34.89706171,2,Masjid Kalan,Kapisa,3,Tagab,1,Qala-E-Saleh,2,Village,6,3,0,TRUE
+206083,69.63621942,34.88716927,3,Jalo Khel Mosque,Kapisa,4,Tagab,1,Jalo Khel,2,Building,6,4,0,TRUE
+206084,69.68068459,34.72338998,4,Agha Shareen Secondary School,Kapisa,4,Tagab,0,Sheenki  Village,2,Building,6,4,0,TRUE
+206085,69.62173385,34.93317445,3,Shaheed Salam Secondary School,Kapisa,4,Tagab,1,Landa Khel,2,Building,6,4,0,TRUE
+206095,69.68533361,34.88705194,4,Shaheed Hafizullah Secondary School,Kapisa,4,Tagab,0,Shokut,2,Building,6,0,4,FALSE
+206097,69.67276733,34.87849135,2,Tetar Khel Mosque,Kapisa,3,Tagab,1,Tater Khel (Kuchian),2,Building,6,0,3,FALSE
+206098,69.62067108,34.91516613,2,Hada-E-Anwer Mosque,Kapisa,3,Tagab,1,Landa Khel,2,Village,6,3,0,TRUE
+207109,69.71911923,34.89259882,3,Hayatullah Shaheed High School (Kuchi),Kapisa,4,Alasay,1,Alasay Center,2,Village,7,0,4,FALSE
+301001,69.17554112,35.01635018,4,Noman High School,Parwan,6,Charikar,2,Charikar,3,Building,1,6,0,TRUE
+301002,69.17303043,35.02094994,3,Sadiqi High School,Parwan,5,Charikar,2,Charikar,3,Building,1,6,0,TRUE
+301003,69.16898219,35.01350184,4,Mohammad Usman Experimental High School,Parwan,6,Charikar,2,Charikar,3,Building,1,6,0,TRUE
+301004,69.16808,35.00572,3,Laila Sarahat Roshani High School,Parwan,4,Charikar,1,Charikar,3,Building,1,4,0,TRUE
+301005,69.24318173,35.01539086,3,Deh Qazi High School,Parwan,4,Charikar,1,Deh Qazi,3,Building,1,4,0,TRUE
+301006,69.19735298,34.98302689,4,Meyan Shakh High School,Parwan,5,Charikar,1,Mian Shakh,3,Building,1,5,0,TRUE
+301007,69.19486294,35.07926887,4,Tatmdara-E-Ulya High School,Parwan,5,Charikar,1,Tatumdara-E-Ulya,3,Building,1,5,0,TRUE
+301008,69.20716527,35.06423068,3,Omer Farooq High School,Parwan,4,Charikar,1,Tatumdara-E-Sufla,3,Building,1,4,0,TRUE
+301009,69.17499309,35.01811233,3,Sofi Qalandar Mosque,Parwan,4,Charikar,1,Charikar,3,Building,1,4,0,TRUE
+301010,69.17145861,35.00728027,4,Mir Ali Ahmad Shaheed High School,Parwan,5,Charikar,1,Charikar,3,Building,1,5,0,TRUE
+301011,69.17161604,35.01648726,3,Toghbardi Mosque,Parwan,4,Charikar,1,Toghbardi,3,Village,1,4,0,TRUE
+301012,69.16602488,35.03773149,4,Hofian Sharif Secondary School,Parwan,6,Charikar,2,Hofian-E-Sharif,3,Building,1,6,0,TRUE
+301013,69.16348664,34.99026242,2,Khwaja Sayaran Payan School,Parwan,3,Charikar,1,Khwaja Sayaran Payan,3,Building,1,3,0,TRUE
+301014,69.21134394,34.99392132,2,Qalach-E-Sokhta Secondary School,Parwan,3,Charikar,1,Qalacha-E-Sokhta,3,Building,1,3,0,TRUE
+301015,69.23486823,35.01939688,2,Abdi By Mosque,Parwan,3,Charikar,1,Abdi By,3,Building,1,3,0,TRUE
+301016,69.2231831,35.05567613,2,Dado High School,Parwan,3,Charikar,1,Saudullah,3,Building,1,3,0,TRUE
+301017,69.14613013,35.00922812,1,Khwaja Sayaran Ulya School,Parwan,2,Charikar,1,Khwaja Sayaran Ulya,3,Building,1,2,0,TRUE
+301018,69.162266525,34.998212179,2,Jami Peshan Mosque,Parwan,3,Charikar,1,Peshan,3,Building,1,3,0,TRUE
+301019,69.21062221,35.0170575,2,Dolana Mosque,Parwan,3,Charikar,1,Dolana,3,Building,1,3,0,TRUE
+301020,69.22274772,35.04110625,2,Telanchi Girls School,Parwan,3,Charikar,1,Telanchi,3,Building,1,3,0,TRUE
+301021,69.122010073,34.947033625,3,Sunjid Dara Mosque,Parwan,4,Charikar,1,Sunjid Dara,3,Building,1,4,0,TRUE
+301022,69.17333492,35.02312348,2,Sadiqi Padshah Mosque,Parwan,3,Charikar,1,Guzar-E-Dehqanan,3,Building,1,3,0,TRUE
+301023,69.142204185,34.913674788,2,Khala Zaye Mosque,Parwan,3,Charikar,1,Khalazaye,3,Village,1,3,0,TRUE
+301024,69.15657566,34.96845195,2,Laghmani High School,Parwan,3,Charikar,1,Laghmani,3,Building,1,3,0,TRUE
+301025,69.20920423,35.03813581,2,Bayan Bala Secondary School,Parwan,3,Charikar,1,Bayan Bala,3,Building,1,3,0,TRUE
+301026,69.209781245,35.039918019,3,Bala Ghail Mosque,Parwan,4,Charikar,1,Bala Ghail,3,Building,1,4,0,TRUE
+301027,69.12533518,34.98421251,2,Toop Dara School,Parwan,3,Charikar,1,Toop Dara,3,Building,1,3,0,TRUE
+301028,69.219927217,34.992704469,1,Qala-E-Sahil Mosque,Parwan,2,Charikar,1,Qala-E-Sahil,3,Building,1,2,0,TRUE
+301029,69.20299542,35.03203636,1,Deh Molla Yousuf Mosque,Parwan,2,Charikar,1,Deh Mula Yousuf,3,Building,1,2,0,TRUE
+301030,69.16703539,35.00176719,3,Muncipality Building,Parwan,4,Charikar,1,"Parch 6, Charikar City",3,Building,1,4,0,TRUE
+301031,69.16960427,35.01545301,2,Hura Jalali High School,Parwan,3,Charikar,1,"Parcha 7, Charikar City",3,Building,1,3,0,TRUE
+301032,69.26515206,35.00918424,2,Sayadan School,Parwan,3,Charikar,1,Sayadan,3,Building,1,3,0,TRUE
+301033,69.20925729,35.03816424,1,Bayan Payan Mosque,Parwan,2,Charikar,1,Bayan Payan,3,Building,1,2,0,TRUE
+301034,69.1781212,35.03986571,3,Barak School,Parwan,4,Charikar,1,"Parcha 13, Charikar City",3,Building,1,5,0,TRUE
+301035,69.157632,35.006795,2,Mir Abdul Karim Maqool High School,Parwan,3,Charikar,1,"Parcha 12, Charikar City",3,Building,1,3,0,TRUE
+301036,69.09197061,34.95031483,2,Masoud Buzurg High School,Parwan,3,Charikar,1,Sunjid Dara,3,Building,1,3,0,TRUE
+302100,69.22707414,34.96173534,4,Shafaq Shaheed High School,Parwan,5,Bagram,1,District Compound,3,Building,2,5,0,TRUE
+302101,69.17677222,34.91432483,3,Abu Zar Ghafari High School,Parwan,5,Bagram,2,Rabat,3,Building,2,5,0,TRUE
+302102,69.30585115,34.98899114,3,Nasiri High School,Parwan,5,Bagram,2,Sayaad,3,Building,2,5,0,TRUE
+302103,69.22225259,34.97603438,2,Mula Mohammad Shaheed School And Tonchi Mosque,Parwan,4,Bagram,2,Tonchi,3,Building,2,4,0,TRUE
+302104,69.25361138,34.98960148,2,Talot Shaheed School,Parwan,3,Bagram,1,Qalandar Khel,3,Building,2,3,0,TRUE
+302105,69.39529883,34.96409797,2,Khwaja Khesraw Wali High School,Parwan,4,Bagram,2,Awogamti,3,Building,2,4,0,TRUE
+302106,69.161314,34.94726403,3,Qazi Abdul Jamil Khel Secondary School,Parwan,4,Bagram,1,Chaikal,3,Building,2,4,0,TRUE
+302107,69.20060466,34.93956726,2,Qala-E- Dasht Rabat Girls School,Parwan,3,Bagram,1,Dasht-E-Rabat,3,Building,2,3,0,TRUE
+302108,69.20066534,34.93960652,2,Aziz Rahman Shah School,Parwan,4,Bagram,2,Qala-E-Khwaja,3,Building,2,4,0,TRUE
+302109,69.28750458,34.98720972,2,Qala-E-Biland High School,Parwan,4,Bagram,2,Qala-E-Biland,3,Building,2,4,0,TRUE
+302110,69.23327169,34.93473547,2,Dahan-E-Maidan Mosque,Parwan,4,Bagram,2,Dahan-E-Maidan,3,Building,2,6,0,TRUE
+302111,69.19891676,34.96375494,2,Abdul Sattar Shaheed High School,Parwan,4,Bagram,2,Dowlat Shahi,3,Building,2,4,0,TRUE
+302112,69.24527139,34.94095117,3,Maidan Boys High School,Parwan,5,Bagram,2,Famili Hai Maidan Hawaye,3,Building,2,5,0,TRUE
+302113,69.22580595,34.95293403,2,Ghulam Ali Deh Payan Mosque,Parwan,4,Bagram,2,Ghulam Ali,3,Building,2,4,0,TRUE
+302114,69.1679191,34.95982943,2,Deh Meskeen Mosque,Parwan,4,Bagram,2,Deh Meskeen,3,Building,2,4,0,TRUE
+302115,69.20512951,34.90875253,2,Qala-E-Nasro School,Parwan,4,Bagram,2,Qala-E-Nasro,3,Building,2,4,0,TRUE
+302116,69.25362245,34.94569438,3,Janqadam School,Parwan,5,Bagram,2,Janqadam,3,Building,2,5,0,TRUE
+302117,69.26327845,34.96862339,3,Sher Aqa Shaheed School,Parwan,4,Bagram,1,Jafar Khel,3,Building,2,5,1,TRUE
+302118,69.22725592,34.9578701,3,Darul Olum Mehdi And Shahr-E-Now Mosque,Parwan,4,Bagram,1,Shahr-E-Naw Ghulam Ali,3,Building,2,4,0,TRUE
+302119,69.28416666,34.91241832,3,Barik Aab Mosque,Parwan,5,Bagram,2,Barik Aab,3,Building,2,5,0,TRUE
+302120,69.20992838,34.96968504,2,Qala-E-Malik High School,Parwan,3,Bagram,1,Qala-E-Malak,3,Building,2,3,0,TRUE
+302121,69.31318161,34.89883977,3,Shahrak-E-Muhajerin Barik Aab High School,Parwan,4,Bagram,1,Shahrak-E-Muhajerin Barik Aab,3,Building,2,4,0,TRUE
+302152,69.210118116,34.957631584,2,Deh Mullah Mosque,Parwan,3,Bagram,1,Deh Mulah,3,Building,2,3,0,TRUE
+302153,69.215931585,34.983508327,2,Yor Chi Mosque,Parwan,3,Bagram,1,Yor Chi,3,Building,2,3,0,TRUE
+303072,69.00620566,35.03944171,2,Tafhimul Quran School,Parwan,3,Shinwari,1,Qashqal,3,Building,3,3,0,TRUE
+303073,68.94493679,35.01639248,3,Nomania High School,Parwan,4,Shinwari,1,Ashtar Shahar,3,Building,3,4,0,TRUE
+303074,68.98139113,35.00551855,1,Jan Fida Shaheed School,Parwan,2,Shinwari,1,Shewa,3,Building,3,2,0,TRUE
+303075,69.03781684,35.04348144,1,Sofi Khel Secondary School,Parwan,2,Shinwari,1,Sofi Khel,3,Building,3,2,0,TRUE
+303076,68.9060834,35.01020628,2,Daraz Gird Madrassa,Parwan,3,Shinwari,1,Daraz Gird,3,Building,3,3,0,TRUE
+303077,69.1046664,35.07410774,1,Abdul Sattar Shaheed High School,Parwan,2,Shinwari,1,Bagh-E-Afghan,3,Building,3,2,0,TRUE
+304037,69.2652321,35.05150528,3,"Imam-E-Azaam Uqtash High School,",Parwan,4,Sayid Khial,1,Uqtash,3,Building,4,4,0,TRUE
+304038,69.25827879,35.05575926,1,Qazi Khel Girls High School,Parwan,2,Sayid Khial,1,Ibrahim Khel,3,Building,4,2,0,TRUE
+304039,69.25291624,35.08351695,2,Darul Hifaaz Said Khel,Parwan,3,Sayid Khial,1,Saded Khel Bazar,3,Building,4,3,0,TRUE
+304040,69.28219778,35.09958278,2,Chinki Ulya Girls High School,Parwan,3,Sayid Khial,1,Malik Khel,3,Building,4,3,0,TRUE
+304041,69.24523702,35.06500379,1,Sayed Rahman Shaheed School,Parwan,2,Sayid Khial,1,Kumangar,3,Building,4,2,0,TRUE
+304042,69.26670235,35.08157742,1,Abdul Qadir Shaheed Secondary School,Parwan,2,Sayid Khial,1,Kaka Khel,3,Building,4,2,0,TRUE
+304043,69.28051808,35.01882866,2,Ancho Madrassa,Parwan,3,Sayid Khial,1,Bala Deh Ancho,3,Building,4,3,0,TRUE
+304044,69.25814963,35.06910387,2,Haibat Khel Girls High School,Parwan,3,Sayid Khial,1,Haibat Khel,3,Building,4,3,0,TRUE
+304045,69.25145,35.05713611,1,Khan Jan Khel Mosque,Parwan,2,Sayid Khial,1,Mula Sayed Khel,3,Building,4,2,0,TRUE
+304046,69.27251108,35.07628986,1,Chinki Payan Mosque And Elhaqia,Parwan,2,Sayid Khial,1,Chinki Payan,3,Building,4,2,0,TRUE
+304047,69.29410555,35.00589722,3,Ancho Mosque,Parwan,5,Sayid Khial,2,Qala-E-Pastak,3,Building,4,5,0,TRUE
+304048,69.27440977,35.03588373,1,3 Dukana Ancho Mosque,Parwan,2,Sayid Khial,1,3 Dukana-E-Ancho,3,Building,4,2,0,TRUE
+304049,69.25843549,35.09988087,1,Saifurahman Shaheed High School,Parwan,2,Sayid Khial,1,Burj-E-Mustofi,3,Building,4,2,0,TRUE
+305050,69.23461944,35.12184166,5,Jabal Seraj Boys High School,Parwan,5,Jabulussaraj,0,Jabul Saraj Center,3,Building,5,5,0,TRUE
+305051,69.23573905,35.11896981,0,Jabal Seraj Girls High School,Parwan,4,Jabulussaraj,4,Munara,3,Building,5,4,0,TRUE
+305052,69.21169231,35.09392376,4,Zarbia High School,Parwan,6,Jabulussaraj,2,Bala Tapa-E-Zarbia Village,3,Building,5,6,0,TRUE
+305053,69.2436663,35.12758212,3,Cement Factory,Parwan,4,Jabulussaraj,1,Eshq Abad,3,Building,5,4,0,TRUE
+305054,69.23467348,35.12174064,3,Khalid Ibne Wlid School,Parwan,4,Jabulussaraj,1,Deh Mir Khan Village,3,Building,5,4,0,TRUE
+305055,69.28823306,35.14899192,3,Penjah Khana Mosque,Parwan,4,Jabulussaraj,1,Gul Bahar Bazar,3,Building,5,6,0,TRUE
+305056,69.26195439,35.11507855,3,Malik Jan Khel Mosque,Parwan,4,Jabulussaraj,1,Malik Jan Khel,3,Building,5,4,0,TRUE
+305057,69.27843799,35.12619001,3,Du Bandi Mosque,Parwan,4,Jabulussaraj,1,Dubandi,3,Building,5,4,0,TRUE
+305058,69.11027099,35.1152164,2,Aushaba Mosque,Parwan,3,Jabulussaraj,1,Ashaba Center,3,Building,5,3,0,TRUE
+305059,69.280551225,35.108861412,2,Esa Khel Mosque,Parwan,4,Jabulussaraj,2,Esa Khel,3,Building,5,4,0,TRUE
+305060,69.22837568,35.11293198,3,"Khalil Zaman Secondary School, Tape Sorkh",Parwan,4,Jabulussaraj,1,Meyana Guzar,3,Building,5,4,0,TRUE
+305061,69.27574444,35.14252649,3,Gul Bahar No.1 Girls High School,Parwan,4,Jabulussaraj,1,Gul Mirza Khel,3,Building,5,4,0,TRUE
+305062,69.09394589,35.1211724,3,Aahangaran Chap Qol Mosque,Parwan,4,Jabulussaraj,1,Ahangaran,3,Building,5,4,0,TRUE
+305154,69.285446149,35.142909838,2,Abdul Hadi Shaheed Secondary School,Parwan,3,Jabulussaraj,1,Ezatullah Khil_ Gul Bahar,3,Building,5,3,0,TRUE
+305155,69.110851179,35.120437772,2,Abo Hanifa High School,Parwan,3,Jabulussaraj,1,Ashawa,3,Building,5,3,0,TRUE
+306063,69.21415225,35.22357854,3,Salang Boys High School,Parwan,4,Salang,1,Bagh-E-Maidan,3,Building,6,4,0,TRUE
+306064,69.222316154,35.175362331,2,Takhma Mosque,Parwan,3,Salang,1,Takhma,3,Building,6,3,0,TRUE
+306065,69.09846804,35.28440863,1,Awlang School,Parwan,2,Salang,1,Jawar-E-Qamar,3,Building,6,2,0,TRUE
+306066,69.150870047,35.239219656,2,Aahangaran Mosque,Parwan,3,Salang,1,Ahangaran Salang,3,Building,6,3,0,TRUE
+306067,69.199599288,35.162105904,1,Tatumzar Mosque,Parwan,2,Salang,1,Tutumzar Village,3,Building,6,2,0,TRUE
+306068,69.150816153,35.092665943,1,Roye Aab Madrassa,Parwan,2,Salang,1,Roy Aab,3,Building,6,2,0,TRUE
+306069,69.201069779,35.261923391,1,Awnamak Mosque,Parwan,2,Salang,1,Awnamak-E-Salang,3,Village,6,2,0,TRUE
+306070,69.174876791,35.303558277,1,Viva Mosque,Parwan,2,Salang,1,Veva,3,Building,6,2,0,TRUE
+306071,69.17679557,35.1115135,1,Lalmi Sabzak Secondary School,Parwan,2,Salang,1,Lalmi Sabzak,3,Building,6,2,0,TRUE
+307082,68.85729275,34.99769397,3,Hazrat Ali High School,Parwan,4,Syahgirdi Ghorband,1,Seya Gird Bazar,3,Building,7,4,0,TRUE
+307085,68.75633654,34.99853505,2,Chahar Deh High School,Parwan,3,Syahgirdi Ghorband,1,Chahar Deh,3,Building,7,3,0,TRUE
+307086,68.87802982,34.97928561,2,Fundaqistan School,Parwan,3,Syahgirdi Ghorband,1,Fundaqistan,3,Building,7,3,0,TRUE
+307087,68.7064956,34.98420516,2,Faranjil High School,Parwan,3,Syahgirdi Ghorband,1,Faranjil,3,Building,7,3,0,TRUE
+307090,68.86111751,35.00530741,2,Du Aab Mosque,Parwan,3,Syahgirdi Ghorband,1,Sar-E-Pul Du Aab,3,District,7,3,0,TRUE
+307092,68.84751111,35.00060277,1,Hazrat Ali Secondary School,Parwan,2,Syahgirdi Ghorband,1,Seya Gird Village,3,Building,7,2,0,TRUE
+308143,69.3929361,34.85720486,2,Mula Ahmad Khel School,Parwan,3,Kohi Safi,1,Mula Ahmad Khel,3,Building,8,3,0,TRUE
+308144,69.46397381,34.79483419,1,Dandar School,Parwan,2,Kohi Safi,1,Dandar,3,Building,8,2,0,TRUE
+308145,69.47462395,34.79111889,2,Seya Sang Mosque,Parwan,3,Kohi Safi,1,Seya Sang,3,Building,8,3,0,TRUE
+308146,69.44830358,34.77938428,1,Momin Khel School,Parwan,2,Kohi Safi,1,Momin Khail,3,Building,8,2,0,TRUE
+308147,69.43973527,34.89980403,1,Ahmadzai Mosque,Parwan,2,Kohi Safi,1,Ahmadzai,3,Village,8,2,0,TRUE
+308148,69.39375186,34.85673345,1,Mula Ahmad Khel Mosque,Parwan,2,Kohi Safi,1,Mula Ahmad Khel,3,Building,8,2,0,TRUE
+308149,69.45384888,34.8240131,2,Shamal Khel Mosque,Parwan,3,Kohi Safi,1,Shamal Khel,3,Building,8,3,0,TRUE
+308156,69.358955136,34.838144772,2,Hasan Zai Mosque,Parwan,3,Kohi Safi,1,Hasan Zai,3,Village,8,3,0,TRUE
+309132,68.64786727,34.92405001,2,Female High School_Bazar Lolegn,Parwan,3,Surkhi Parsa,1,Bazar Lolenj,3,Building,9,3,0,TRUE
+309133,68.65777241,34.82091899,1,Abdul Rawoof Hojat Darul Olum,Parwan,2,Surkhi Parsa,1,Baqi Peer Sultan Village,3,Building,9,2,0,TRUE
+309134,68.56455948,34.78443167,1,Shaheed Zulfaqar High School,Parwan,2,Surkhi Parsa,1,Ali Khani,3,Building,9,2,0,TRUE
+309135,68.48534531,34.7551041,1,Khedri High School,Parwan,2,Surkhi Parsa,1,Dahan-E-Parandaz,3,Building,9,2,0,TRUE
+309136,68.729627141,34.877725919,1,Abdul Parsa Mosque,Parwan,2,Surkhi Parsa,1,Abdal Village,3,Building,9,2,0,TRUE
+309137,68.66355525,34.77029208,1,Sheena Mosque,Parwan,2,Surkhi Parsa,1,Sheena Village,3,Building,9,2,0,TRUE
+309138,68.6375709,34.83659194,1,Shaheed Ali Dost High School,Parwan,2,Surkhi Parsa,1,Dahan-E-Naik,3,Building,9,2,0,TRUE
+309139,68.382040779,34.713641456,1,Membar-E-Dahane Khakrez,Parwan,2,Surkhi Parsa,1,Dahan-E-Khakriz,3,Building,9,2,0,TRUE
+309140,68.7410035,34.72732392,1,Qatandar School,Parwan,2,Surkhi Parsa,1,Dahan-E-Barik,3,Building,9,2,0,TRUE
+309141,68.802118159,34.791651684,1,Wand Mosque,Parwan,2,Surkhi Parsa,1,Deyar Wand,3,Building,9,2,0,TRUE
+309142,68.646067116,34.916356754,1,Ziarat-E-Shah Daleer Lolenj,Parwan,2,Surkhi Parsa,1,Lolenj,3,Building,9,2,0,TRUE
+310122,68.32900125,34.92093394,2,Imam-E-Mahdi Boys High School,Parwan,3,Shaykh Ali,1,Chocha Sheer,3,Building,10,3,0,TRUE
+310123,68.45583912,34.92934213,1,Dahan-E-Jarf High School,Parwan,2,Shaykh Ali,1,Dahan-E-Jarf,3,Building,10,2,0,TRUE
+310124,68.58143171,34.96511678,1,Abu Bakr-E-Sediq High School,Parwan,2,Shaykh Ali,1,Tapa Ziarat-E-Qarlaq Baba,3,Building,10,2,0,TRUE
+310125,68.47927375,34.91525925,1,Hazrat Ali Secondary School,Parwan,2,Shaykh Ali,1,Badal Dara Nerkh,3,Building,10,2,0,TRUE
+310126,68.51232536,34.94624658,1,Navi High School,Parwan,2,Shaykh Ali,1,Nevy,3,Building,10,2,0,TRUE
+310127,68.58285345,34.89860843,1,Membar-E-Pawaz,Parwan,2,Shaykh Ali,1,Pawaz Bala,3,Building,10,2,0,TRUE
+310128,68.3591892,34.92257249,1,Dahan-E-Botyan Tent,Parwan,2,Shaykh Ali,1,Dahan-E-Botyan Village,3,Village,10,2,0,TRUE
+310129,68.60811769,34.99029931,1,Babor Secondary School,Parwan,2,Shaykh Ali,1,Babor Payan,3,Village,10,2,0,TRUE
+310130,68.27701267,34.90840642,1,Pay-E-Kotal Tent,Parwan,2,Shaykh Ali,1,Zeer Shebar Village,3,Village,10,2,0,TRUE
+310131,68.541312151,34.94656316,1,District Building,Parwan,2,Shaykh Ali,1,District Bazar Dasht-E-Guzar,3,Building,10,2,0,TRUE
+401001,68.86581843,34.39469009,5,Municipality Building,Wardak,7,Maydan Shahr,2,Maidan Shahr Municipality Building,4,Building,1,10,0,TRUE
+401002,68.85723045,34.32924822,1,Pul-E-Surkh School,Wardak,4,Maydan Shahr,3,Shahabuddin Village,4,Building,1,4,1,TRUE
+401003,68.83821321,34.38341837,3,Deh Afghanan School,Wardak,4,Maydan Shahr,1,Deh Afghanan,4,Building,1,5,0,TRUE
+401004,68.82490058,34.42715568,3,Charka School,Wardak,4,Maydan Shahr,1,Gardani Village,4,District,1,4,0,TRUE
+401005,68.7776667,34.45345771,3,Rahman Khel Mosque,Wardak,4,Maydan Shahr,1,Rahman Khel,4,Village,1,4,0,TRUE
+401006,68.82277363,34.34863785,4,Ibrahim Khel High School,Wardak,4,Maydan Shahr,0,Ibrahim Khel,4,Building,1,4,0,TRUE
+401007,68.81902003,34.35643363,3,Ibrahim Khel Clinic,Wardak,4,Maydan Shahr,1,Ibrahim Khel,4,Village,1,1,3,TRUE
+401008,68.812659,34.412518,3,Kute Ashru Girls School,Wardak,5,Maydan Shahr,2,Tur Khel Village,4,Village,1,5,0,TRUE
+401009,68.79819115,34.49256746,3,Kuhna Khumar School,Wardak,4,Maydan Shahr,1,Kuhna Khumar,4,Village,1,4,0,TRUE
+401010,68.83340376,34.37569153,1,Naiban School,Wardak,4,Maydan Shahr,3,Naieban,4,Village,1,5,0,TRUE
+401011,68.85304365,34.3860302,3,Family Houses,Wardak,6,Maydan Shahr,3,Family Kuchian Kalai,4,Village,1,6,0,TRUE
+401012,68.86038279,34.38488873,3,Qule Dost Khel Tent,Wardak,5,Maydan Shahr,2,Qul-E-Dost Khel,4,Village,1,3,2,TRUE
+401013,68.85495174,34.34089229,1,Koh-E-Ibrahim Khel Tent,Wardak,4,Maydan Shahr,3,Koh-E-Ibrahim Khel Village,4,Village,1,2,2,TRUE
+402143,68.77194444,34.36944444,2,Mohammad Wali House,Wardak,3,Nerkh,1,Deh Hayat,4,Village,2,3,0,TRUE
+402144,68.71953919,34.37380706,3,Hassan Khel Village Clinic,Wardak,4,Nerkh,1,Hasan Khel,4,Village,2,4,0,TRUE
+402145,68.65365641,34.40455188,1,Sahak School,Wardak,2,Nerkh,1,Sahak,4,Village,2,2,0,TRUE
+402146,68.70407164,34.3917342,1,Karmo Khel School,Wardak,2,Nerkh,1,Karmo Khel Yak,4,Village,2,2,0,TRUE
+402147,68.80007813,34.35638127,1,Kan-E-Ezat School,Wardak,2,Nerkh,1,Bashi Khel,4,Building,2,2,0,TRUE
+402148,68.68162351,34.35009875,1,Imamuddin House,Wardak,2,Nerkh,1,Femal Clinic Gaghundi,4,Village,2,2,0,TRUE
+402149,68.78753027,34.24329862,1,Malik Qarya House,Wardak,2,Nerkh,1,Bain Badim Village,4,Village,2,2,0,TRUE
+402150,68.714165,34.354993,1,School And Clinic,Wardak,2,Nerkh,1,Omer Khel Yak,4,Building,2,0,2,FALSE
+402151,68.68343877,34.34340933,2,Aslam Khel School,Wardak,3,Nerkh,1,Aslam Khel,4,Village,2,3,0,TRUE
+402152,68.65694098,34.36074872,2,Sare Marda School,Wardak,3,Nerkh,1,Sarmarda,4,Village,2,3,0,TRUE
+402153,68.67,34.3275,2,Ismaiel Khel School,Wardak,3,Nerkh,1,Ismaiel Khel,4,Village,2,3,0,TRUE
+402154,68.7256,34.3233,1,Akhchi Mosque,Wardak,2,Nerkh,1,Akhchi,4,Village,2,2,0,TRUE
+402155,68.69763835,34.30680725,2,Boys And Girls School,Wardak,3,Nerkh,1,Tukarak,4,Village,2,3,0,TRUE
+402156,68.87864626,34.321247,1,Shadi Kala Mosque,Wardak,2,Nerkh,1,Shadi Qala Village,4,Village,2,2,0,TRUE
+402157,68.90840757,34.34218988,2,Hajan Village Mosque,Wardak,3,Nerkh,1,Hajan Village,4,Village,2,2,1,TRUE
+402158,68.81658475,34.25741516,2,Mushk-E-Aalam School,Wardak,3,Nerkh,1,Andar,4,Village,2,3,0,TRUE
+402159,68.81210624,34.37078926,2,Surbaghal Tent,Wardak,3,Nerkh,1,Surbaghal,4,Village,2,3,0,TRUE
+402160,68.8602604,34.30502741,2,Awal Khel Tent,Wardak,3,Nerkh,1,Awal Khel,4,Village,2,3,0,TRUE
+403014,68.72915133,34.45911038,3,Zewalat High School,Wardak,4,Jalrez,1,Zewalat,4,Building,3,4,0,TRUE
+403015,68.71374674,34.46521112,2,Ismaiel Khel Secondary School,Wardak,3,Jalrez,1,Ismaiel Khel,4,Building,3,3,0,TRUE
+403016,68.64959792,34.52618185,2,Mir Ahmad Shah School,Wardak,3,Jalrez,1,Qala-E-Shah,4,Building,3,3,0,TRUE
+403017,68.67113347,34.46999304,2,Khwaja Mohammad Wali High School,Wardak,3,Jalrez,1,Bazar-E-Ziarat,4,Building,3,3,0,TRUE
+403018,68.58455683,34.45847419,2,Imam-E-Azam School,Wardak,3,Jalrez,1,Sia Pehtab,4,Building,3,3,0,TRUE
+403019,68.54637198,34.44171107,2,Ghulam Dastager-E-Shaheed Secondary School,Wardak,3,Jalrez,1,Qawmi Jamil Village,4,Building,3,3,0,TRUE
+403020,68.51714436,34.43425473,2,Imam-E-Mohammad Baqir High School,Wardak,3,Jalrez,1,Qala-E-Aslam,4,Building,3,3,0,TRUE
+403021,68.48044176,34.42851112,2,Shaheed Yaqubi High School,Wardak,3,Jalrez,1,Sia Khak,4,Building,3,3,0,TRUE
+403022,68.57456538,34.54576062,2,Bibi Ayesha Sedeqa Secondary School,Wardak,3,Jalrez,1,Yadgar Village,4,District,3,3,0,TRUE
+403023,68.59678233,34.48532586,2,Dawalan Secondary School,Wardak,3,Jalrez,1,Ahmad Zai Village,4,Village,3,3,0,TRUE
+403024,68.817715,34.443698,2,Kohi Zaiolat Tent,Wardak,3,Jalrez,1,Ahmad Zai Village,4,Village,3,3,0,TRUE
+404083,68.66176371,34.13266218,2,Saleh Mohammad House,Wardak,4,Chaki Wardak,2,Noor Khel,4,Village,4,4,0,TRUE
+404084,68.68389434,34.15868679,2,Langar Madrassa,Wardak,4,Chaki Wardak,2,Langar,4,Building,4,4,0,TRUE
+404085,68.61357686,34.10261527,1,Sar-E-Koh School,Wardak,2,Chaki Wardak,1,Lando,4,Village,4,2,0,TRUE
+404086,68.50148492,34.0082358,2,Local School,Wardak,3,Chaki Wardak,1,Bunan,4,Village,4,3,0,TRUE
+404087,68.52814954,34.05518678,2,Sebak Village Clinic,Wardak,4,Chaki Wardak,2,Sebak Village,4,Building,4,4,0,TRUE
+404088,68.73465518,34.15223622,2,Ambukhak School,Wardak,3,Chaki Wardak,1,Ambu Khak,4,Building,4,3,0,TRUE
+404089,68.76199947,34.21821209,2,Alasang School,Wardak,3,Chaki Wardak,1,Alasang,4,Village,4,3,0,TRUE
+404090,68.58744765,34.11941408,2,Shop In The Pune Village Bazar,Wardak,4,Chaki Wardak,2,Puna Village,4,Village,4,4,0,TRUE
+404091,68.55201893,34.08050503,2,Mangal House,Wardak,4,Chaki Wardak,2,Qala-E-Qurbani,4,Village,4,4,0,TRUE
+404092,68.45903929,34.06531432,3,Araban Primary School,Wardak,4,Chaki Wardak,1,Shahbaz Khan,4,Village,4,4,0,TRUE
+404093,68.53525356,34.13891602,2,Malik Qarya House,Wardak,3,Chaki Wardak,1,Mongiar Khel,4,District,4,3,0,TRUE
+404094,68.45228317,34.10225893,2,Shuker Dad Village Mosque,Wardak,3,Chaki Wardak,1,Shakardad Village,4,Village,4,3,0,TRUE
+404095,68.51626395,34.11132479,2,Saheb Char Qala Primary School,Wardak,3,Chaki Wardak,1,Char Qala,4,Village,4,3,0,TRUE
+404096,68.4178,34.1439,2,Noorul Mudarus Primary School,Wardak,3,Chaki Wardak,1,Miana Qul,4,Village,4,3,0,TRUE
+404097,68.6173608,34.13108255,2,Shop In Bumbai,Wardak,4,Chaki Wardak,2,Bumbi Village,4,Village,4,4,0,TRUE
+404098,68.41279316,34.03740778,1,Sherzad Primary School,Wardak,2,Chaki Wardak,1,Sharif Khel,4,Village,4,2,0,TRUE
+404099,68.49841843,34.21240199,1,Zarkak Village Mosque,Wardak,2,Chaki Wardak,1,Goda (Zakak) Village,4,Village,4,2,0,TRUE
+404100,68.3307944,33.9870194,3,Qazi Alam Gul House,Wardak,4,Chaki Wardak,1,Kerakat Village,4,Village,4,4,0,TRUE
+404101,68.50518647,34.12904893,2,Siab School,Wardak,3,Chaki Wardak,1,Berana,4,Village,4,3,0,TRUE
+404102,68.44965503,34.14002675,2,Omer-E-Farooq Primary School,Wardak,3,Chaki Wardak,1,Sarpush,4,Village,4,3,0,TRUE
+404103,68.53913712,34.08667138,2,Kolak Village House,Wardak,3,Chaki Wardak,1,Qulak Village,4,Village,4,3,0,TRUE
+404104,68.62934364,34.12510584,2,Dagarwal Sardar Khan House,Wardak,3,Chaki Wardak,1,Khalili Village,4,Village,4,3,0,TRUE
+404105,68.65470217,34.12846068,2,Molla Shafiq House,Wardak,3,Chaki Wardak,1,Zaman Khel Village,4,Village,4,3,0,TRUE
+404106,68.47117601,33.97120348,1,Qadir Khel Village Mosque,Wardak,2,Chaki Wardak,1,Qader Khel Village,4,Village,4,2,0,TRUE
+404107,68.67641055,34.15755112,3,Gawgosh Tent,Wardak,5,Chaki Wardak,2,Gawgush Tent,4,Village,4,5,0,TRUE
+405108,68.71015353,33.99636577,2,Sayed Abad High School,Wardak,4,Sayyd Abad,2,Aman Khel,4,Building,5,6,0,TRUE
+405109,68.74222689,34.03612621,2,Mosque,Wardak,3,Sayyd Abad,1,Si Si,4,Building,5,3,0,TRUE
+405110,68.72876886,34.01350798,3,Malik Jelani House,Wardak,4,Sayyd Abad,1,Shater Village,4,Village,5,5,0,TRUE
+405111,68.71845018,34.01901638,2,Qala-E-Saeduddin Village Mosque,Wardak,3,Sayyd Abad,1,Qala Saduddin,4,Village,5,4,0,TRUE
+405112,68.69892709,33.95795352,2,Haider Khel Village School,Wardak,3,Sayyd Abad,1,Haider Khel,4,Village,5,3,0,TRUE
+405113,68.76090735,34.08226048,1,Shaikh Abad High School,Wardak,2,Sayyd Abad,1,Hashim Khel,4,Building,5,4,0,TRUE
+405114,68.79581913,34.16858405,4,Dasht-E-Toop High School,Wardak,6,Sayyd Abad,2,Dasht-E-Toop,4,Building,5,9,0,TRUE
+405115,68.73753609,34.10587413,1,Zahen Khan Khel School,Wardak,2,Sayyd Abad,1,Zahen Khan Khel,4,Village,5,2,2,TRUE
+405116,68.6219039,33.86363235,1,Otary School,Wardak,2,Sayyd Abad,1,Otarri,4,Village,5,2,0,TRUE
+405117,68.61333912,33.84338278,1,Tent In Haft Asia Village,Wardak,2,Sayyd Abad,1,Haft Asia,4,Village,5,2,0,TRUE
+405118,68.54615353,33.75065378,1,Shash Qala School,Wardak,2,Sayyd Abad,1,Shash Qala,4,Village,5,2,0,TRUE
+405119,68.57138314,33.77688677,1,Lura School,Wardak,2,Sayyd Abad,1,Lurra,4,Village,5,2,0,TRUE
+405120,68.59980529,33.96571585,1,Tent In Alif Khel Village,Wardak,2,Sayyd Abad,1,Alif Khel-Chinar Khel,4,Village,5,2,0,TRUE
+405121,68.62077329,33.98966094,1,Musa Khel Village School,Wardak,2,Sayyd Abad,1,Musa Khel,4,Village,5,2,0,TRUE
+405122,68.5803451,33.97908852,1,Hosai Khel Village Tent,Wardak,2,Sayyd Abad,1,Husai Khel,4,Village,5,4,0,TRUE
+405123,68.61640388,34.02365903,1,Hassan Baik Mosque,Wardak,2,Sayyd Abad,1,Hasan Baik,4,Village,5,2,0,TRUE
+405124,68.66935822,34.01490465,1,School And Tent,Wardak,2,Sayyd Abad,1,Hakim Khel,4,Village,5,4,0,TRUE
+405125,68.68700728,33.93023614,2,Khazandar House,Wardak,3,Sayyd Abad,1,Aka Khel Village,4,Village,5,3,0,TRUE
+405126,68.6666853,33.9031932,1,Salar Mosque,Wardak,2,Sayyd Abad,1,Salar,4,Village,5,2,0,TRUE
+405127,68.63747904,33.87735625,1,Sultan Khel Mosque,Wardak,2,Sayyd Abad,1,Sultan Khel,4,Village,5,2,0,TRUE
+405128,68.62996977,33.90627993,1,Almar School,Wardak,2,Sayyd Abad,1,Bahadur Khel,4,Village,5,2,0,TRUE
+405129,68.48496767,33.72644783,1,Private House,Wardak,2,Sayyd Abad,1,Kurbat Baghak,4,Village,5,2,0,TRUE
+405130,68.62290901,33.73509231,1,Zana Khan Mosque,Wardak,2,Sayyd Abad,1,Zana Khan,4,Village,5,2,0,TRUE
+405131,68.67868101,34.08227433,1,Private House,Wardak,2,Sayyd Abad,1,Che Jan Village,4,Village,5,4,0,TRUE
+405132,68.77847499,34.02499628,1,Hassan Khel Village Mosque,Wardak,2,Sayyd Abad,1,Hasan Khel,4,Village,5,2,0,TRUE
+405133,68.67916251,33.95464026,1,Tent In Dasht-E-Larram,Wardak,2,Sayyd Abad,1,Larram,4,Village,5,2,0,TRUE
+405134,68.80234138,34.00322172,1,Private House,Wardak,2,Sayyd Abad,1,Beni Safid,4,Village,5,2,0,TRUE
+405135,68.78392685,34.02083697,1,Joy Zarin High School,Wardak,2,Sayyd Abad,1,Joy Zarin,4,Village,5,2,0,TRUE
+405136,68.830496,33.995382,1,Tent And Private House,Wardak,2,Sayyd Abad,1,Qala-E-Amir,4,Village,5,2,0,TRUE
+405137,68.81473066,33.99450125,1,Kamran Khel School,Wardak,2,Sayyd Abad,1,Kamran Khel,4,Village,5,2,0,TRUE
+405138,68.53934185,33.81078457,2,Tent And Private House,Wardak,3,Sayyd Abad,1,Sandawar,4,Village,5,3,0,TRUE
+405139,68.76274359,34.03966348,2,Imam-E-Mohammad School,Wardak,3,Sayyd Abad,1,Du Aab,4,Village,5,3,0,TRUE
+405140,68.7570973,34.08753708,2,Tent Of Koh-E-Shaikh Abad,Wardak,4,Sayyd Abad,2,Koh-E-Shaikh Abad,4,Village,5,5,0,TRUE
+405141,68.63872512,33.86988201,2,Tent Of Koh-E-Salar,Wardak,3,Sayyd Abad,1,Koh-E-Salar,4,Village,5,3,0,TRUE
+405142,68.79283403,34.20054289,2,Dasht-E-Toop Old High School,Wardak,3,Sayyd Abad,1,Muien Khel,4,Village,5,4,0,TRUE
+406064,68.26185207,34.17408261,3,Lalanar School,Wardak,5,Daymirdad,2,Lalandar,4,Building,6,5,0,TRUE
+406065,68.2283519,34.11501449,2,Private House,Wardak,3,Daymirdad,1,Para Qala,4,Village,6,3,0,TRUE
+406066,68.30600765,34.22193554,2,Miran Clinic,Wardak,3,Daymirdad,1,Miran Village,4,Village,6,3,0,TRUE
+406067,68.38194087,34.23126401,1,Ghazi Abdul Kabir Khan High School,Wardak,2,Daymirdad,1,Babak Village,4,Building,6,2,0,TRUE
+406068,68.30291933,34.38453552,2,Block Hussaini School,Wardak,3,Daymirdad,1,Block Hussaini Village,4,Building,6,3,0,TRUE
+406069,68.30651264,34.29385359,3,Malik Asadullah House,Wardak,5,Daymirdad,2,Naqshen Village,4,Village,6,5,0,TRUE
+406070,68.48719312,34.23750654,3,Tangi Saiedan Clinic,Wardak,5,Daymirdad,2,Tangi Saiedan,4,Village,6,5,0,TRUE
+406071,68.20945189,34.06204855,2,Mohammad Aalim Shop,Wardak,3,Daymirdad,1,Chahar Dewal,4,Village,6,3,0,TRUE
+407025,68.1591216,34.31130639,2,Qala-E-Sayed Temor School,Wardak,3,Hissa-E-Awali Bihsud,1,Qala-E-Sayed Temor,4,Building,7,3,0,TRUE
+407026,68.241067,34.30237,1,Tezak Clinic,Wardak,2,Hissa-E-Awali Bihsud,1,Tezak,4,Village,7,2,0,TRUE
+407027,68.0382697,34.49630146,2,Sia Buta School,Wardak,3,Hissa-E-Awali Bihsud,1,Sia Buta,4,Building,7,3,0,TRUE
+407028,68.27643052,34.72034023,2,Bazar-E-Dahan Aabdara,Wardak,3,Hissa-E-Awali Bihsud,1,Dahan-E-Aabdara,4,Village,7,3,0,TRUE
+407029,68.29671723,34.67441264,2,Dawlat Quli School,Wardak,3,Hissa-E-Awali Bihsud,1,Dawlat Quli Village,4,Building,7,3,0,TRUE
+407030,68.24855938,34.70673633,1,Argin Secondary School,Wardak,2,Hissa-E-Awali Bihsud,1,Argin Quli Khwish,4,Village,7,2,0,TRUE
+407031,68.13410482,34.60973599,1,Girdi Mosque,Wardak,2,Hissa-E-Awali Bihsud,1,Sia Sang,4,Village,7,2,0,TRUE
+407032,68.24312099,34.50573282,3,Haji Merza Shop,Wardak,5,Hissa-E-Awali Bihsud,2,Dahan-E-Sia Sang Village,4,Building,7,5,0,TRUE
+407033,68.23935611,34.42506471,1,Payen Nuqat Mosque,Wardak,2,Hissa-E-Awali Bihsud,1,Paien Nuqat Village,4,Building,7,2,0,TRUE
+408072,68.35680808,33.77064918,2,Sayed Farooq House,Wardak,3,Jaghatu,1,Sadad-E-Sarband Village,4,Village,8,3,0,TRUE
+408073,68.334564923,33.831149034,2,Kudan School,Wardak,4,Jaghatu,2,Kushan,4,District,8,4,0,TRUE
+408074,68.42284665,33.88576408,3,Imam-E-Abu Hanifa School,Wardak,5,Jaghatu,2,Baber Baba Khel,4,Building,8,5,0,TRUE
+408075,68.39220794,33.84357601,2,Sanzala Mosque,Wardak,3,Jaghatu,1,Sanzala,4,Village,8,3,0,TRUE
+408076,68.39792887,33.8213758,2,Kalandeh Clinic,Wardak,3,Jaghatu,1,Kalandeh,4,Building,8,3,0,TRUE
+408077,68.37778196,33.79702715,1,Laghari Clinic,Wardak,2,Jaghatu,1,Laghari,4,Village,8,2,0,TRUE
+408078,68.38339819,33.75464194,1,Nazar Khan School,Wardak,2,Jaghatu,1,Band-E-Sultan,4,Building,8,2,0,TRUE
+408079,68.33451109,33.75035699,1,Malik Qarya Office,Wardak,2,Jaghatu,1,Busha Khel,4,Village,8,2,0,TRUE
+408080,68.2922876,33.72825826,1,Noor Khel Mosque,Wardak,2,Jaghatu,1,Noor Khel,4,Village,8,2,0,TRUE
+408081,68.27370671,33.72145721,1,Private House,Wardak,2,Jaghatu,1,Qala-E-Sulaiman,4,Village,8,2,0,TRUE
+408082,68.42569475,33.92804782,1,Rahmatullah House,Wardak,2,Jaghatu,1,Mola,4,Village,8,2,0,TRUE
+409034,67.89919982,34.37193758,3,Darunjoi Mosque,Wardak,4,Markaz-E-Behsud,1,Darun Joi Village,4,Village,9,4,0,TRUE
+409035,67.90696511,34.4396788,1,Shuhada High School,Wardak,2,Markaz-E-Behsud,1,Pul-E-Afghanan,4,Village,9,2,0,TRUE
+409036,67.91386571,34.50307399,1,Rashak School,Wardak,2,Markaz-E-Behsud,1,Rashak,4,Village,9,2,0,TRUE
+409037,67.71103817,34.54148353,1,Daman Khalil Mosque,Wardak,2,Markaz-E-Behsud,1,Daman Khalil,4,Village,9,2,0,TRUE
+409038,67.80806274,34.55486657,1,Marak High School,Wardak,2,Markaz-E-Behsud,1,Marak,4,Village,9,2,0,TRUE
+409039,67.63524327,34.31088925,1,Surkh Abad Madrassa,Wardak,2,Markaz-E-Behsud,1,Sia Zamin Village,4,Building,9,2,0,TRUE
+409040,67.74910334,34.27419048,1,Kuhna Qala School,Wardak,2,Markaz-E-Behsud,1,Kuhna Qala,4,Building,9,2,0,TRUE
+409041,67.55146241,34.25785273,1,Tagab-E-Zerat Mosque,Wardak,2,Markaz-E-Behsud,1,Zerat Village,4,Building,9,2,0,TRUE
+409042,67.52519273,34.30414063,1,Nai Bolaq-E-Ajam Mosque,Wardak,2,Markaz-E-Behsud,1,Nai Bolaq Ajam Village,4,Village,9,2,0,TRUE
+409043,67.81666371,34.42346777,1,Aabsherum School,Wardak,2,Markaz-E-Behsud,1,Aabsherum,4,Building,9,2,0,TRUE
+409044,67.78056031,34.40716214,2,Tagab-E-Ramoz High School,Wardak,3,Markaz-E-Behsud,1,Tagab Ramoz Village,4,Building,9,3,0,TRUE
+409045,67.67671138,34.41956246,2,Kotal-E-Molla Yaqub School,Wardak,3,Markaz-E-Behsud,1,Kutal-E-Molla Yaqub,4,Building,9,3,0,TRUE
+409046,67.65959812,34.53758421,1,Gardan Qada Mosque,Wardak,2,Markaz-E-Behsud,1,Gardan Qada,4,Building,9,2,0,TRUE
+409047,67.47345954,34.36343565,1,Mehar Khana,Wardak,2,Markaz-E-Behsud,1,Mehar Khana,4,Building,9,2,0,TRUE
+409048,67.47783364,34.32975729,1,Qala-E-Gordoom Mosque,Wardak,2,Markaz-E-Behsud,1,Qala-E-Gordoom,4,Building,9,2,0,TRUE
+409049,67.52189177,34.59979095,1,Dasht-E-Qala Jarikhana,Wardak,2,Markaz-E-Behsud,1,Dasht Qala,4,Building,9,2,0,TRUE
+409050,67.39963895,34.57916728,2,Sarbalaq School,Wardak,3,Markaz-E-Behsud,1,Sarbalaq Village,4,Building,9,3,0,TRUE
+409051,67.454771,34.52035612,1,Tent,Wardak,2,Markaz-E-Behsud,1,Ghawas Village,4,Village,9,2,0,TRUE
+409052,67.35627588,34.47316751,1,Bara Khana School,Wardak,2,Markaz-E-Behsud,1,Sabza,4,Building,9,2,0,TRUE
+409053,67.90390021,34.34495092,2,Bazar-E-Markaz,Wardak,3,Markaz-E-Behsud,1,Bazar-E-Markaz,4,Village,9,3,0,TRUE
+409054,67.82075307,34.35439569,2,Rahqul Girls High School,Wardak,3,Markaz-E-Behsud,1,Rahqul,4,Building,9,3,0,TRUE
+409055,67.97147811,34.37206787,1,Bad-E-Asyab School,Wardak,2,Markaz-E-Behsud,1,Kuta Maktab,4,Building,9,2,0,TRUE
+409056,68.05704259,34.4287391,1,Sare Tala Clinic,Wardak,2,Markaz-E-Behsud,1,Sare Tala,4,Building,9,2,0,TRUE
+409057,68.00233915,34.24592389,2,Mer Hazar-E-Kajab High School,Wardak,3,Markaz-E-Behsud,1,Mer Hazar Village,4,Building,9,3,0,TRUE
+409058,67.88883324,34.23645946,1,Dahan Oji School,Wardak,2,Markaz-E-Behsud,1,Dahan-E-Oji,4,Village,9,2,0,TRUE
+409059,67.82431462,34.2369274,1,Gulzar Clinic,Wardak,2,Markaz-E-Behsud,1,Gulzar Village,4,Village,9,2,0,TRUE
+409060,67.34027244,34.07881096,1,Band Buta Clinic,Wardak,2,Markaz-E-Behsud,1,Band-E-Buta,4,Village,9,2,0,TRUE
+409061,67.48024984,34.21208123,1,Tagab Bermak Mosque,Wardak,2,Markaz-E-Behsud,1,Tagab Beramak,4,Building,9,2,0,TRUE
+409062,67.57212837,34.15829647,1,Kamarak Mosque,Wardak,2,Markaz-E-Behsud,1,Kamarak,4,Village,9,2,0,TRUE
+409063,67.33691654,34.01449416,2,Qara Qul Madrassa,Wardak,3,Markaz-E-Behsud,1,Qaraqul,4,Village,9,3,0,TRUE
+501001,69.01007298,34.01109444,6,Omar Farooq High School,Logar,10,Puli Alam,4,Provincial Center,5,Building,1,10,0,TRUE
+501002,69.0178041,34.04578259,7,Kolangar Jehadi High School,Logar,10,Puli Alam,3,Kalangar,5,Building,1,10,0,TRUE
+501003,69.01559629,34.00708303,5,Red Crescent Center,Logar,6,Puli Alam,1,Women Affairs Of Red Crescent,5,Building,1,6,0,TRUE
+501004,69.05197173,33.95679051,5,Pad Khawb-E-Shana Secondary School,Logar,8,Puli Alam,3,Pad Khawb Khadr,5,Building,1,9,0,TRUE
+501005,69.05395878,34.10328018,4,Poorak School,Logar,7,Puli Alam,3,Konjak,5,Building,1,7,0,TRUE
+501006,68.98776353,34.04012699,3,Qala-E-Ghafar School,Logar,5,Puli Alam,2,Qala-E-Ghafar,5,Building,1,5,0,TRUE
+501007,69.0365336,34.00026632,5,Hesarak Secondary School,Logar,9,Puli Alam,4,Hesarak,5,Building,1,13,0,TRUE
+501008,69.09519062,34.08332936,4,Dadokhel Secondary School,Logar,5,Puli Alam,1,Dado Khel,5,Building,1,5,0,TRUE
+501009,69.09555773,33.79215054,6,Altamor Secondary School,Logar,8,Puli Alam,2,Altamor,5,Building,1,8,0,TRUE
+501010,68.97251682,34.08155698,3,Babos School,Logar,5,Puli Alam,2,Babos,5,Building,1,5,0,TRUE
+501011,69.06914696,33.95466934,3,Pas Kariz School,Logar,5,Puli Alam,2,Pas Kariz,5,Building,1,5,0,TRUE
+501012,68.88948039,34.11100968,1,Sholak School,Logar,4,Puli Alam,3,Shalook,5,Village,1,4,0,TRUE
+501013,69.00933864,33.95620869,2,Shaheedan Doshanba School,Logar,3,Puli Alam,1,Shaheedan,5,Building,1,3,0,TRUE
+501014,69.13026177,33.87698637,1,Choni School,Logar,3,Puli Alam,2,Choni,5,Building,1,5,0,TRUE
+501015,69.03871745,34.05722559,2,Qala-E-Shahi School,Logar,4,Puli Alam,2,Shahi,5,Building,1,4,0,TRUE
+501016,69.2431011,33.89286051,3,Aabchakan School,Logar,5,Puli Alam,2,Aabchakan,5,Village,1,5,0,TRUE
+501017,69.02141181,33.97700633,2,Honi Saidan Mosque,Logar,3,Puli Alam,1,Honi Sayedan,5,Building,1,2,1,TRUE
+501018,69.06601051,34.07373179,1,Dasht-E-Bari School,Logar,3,Puli Alam,2,Dasht-E-Bari,5,Building,1,3,0,TRUE
+501019,69.08470761,34.01872732,3,Shahrak-E-Mohajerin Clinic,Logar,4,Puli Alam,1,Shahrak-E-Mohajerin,5,Building,1,5,0,TRUE
+501020,69.17348997,33.84984877,2,Pashton Abad Mosque,Logar,3,Puli Alam,1,Pashton Abad,5,District,1,3,0,TRUE
+501021,68.99761323,33.96168899,1,Deh Doshanbi Mosque,Logar,3,Puli Alam,2,Deh Doshanbi,5,Village,1,2,1,TRUE
+502022,68.9410663,33.96760049,7,Ghazi Amanullah High School,Logar,8,Baraki Barak,1,Baraki Barak,5,Building,2,8,0,TRUE
+502023,68.96455288,33.94384107,5,Padkhwab Roghani Boys & Girls School,Logar,7,Baraki Barak,2,Pad Khwab Roghani,5,Building,2,7,0,TRUE
+502024,68.96607638,33.94081404,1,Ziarat-E-Shah Samit Per Yakh Posh,Logar,2,Baraki Barak,1,Qala Babi,5,Building,2,2,0,TRUE
+502025,68.92274784,33.94286056,4,Baraki Rajan High School,Logar,7,Baraki Barak,3,Baraki Rajan,5,Building,2,7,0,TRUE
+502026,68.97278846,33.97139606,1,Pandah School,Logar,2,Baraki Barak,1,Pandah,5,Building,2,2,0,TRUE
+502027,68.99726053,33.92307355,2,Qala-E-Shaki Boys And Girls School,Logar,4,Baraki Barak,2,Qala-E-Shaki,5,Building,2,4,0,TRUE
+502028,68.8798511,33.96201754,2,Pul-E-Ghazi School And Clinic,Logar,3,Baraki Barak,1,Chalozaye,5,Building,2,1,2,TRUE
+502031,68.9472603,33.88647505,2,Shah Mazar Mosque,Logar,3,Baraki Barak,1,Shah Mazar,5,Building,2,3,0,TRUE
+502033,68.86293713,33.94145886,1,Qala-E-Jabir School,Logar,2,Baraki Barak,1,Qala-E-Jabir,5,Building,2,2,0,TRUE
+502034,68.91264852,33.96563407,2,Zehqom Khel School,Logar,3,Baraki Barak,1,Zahqom Khel,5,Building,2,3,0,TRUE
+502035,68.86682476,33.92275255,2,Qala-E-Mami School,Logar,3,Baraki Barak,1,Qala-E-Momi,5,Building,2,2,1,TRUE
+502036,68.97809524,33.97090739,2,Qala-E-Badi Mosque,Logar,3,Baraki Barak,1,Qala-E-Badi,5,Building,2,3,0,TRUE
+502037,68.93587548,33.91441805,3,Pul-E-Rajan Mosque,Logar,4,Baraki Barak,1,Pul-E-Rajan,5,Building,2,4,0,TRUE
+502038,68.8988969,33.94915131,2,Hazrat-E-Bilal High School,Logar,3,Baraki Barak,1,Pul-E-Ghazi,5,Village,2,3,0,TRUE
+502039,68.89852732,33.93784771,2,Cheheltan School,Logar,4,Baraki Barak,2,Cheheltan,5,Building,2,4,0,TRUE
+502040,68.94915111,33.87831855,2,Allah Dad Khel Mosque,Logar,3,Baraki Barak,1,Allah Dad Khel,5,Building,2,3,0,TRUE
+503041,68.94382649,33.79089587,3,Alhaj Shaheed Tafser Shah Secondary School,Logar,5,Charkh,2,Pengeram Sar Asyab,5,Building,3,0,5,FALSE
+503042,68.94278966,33.829064,3,Argum Clinic,Logar,5,Charkh,2,Argum Village,5,Building,3,0,5,FALSE
+503043,68.94362033,33.80062887,7,Mawlana Yaqoub Charkhi School,Logar,10,Charkh,3,Garm Aaba,5,Building,3,2,8,TRUE
+503044,68.92576804,33.80904455,3,Qala-E-Naw School,Logar,5,Charkh,2,Dasht,5,Building,3,5,0,TRUE
+503045,68.96592233,33.84878405,3,Dabar School,Logar,6,Charkh,3,Dabar Ha,5,Building,3,3,3,TRUE
+504046,69.19344346,34.01006329,6,Khoshi High School & Mian Deh Girls School,Logar,10,Khushi,4,Mian Deh,5,Building,4,10,0,TRUE
+504047,69.24434132,34.03784429,3,Karezona School,Logar,5,Khushi,2,Karizona,5,Building,4,5,0,TRUE
+504048,69.30181612,34.02979997,2,Sheen Gul Qala,Logar,4,Khushi,2,Kandow,5,Building,4,3,1,TRUE
+504049,69.31619672,33.9591162,3,Dubandi School,Logar,5,Khushi,2,Dubandi Baghal,5,Building,4,4,1,TRUE
+505050,69.14851356,34.29448544,4,Safid Sang School,Logar,5,Mohammad Agha,1,Safid Sang,5,Building,5,6,0,TRUE
+505051,69.09387222,34.15436306,3,Deh Naw School,Logar,5,Mohammad Agha,2,Deh Naw,5,Building,5,5,0,TRUE
+505052,69.23325801,34.22404976,1,Aab Paran School,Logar,2,Mohammad Agha,1,Aabparan,5,Village,5,3,0,TRUE
+505053,69.25029834,34.3103209,1,Dashtak School,Logar,2,Mohammad Agha,1,Dashtak Village,5,Village,5,2,0,TRUE
+505054,69.19407522,34.14277788,2,Sorkhaab School,Logar,3,Mohammad Agha,1,Surkhaab,5,Building,5,3,0,TRUE
+505055,69.05878207,34.27244807,2,Abazak School,Logar,3,Mohammad Agha,1,Abazak,5,Building,5,3,0,TRUE
+505056,69.237895811,34.133906135,2,Haro Mosque,Logar,3,Mohammad Agha,1,Borag,5,Village,5,0,3,FALSE
+505057,69.08412778,34.20199854,3,Old District Building,Logar,5,Mohammad Agha,2,Mohammad Agha,5,Building,5,5,0,TRUE
+505058,69.1293884,34.11534155,3,Zarghon Shahr Boys & Girls School,Logar,6,Mohammad Agha,3,Zarghon Shahr,5,Building,5,6,0,TRUE
+505059,69.14945702,34.28315228,2,Gumaran School,Logar,3,Mohammad Agha,1,Gomaran,5,Building,5,3,0,TRUE
+505060,69.1324771,34.26807285,2,Mohammad Jan Khan School,Logar,4,Mohammad Agha,2,Zaid Abad,5,Building,5,5,0,TRUE
+505061,69.13576677,34.24656449,2,Sayed Salih Pad Shah School,Logar,3,Mohammad Agha,1,Sayed Saleem Pad Shah,5,Building,5,3,0,TRUE
+505062,69.13686238,34.22853932,2,Kutob Khel School,Logar,4,Mohammad Agha,2,Qala-E-Keshtom,5,Building,5,4,0,TRUE
+505063,69.05883474,34.15596354,2,Moghul Khel Girls School,Logar,3,Mohammad Agha,1,Moghul Khel,5,Building,5,5,0,TRUE
+505064,69.27870853,34.14073266,2,Dara Mosque,Logar,3,Mohammad Agha,1,Dara Village,5,Village,5,3,0,TRUE
+505065,69.09598165,34.19338618,3,Qala-E-Ahmadzai Mosque,Logar,5,Mohammad Agha,2,Qala-E-Ahmadzai,5,Building,5,5,0,TRUE
+505066,69.07234055,34.17819556,2,Surkh Abad Girls Secondary School,Logar,3,Mohammad Agha,1,Surkh Abad,5,Building,5,6,0,TRUE
+505067,69.10477158,34.22533761,3,Mohammad Agha High School,Logar,4,Mohammad Agha,1,Pul-E-Qandahari,5,Building,5,6,1,TRUE
+505083,69.070626877,34.159158764,2,Aqeb Bazar Mosque,Logar,3,Mohamad Agha,1,Waghjan Bazar,5,Building,5,3,0,TRUE
+506068,69.034674,33.70017436,4,Khwaja Angor School,Logar,8,Khar War,4,Khwaja Angor Village,5,Village,6,0,8,FALSE
+506069,68.86635526,33.6951835,1,Apa Khan School,Logar,2,Khar War,1,Mani Bazar Village,5,Village,6,0,2,FALSE
+506070,68.87816979,33.70766714,2,Horya Khel Primary School,Logar,3,Khar War,1,Horya Khel,5,Building,6,0,3,FALSE
+506071,68.86439268,33.70320742,4,Kotagi School,Logar,7,Khar War,3,Gudi Khel,5,Building,6,0,7,FALSE
+506072,68.9099557,33.66324174,4,District Compound Secondary School,Logar,6,Khar War,2,Jozi District,5,Building,6,6,0,TRUE
+506073,68.89722775,33.67805607,4,Mango,Logar,6,Khar War,2,Mango,5,Village,6,5,1,TRUE
+507075,69.71557287,34.17792999,6,Chotra School,Logar,10,Azra,4,Chotra,5,Building,7,10,0,TRUE
+507076,69.66676956,34.17697461,4,Akbar Khel Boys & Girls School,Logar,8,Azra,4,Akbar Khel,5,Building,7,8,0,TRUE
+507077,69.64624514,34.17280178,4,Sang Baran School,Logar,7,Azra,3,Sang Baran Village,5,Village,7,7,0,TRUE
+507078,69.55131385,34.14555329,5,Musa Khan School,Logar,8,Azra,3,Musa Khan Village,5,Village,7,8,0,TRUE
+507079,69.72709831,34.1237192,5,Razi Khel Secondary School,Logar,8,Azra,3,Razi Khel,5,Building,7,0,8,FALSE
+507081,69.63316671,34.16600573,3,Baber School,Logar,6,Azra,3,Baber,5,Building,7,5,1,TRUE
+601002,70.440749636,34.436673805,0,Experimental High School,Nangarhar,8,Jalalabad,8,D03-Nahia 3,6,Building,1,8,0,TRUE
+601003,70.440170083,34.437137181,6,Faculty Of Education,Nangarhar,6,Jalalabad,0,D03-Nahia 4,6,Building,1,7,0,TRUE
+601004,70.468140692,34.428620296,0,Allayee High School,Nangarhar,8,Jalalabad,8,D04-Nahia 4,6,Building,1,8,0,TRUE
+601005,70.4705395,34.42869984,6,Bibi Ayesha,Nangarhar,6,Jalalabad,0,D04-Nahia 4,6,Building,1,6,0,TRUE
+601006,70.46834071,34.43314435,6,Abdul Wakel High School,Nangarhar,6,Jalalabad,0,D01-Nahia 1,6,Building,1,6,0,TRUE
+601007,70.47070846,34.422752174,0,Nasrat High School,Nangarhar,5,Jalalabad,5,D04-Nahia 4,6,Building,1,5,0,TRUE
+601008,70.478041501,34.411590127,4,Procurement Base,Nangarhar,5,Jalalabad,1,D04-Nahia 4,6,Building,1,6,0,TRUE
+601009,70.4742476,34.41604212,7,Irrigation Directorate,Nangarhar,7,Jalalabad,0,D04-Nahia 4,6,Building,1,7,0,TRUE
+601010,70.46345348,34.42778762,0,Nangrahar High School,Nangarhar,8,Jalalabad,8,D04-Nahia 4,6,Building,1,8,0,TRUE
+601011,70.45115496,34.42581902,0,Bibi Hawa High School,Nangarhar,8,Jalalabad,8,D02-Nahia 2,6,Building,1,8,0,TRUE
+601012,70.42533898,34.36220652,5,Jami Mosque,Nangarhar,8,Jalalabad,3,D06-Nahia 6,6,Building,1,8,0,TRUE
+601013,70.43,34.363855576,3,Najmul Jihad High School,Nangarhar,5,Jalalabad,2,D06-Nahia 6,6,Building,1,5,0,TRUE
+601014,70.43224991,34.43813924,0,Bibi Zainab School,Nangarhar,6,Jalalabad,6,D03-Nahia 3,6,Building,1,6,0,TRUE
+601015,70.43440408,34.42273333,0,Estiqlal School,Nangarhar,6,Jalalabad,6,D05-Nahia 5,6,Building,1,6,0,TRUE
+601016,70.43820749,34.41544453,4,Kuchi Mosque,Nangarhar,5,Jalalabad,1,D05-Nahia 5,6,Building,1,5,0,TRUE
+601017,70.43557566,34.422691,6,Nazo Ana School,Nangarhar,6,Jalalabad,0,D05-Nahia 5,6,Building,1,6,0,TRUE
+601018,70.4338311,34.42306548,0,Shaheed Arif High School,Nangarhar,7,Jalalabad,7,D05-Nahia 5,6,Building,1,7,0,TRUE
+601019,70.43982051,34.435413391,6,Imam-E-Bukhari High School,Nangarhar,6,Jalalabad,0,D03-Nahia 3,6,Building,1,6,0,TRUE
+601020,70.433192375,34.432705229,0,Women Affairs Directorate,Nangarhar,7,Jalalabad,7,D03-Nahia 3,6,Building,1,7,0,TRUE
+601021,70.43259062,34.43458337,7,Cheknowri High School,Nangarhar,7,Jalalabad,0,D03-Nahia 3,6,Building,1,7,0,TRUE
+601022,70.44159363,34.43075018,0,Araban School,Nangarhar,7,Jalalabad,7,D03-Nahia 3,6,Building,1,7,0,TRUE
+601023,70.432748035,34.423495756,7,Teacher Training Institution,Nangarhar,7,Jalalabad,0,D05-Nahia 5,6,Building,1,7,0,TRUE
+601024,70.44560498,34.43411054,5,Taqwa Mosque,Nangarhar,9,Jalalabad,4,D03-Nahia 3,6,Building,1,9,0,TRUE
+601025,70.46638021,34.42588171,6,Eidgah Mosque,Nangarhar,6,Jalalabad,0,D04-Nahia 4,6,Building,1,8,0,TRUE
+601026,70.44482601,34.42902739,0,Ameer Shaheed Bagh,Nangarhar,6,Jalalabad,6,D02-Nahia 2,6,Building,1,6,0,TRUE
+601027,70.45194813,34.43482562,6,Sirajul Amarat Bagh,Nangarhar,6,Jalalabad,0,D01-Nahia 1,6,Building,1,6,0,TRUE
+601028,70.46273057,34.43797698,2,Rural Development Directorate,Nangarhar,7,Jalalabad,5,D01-Nahia 1,6,Building,1,7,0,TRUE
+601029,70.46286222,34.43871862,7,Campono Mosque,Nangarhar,7,Jalalabad,0,D01-Nahia 1,6,Building,1,7,0,TRUE
+601030,70.4608243,34.426631,5,Shanzda Family Mosque,Nangarhar,5,Jalalabad,0,D04-Nahia 4,6,Building,1,5,0,TRUE
+601031,70.45376059,34.43002414,5,Custom House Mosque,Nangarhar,5,Jalalabad,0,D02-Nahia 2,6,Building,1,5,0,TRUE
+601032,70.46385866,34.42343013,5,Chelmetra Mosque,Nangarhar,5,Jalalabad,0,D04-Nahia 4,6,Building,1,5,0,TRUE
+601033,70.46391918,34.41656773,5,Zer Mosque,Nangarhar,5,Jalalabad,0,D04-Nahia 4,6,Building,1,5,0,TRUE
+601034,70.46371397,34.4206627,0,Kochi Mosque,Nangarhar,5,Jalalabad,5,D04-Nahia 4,6,Building,1,5,0,TRUE
+601035,70.44803375,34.41887825,6,Etifaq Mosque,Nangarhar,6,Jalalabad,0,D02-Nahia 2,6,Building,1,6,0,TRUE
+601036,70.45728653,34.41756923,6,Gonbazi Mosque,Nangarhar,6,Jalalabad,0,D02-Nahia 2,6,Building,1,6,0,TRUE
+601037,70.45641606,34.43359036,5,Speen Mosque,Nangarhar,8,Jalalabad,3,D01-Nahia 1,6,Building,1,8,0,TRUE
+601038,70.46686039,34.4277846,5,Medical Faculty,Nangarhar,5,Jalalabad,0,D04-Nahia 4,6,Building,1,5,0,TRUE
+601039,70.470248035,34.41341364,5,Majboor Abad Jame Mosque,Nangarhar,5,Jalalabad,0,D04-Nahia 4,6,Building,1,5,0,TRUE
+601040,70.457868173,34.415480032,3,Angoor Bagh Jame Mosque,Nangarhar,5,Jalalabad,2,D02-Nahia 2,6,Building,1,6,0,TRUE
+601041,70.470346187,34.412415553,0,Majboor Abad School,Nangarhar,5,Jalalabad,5,D04-Nahia 4,6,Building,1,5,0,TRUE
+601042,70.484961977,34.422198428,0,Abdul Rahim School,Nangarhar,5,Jalalabad,5,D01-Nahia 1,6,Building,1,5,0,TRUE
+601043,70.472200236,34.423108474,5,Agriculture School,Nangarhar,5,Jalalabad,0,D04-Nahia 4,6,Building,1,5,0,TRUE
+601044,70.452293084,34.419876887,0,Mia Umar School,Nangarhar,7,Jalalabad,7,D02-Nahia 2,6,Building,1,7,0,TRUE
+601508,70.412766381,34.39038983,3,Shahrak Saiaf Mosque,Nangarhar,4,Jalalabad,1,Farm Hada Family,6,Building,1,4,0,TRUE
+602045,70.46730561,34.45214691,5,Janan Khan High School,Nangarhar,7,Behsud,2,Qala-E- Janan Khan,6,Building,2,7,0,TRUE
+602046,70.5069143,34.45867416,3,Hazrat Abu Bakr Sediq High School,Nangarhar,4,Behsud,1,Qala-E-Regee,6,Village,2,4,0,TRUE
+602048,70.5053882,34.37247509,4,Shaheed Sardar Mohammad Dawood Khan High School,Nangarhar,6,Behsud,2,"Joee 10,11",6,Building,2,6,0,TRUE
+602049,70.48958257,34.41368282,3,Haji Haleem Mosque,Nangarhar,4,Behsud,1,Nader Shahee,6,Building,2,4,0,TRUE
+602050,70.50584211,34.45477772,4,Shahid Agha Mosque,Nangarhar,4,Behsud,0,Jamaly,6,Building,2,4,0,TRUE
+602051,70.50916448,34.47055202,0,Malakh Village School,Nangarhar,3,Behsud,3,Jamaly,6,Building,2,3,0,TRUE
+602053,70.48586714,34.44187216,5,Nahid-E- Shaheed School,Nangarhar,7,Behsud,2,Tamerat,6,Village,2,7,0,TRUE
+602054,70.50828251,34.40859803,2,Haji Hafeez Mosque,Nangarhar,3,Behsud,1,Khoshgunbad Bany Chauk,6,Building,2,3,0,TRUE
+602056,70.56377051,34.37151936,4,Samar Khel School,Nangarhar,6,Behsud,2,Samar Khel,6,Building,2,6,0,TRUE
+602057,70.53348504,34.36856313,4,Saracha Boys High School,Nangarhar,6,Behsud,2,Saracha,6,Building,2,6,0,TRUE
+602058,70.5201386,34.3789408,0,Kaarez Kabeer Clinic,Nangarhar,3,Behsud,3,Karez Kaber,6,Village,2,3,0,TRUE
+602059,70.51977357,34.36963815,4,Kaarez Kabeer School,Nangarhar,4,Behsud,0,Karez Kaber,6,Building,2,4,0,TRUE
+602060,70.52953363,34.48965313,3,Wuch Tangai High School,Nangarhar,4,Behsud,1,Woch Tangahe,6,Village,2,4,0,TRUE
+602061,70.52382896,34.46278846,7,Baanda Mosque,Nangarhar,7,Behsud,0,Bani Gah,6,Village,2,7,0,TRUE
+602062,70.53072842,34.46203345,0,Ghulam Mohammad Dera,Nangarhar,5,Behsud,5,Bani Gah,6,Village,2,5,0,TRUE
+602064,70.51865823,34.45047685,4,Mohammady Sahebzada High School,Nangarhar,7,Behsud,3,Baland Ghar,6,Building,2,7,0,TRUE
+602066,70.49672997,34.44374684,4,Haji Mazdoor Khan Tahwildar Dera,Nangarhar,6,Behsud,2,Walayaty Kelae,6,Village,2,6,0,TRUE
+602067,70.47160351,34.36314468,4,Hada School,Nangarhar,4,Behsud,0,Hada,6,Building,2,4,0,TRUE
+602068,70.47027914,34.36261812,0,Najmul Qura Clinic,Nangarhar,3,Behsud,3,Hada,6,Building,2,3,0,TRUE
+602069,70.43396128,34.3975647,4,Wazir Mohammad Gul Khan High School,Nangarhar,6,Behsud,2,Farm Hada,6,Building,2,6,0,TRUE
+602070,70.41955459,34.45455709,3,Bahr Abad Primary School,Nangarhar,4,Behsud,1,Bahr Abad,6,Village,2,4,0,TRUE
+602072,70.45101188,34.45362492,5,Bahr Abad High School,Nangarhar,7,Behsud,2,Bahr Abad,6,Building,2,7,0,TRUE
+602073,70.49037272,34.46554108,3,Damaan Mosque,Nangarhar,4,Behsud,1,Araban,6,Village,2,5,0,TRUE
+602506,70.48644679,34.43164105,2,Zangoy School,Nangarhar,3,Behsud,1,Qala-E-Zangve,6,Building,2,3,0,TRUE
+602509,70.663916925,34.387488467,2,Primary School,Nangarhar,3,Behsud,1,Gardiks,6,Village,2,3,0,TRUE
+603074,70.29637852,34.412842,3,Sultanpoor Mosque,Nangarhar,3,Surkh Rud,0,Sultanpoor Ulia,6,Village,3,3,0,TRUE
+603075,70.30370833,34.40740555,0,Haji Sardar Bagh,Nangarhar,2,Surkh Rud,2,Sultanpoor,6,Village,3,2,0,TRUE
+603076,70.28874214,34.42242709,0,Shaheed Adam Khan School,Nangarhar,6,Surkh Rud,6,Shamspoor,6,Building,3,6,0,TRUE
+603077,70.28782163,34.41999159,2,Girls High School,Nangarhar,8,Surkh Rud,6,Shamspoor,6,Village,3,8,0,TRUE
+603078,70.40975022,34.42806327,3,Jami Mosque,Nangarhar,4,Surkh Rud,1,Ghawchak,6,Building,3,4,0,TRUE
+603079,70.41609911,34.44114846,2,Mine And Industrial Department,Nangarhar,2,Surkh Rud,0,Cheknowry,6,Building,3,3,0,TRUE
+603080,70.32659714,34.37740982,2,Clinic,Nangarhar,3,Surkh Rud,1,Shekh Mesri,6,Building,3,3,0,TRUE
+603081,70.42202817,34.43929769,0,Cheknowri Mosque,Nangarhar,2,Surkh Rud,2,Cheknowry,6,Village,3,2,0,TRUE
+603082,70.3998631,34.43972954,4,Reyasat Kanan,Nangarhar,4,Surkh Rud,0,Du Saraka,6,Village,3,5,0,TRUE
+603083,70.42133985,34.4476144,3,Afghan Mena Secondary School,Nangarhar,5,Surkh Rud,2,Afghan Mena,6,Building,3,5,0,TRUE
+603084,70.40295759,34.43259103,0,Bakhtaan Clinic,Nangarhar,2,Surkh Rud,2,Du Saraka,6,Village,3,2,0,TRUE
+603085,70.22309465,34.35657341,3,Fateh Abad Clinic,Nangarhar,3,Surkh Rud,0,Fateh Abad,6,Building,3,3,0,TRUE
+603086,70.21824444,34.35350555,0,Fateh Abad School,Nangarhar,2,Surkh Rud,2,Fateh Abad,6,Village,3,2,0,TRUE
+603087,70.3636174,34.45721644,4,Amarkhil School,Nangarhar,4,Surkh Rud,0,Amarkhel,6,Village,3,4,0,TRUE
+603088,70.3653382,34.45554004,0,Amarkhil Clinic,Nangarhar,3,Surkh Rud,3,Amarkhel,6,Village,3,3,0,TRUE
+603089,70.22703199,34.39549271,3,Bala Bagh School,Nangarhar,3,Surkh Rud,0,Bala Bagh,6,Building,3,3,0,TRUE
+603090,70.22175106,34.3949062,0,Bala Bagh Clinic,Nangarhar,2,Surkh Rud,2,Bala Bagh,6,Building,3,2,0,TRUE
+603091,70.38212939,34.4356834,2,Charbagh School,Nangarhar,3,Surkh Rud,1,Charbagh,6,Building,3,5,0,TRUE
+603093,70.32336954,34.4161355,5,Faqrullah School,Nangarhar,7,Surkh Rud,2,Koz Sultanpoor,6,Village,3,7,0,TRUE
+603094,70.32508733,34.41861555,3,Girls' High School,Nangarhar,5,Surkh Rud,2,Koz Sultanpoor,6,Village,3,5,0,TRUE
+603096,70.36474539,34.47881213,3,Bibi Maryam School,Nangarhar,3,Surkh Rud,0,Daronta,6,Building,3,3,0,TRUE
+603097,70.36501388,34.47738333,0,Daronta Clinic,Nangarhar,2,Surkh Rud,2,Daronta,6,Building,3,2,0,TRUE
+603098,70.42804832,34.4062424,1,Ganda Chashma Mosque,Nangarhar,2,Surkh Rud,1,Ganda Chashma,6,Village,3,2,0,TRUE
+603101,70.38269293,34.40010758,1,Siya Sang Mosque,Nangarhar,3,Surkh Rud,2,Siya Sang,6,Building,3,3,1,TRUE
+603510,70.323374439,34.424059719,2,Saido Khil School,Nangarhar,3,Surkh Rud,1,Saido Khil,6,Building,3,3,0,TRUE
+604103,70.32632678,34.25667343,4,Daago Hajiyano Mosque,Nangarhar,4,Chaparhar,0,Daago Village,6,Village,4,2,2,TRUE
+604104,70.32535229,34.25915846,0,Daago Loy Kali Mosque,Nangarhar,2,Chaparhar,2,Daago Village,6,Village,4,2,0,TRUE
+604105,70.45805829,34.33623783,1,Lalma School,Nangarhar,2,Chaparhar,1,Lalma Village,6,Village,4,2,0,TRUE
+604106,70.34788613,34.28195702,2,Kariz Jaame Mosque,Nangarhar,2,Chaparhar,0,Kaarez Village,6,Building,4,2,0,TRUE
+604107,70.35000507,34.27783876,0,Kariz Village Mosque,Nangarhar,2,Chaparhar,2,Kaarez Village,6,Village,4,2,0,TRUE
+604108,70.41039938,34.29828691,2,Secondary School,Nangarhar,2,Chaparhar,0,Zagho Village,6,Building,4,2,0,TRUE
+604109,70.41245351,34.30053855,0,Zagho Village Mosque,Nangarhar,2,Chaparhar,2,Zagho Village,6,Village,4,2,0,TRUE
+604110,70.31685357,34.24873459,2,Maano High School,Nangarhar,3,Chaparhar,1,Maano Village,6,Village,4,3,0,TRUE
+604111,70.39476576,34.30554064,1,Mosque,Nangarhar,2,Chaparhar,1,Dawlatzai Family,6,Building,4,2,0,TRUE
+604112,70.41177091,34.31936844,2,Terelay School,Nangarhar,3,Chaparhar,1,Terelay Village,6,Building,4,3,0,TRUE
+604116,70.39291976,34.28889212,2,Aama Dera (Baghcha),Nangarhar,3,Chaparhar,1,Kandibagh Badol Village,6,Village,4,3,0,TRUE
+604117,70.3729772,34.28724057,2,Haafizan Village School,Nangarhar,2,Chaparhar,0,Hafizan,6,Village,4,2,0,TRUE
+604118,70.36676847,34.28054411,0,Abdul Rahman Dera,Nangarhar,2,Chaparhar,2,Hafizan,6,Village,4,2,0,TRUE
+604120,70.39602217,34.31554034,2,Mula Sahib Mosque,Nangarhar,2,Chaparhar,0,Dawlatzai,6,Building,4,2,0,TRUE
+604121,70.3941641,34.30032609,0,Haji Malook Dera,Nangarhar,2,Chaparhar,2,Dawlatzai,6,Village,4,2,0,TRUE
+604122,70.36289951,34.26614338,2,Bando School,Nangarhar,2,Chaparhar,0,Sholana,6,Building,4,2,0,TRUE
+604123,70.36199531,34.26696667,0,Sholana Mosque,Nangarhar,2,Chaparhar,2,Sholana,6,Village,4,2,0,TRUE
+604126,70.45734532,34.31360298,2,Ghulam Daag School,Nangarhar,3,Chaparhar,1,Darmango Village,6,Village,4,3,0,TRUE
+604127,70.36617553,34.23669737,1,Saparay Secondary School,Nangarhar,2,Chaparhar,1,Chaghara,6,Building,4,0,2,FALSE
+605149,70.57992799,34.41477223,3,Qala-E- Akhund Mosque,Nangarhar,3,Kama,0,Qala-E- Akhund,6,Building,5,3,0,TRUE
+605150,70.58077402,34.41472382,0,Wakel Bagh,Nangarhar,2,Kama,2,Qala-E- Akhund,6,Building,5,2,0,TRUE
+605151,70.60642138,34.43787312,2,Landa Boch Clinic,Nangarhar,2,Kama,0,Landa Boch,6,Building,5,2,0,TRUE
+605152,70.59591898,34.44096667,0,Mohammad Mussa Shafeq High School,Nangarhar,2,Kama,2,Bar Landa Boch,6,Building,5,2,0,TRUE
+605153,70.56391609,34.43108303,2,Khashe Mosque,Nangarhar,2,Kama,0,Khashe,6,Building,5,2,0,TRUE
+605154,70.5641371,34.43055085,0,Khashe Maidan,Nangarhar,3,Kama,3,Khashe,6,Village,5,3,0,TRUE
+605155,70.64232085,34.44478459,2,Spadree Mosque,Nangarhar,3,Kama,1,Spadree,6,Village,5,3,0,TRUE
+605156,70.60907046,34.45357226,1,Shergarh School,Nangarhar,2,Kama,1,Spadree,6,Village,5,2,0,TRUE
+605157,70.6399507,34.41115647,4,Court,Nangarhar,4,Kama,0,Sangar Sray,6,Building,5,4,0,TRUE
+605158,70.64022141,34.41062129,1,Sangar Sray Clinic,Nangarhar,3,Kama,2,Sangar Sray,6,Building,5,3,0,TRUE
+605159,70.67603896,34.41168672,1,Mirza Khel School,Nangarhar,2,Kama,1,Merzakhel,6,Building,5,2,0,TRUE
+605160,70.594289245,34.456239627,2,Darbang School,Nangarhar,3,Kama,1,Darbang,6,Village,5,3,0,TRUE
+605161,70.657991058,34.412492635,2,Sayed Sarwar Qadery High School,Nangarhar,3,Kama,1,Khasa Kama,6,Village,5,3,0,TRUE
+605162,70.559627132,34.398592908,2,Zakhel Mosque,Nangarhar,3,Kama,1,Zakhel,6,Building,5,3,0,TRUE
+605163,70.66108539,34.41930187,2,Chardewali,Nangarhar,2,Kama,0,Mama Khel,6,Village,5,2,0,TRUE
+605164,70.65746316,34.424721,0,Mama Khel Mosque,Nangarhar,2,Kama,2,Mama Khel,6,Village,5,2,0,TRUE
+605165,70.71778586,34.50364105,1,Totakay Mosque,Nangarhar,2,Kama,1,Totakay,6,Village,5,2,0,TRUE
+605166,70.61020833,34.40634444,3,Watapoor Chardewali,Nangarhar,3,Kama,0,Watapoor,6,Village,5,3,0,TRUE
+605167,70.61008774,34.40607783,0,Watapoor Mosque,Nangarhar,2,Kama,2,Watapoor,6,Village,5,2,0,TRUE
+605168,70.61867454,34.43106233,2,Koz Landabooch Mosque,Nangarhar,2,Kama,0,Koz Landabooch,6,Village,5,2,0,TRUE
+605169,70.61690337,34.42583732,0,Chardewali,Nangarhar,2,Kama,2,Koz Landabooch Village,6,Village,5,2,0,TRUE
+605170,70.5764225,34.43232962,2,Tent,Nangarhar,3,Kama,1,Waresa Faqer  Village,6,Village,5,3,0,TRUE
+605171,70.58314439,34.43897322,0,Arbapan Bagh,Nangarhar,2,Kama,2,Arbapan,6,Village,5,2,0,TRUE
+605172,70.58896388,34.43956111,2,Arbapan Mosque,Nangarhar,2,Kama,0,Arbapan,6,Village,5,2,0,TRUE
+605173,70.60235553,34.42051421,2,Murad Ali High School,Nangarhar,3,Kama,1,Zershwee,6,Building,5,3,0,TRUE
+605174,70.58992329,34.42708015,1,Darman School,Nangarhar,2,Kama,1,Zershwee,6,Village,5,2,0,TRUE
+605175,70.70752255,34.39653425,4,Nadar Khan Momand School,Nangarhar,4,Kama,0,Gerdaw,6,Building,5,4,0,TRUE
+605176,70.71823239,34.39289809,0,Gardaaw Chardewali,Nangarhar,3,Kama,3,Gerdaw,6,Building,5,3,0,TRUE
+605177,70.60558273,34.40120079,2,Chaardewali,Nangarhar,2,Kama,0,Kandi  Village,6,Village,5,2,0,TRUE
+605178,70.60227396,34.40814376,0,Shaheed Khudai Dost School,Nangarhar,2,Kama,2,Kandi  Village,6,Village,5,2,0,TRUE
+605179,70.61037233,34.408084,0,Meer Lala Chardiwali,Nangarhar,2,Kama,2,Kandi Meer Lala,6,Village,5,2,0,TRUE
+605180,70.61298842,34.4306727,2,Hasrat Omar Faroq Mosque,Nangarhar,2,Kama,0,Koz Maidan,6,Village,5,2,0,TRUE
+605181,70.55459808,34.4283326,2,Deh Ghazi School,Nangarhar,2,Kama,0,Deh Ghazi,6,Building,5,2,0,TRUE
+605182,70.55990324,34.42250815,0,Deh Ghazi Bagh,Nangarhar,2,Kama,2,Deh Ghazi,6,Building,5,2,0,TRUE
+605183,70.554741,34.43609434,1,Daag Village Maidan,Nangarhar,2,Kama,1,Dak Village,6,Village,5,2,0,TRUE
+605184,70.57504504,34.45500817,1,Kochi Village Maidan,Nangarhar,3,Kama,2,Gach,6,Village,5,3,0,TRUE
+605185,70.64170076,34.44452124,1,Spadree Mosque,Nangarhar,3,Kama,2,Spadree,6,Building,5,3,0,TRUE
+605511,70.622426047,34.403086896,2,School,Nangarhar,3,Kama,1,Deh Taher,6,Building,5,3,0,TRUE
+605512,70.564862527,34.414383097,2,Clinic,Nangarhar,3,Kama,1,Koza Deh Ghazi,6,Building,5,3,0,TRUE
+605513,70.628792683,34.441254681,2,Molawi Ebarahim Kamawi School,Nangarhar,3,Kama,1,Dar Gul Sufla,6,Building,5,3,0,TRUE
+605514,70.65022811,34.431119083,2,Mosque,Nangarhar,3,Kama,1,Bazid Khil,6,Building,5,3,0,TRUE
+606186,70.61419035,34.60529142,3,Loy Kalay Mosque,Nangarhar,3,Kuz Kunar,0,Loy Kalay,6,Village,6,3,0,TRUE
+606187,70.61823559,34.6072381,0,Girls School,Nangarhar,2,Kuz Kunar,2,Bodyalai Kalay,6,Building,6,2,0,TRUE
+606188,70.580940409,34.56939983,2,Zargaran Village Mosque,Nangarhar,3,Kuz Kunar,1,Zargaran Village,6,Building,6,3,0,TRUE
+606189,70.55686071,34.53803413,2,Dand Mosque,Nangarhar,2,Kuz Kunar,0,Aimal Khan Village,6,Village,6,2,0,TRUE
+606190,70.59523317,34.5759802,3,Central Mosque,Nangarhar,3,Kuz Kunar,0,Khewa Center,6,Village,6,3,0,TRUE
+606191,70.56161877,34.55389766,2,Bazarak Mosque,Nangarhar,2,Kuz Kunar,0,Bazarak,6,Village,6,2,0,TRUE
+606192,70.57301611,34.57363758,3,Central Mosque,Nangarhar,3,Kuz Kunar,0,Qala Tak,6,Building,6,3,0,TRUE
+606193,70.61436179,34.58162868,2,Pachahee Mosque,Nangarhar,3,Kuz Kunar,1,Pachahee Qala,6,Village,6,3,0,TRUE
+606194,70.59095926,34.54800043,1,Kachara Mosque,Nangarhar,2,Kuz Kunar,1,Kachra,6,Building,6,2,0,TRUE
+606195,70.58648144,34.50248593,1,Koz Kotai Mosque,Nangarhar,2,Kuz Kunar,1,Koz Kotai,6,Village,6,2,0,TRUE
+606196,70.62174725,34.56328594,4,Goreek Mosque,Nangarhar,4,Kuz Kunar,0,Goreek,6,Village,6,4,0,TRUE
+606197,70.61947998,34.55671531,1,Goreek Clinic,Nangarhar,3,Kuz Kunar,2,Goreek,6,Village,6,3,0,TRUE
+606198,70.67128548,34.57190035,0,Public House,Nangarhar,2,Kuz Kunar,2,Koz Kashkot Village,6,Village,6,0,2,FALSE
+606199,70.66945243,34.57135617,2,Khaws Bagh Mosque,Nangarhar,2,Kuz Kunar,0,Koz Kashkot Village,6,Village,6,0,2,FALSE
+606201,70.71470261,34.58149101,2,Bar Kashkot School,Nangarhar,3,Kuz Kunar,1,Bar Kashkot Village,6,Building,6,3,0,TRUE
+606202,70.73016297,34.59521977,0,Sarkand Mosque,Nangarhar,2,Kuz Kunar,2,Sarkand,6,Village,6,2,0,TRUE
+606203,70.72986587,34.59634477,3,Sarkand School,Nangarhar,3,Kuz Kunar,0,Sarkand,6,Village,6,3,0,TRUE
+606204,70.54556626,34.53843899,2,Yaseen Baba Clinic,Nangarhar,3,Kuz Kunar,1,Yasee Baba,6,Building,6,3,0,TRUE
+606205,70.61823792,34.60834274,0,Poory Village Madrassa,Nangarhar,2,Kuz Kunar,2,Bodyalai Poory Village,6,Village,6,2,0,TRUE
+606206,70.53886822,34.5648411,1,Shamil Village Mosque,Nangarhar,2,Kuz Kunar,1,Shamil Village,6,Village,6,2,0,TRUE
+606207,70.61636139,34.6081579,2,Poory Village Mosque,Nangarhar,2,Kuz Kunar,0,Bodyalai Poory Village,6,Village,6,2,0,TRUE
+606208,70.5991621,34.5888547,1,Rahmat Abad Mosque,Nangarhar,2,Kuz Kunar,1,Rahmat Abad,6,Building,6,2,0,TRUE
+606209,70.5713474,34.57615245,1,Mosque,Nangarhar,2,Kuz Kunar,1,Kohna Deh,6,Building,6,2,0,TRUE
+606210,70.56601142,34.57948812,0,Boys' School,Nangarhar,2,Kuz Kunar,2,Qala Tak,6,Building,6,2,0,TRUE
+606211,70.56935097,34.55606976,0,Bazarak Clinic,Nangarhar,2,Kuz Kunar,2,Bazarak,6,Building,6,2,0,TRUE
+606212,70.59670699,34.57752992,0,Khewa Central Clinic,Nangarhar,2,Kuz Kunar,2,Markazi Khewa,6,Building,6,2,0,TRUE
+606213,70.56211126,34.54001647,0,Girls School,Nangarhar,2,Kuz Kunar,2,Shekhaan,6,Building,6,2,0,TRUE
+606214,70.62753984,34.58649773,1,Islam Poor Village Mosque,Nangarhar,2,Kuz Kunar,1,Islampoor,6,Building,6,2,0,TRUE
+606515,70.530009643,34.563740734,2,Gambiri School,Nangarhar,3,Kuz Kunar,1,Gambiri,6,Building,6,3,0,TRUE
+607128,70.57640532,34.25735323,5,Hesar-E-Shahee Mosque,Nangarhar,5,Rodat,0,Hesar-E-Shahee,6,Building,7,5,0,TRUE
+607129,70.579842427,34.251246363,0,Baaghcha Mosque,Nangarhar,4,Rodat,4,Kankarak,6,Village,7,4,0,TRUE
+607130,70.51438261,34.22299788,2,Meerjay Qala Mosque,Nangarhar,2,Rodat,0,Meerjay Village,6,Building,7,2,0,TRUE
+607131,70.62358132,34.31371701,3,Mosque,Nangarhar,4,Rodat,1,Kabul Camp,6,Building,7,4,0,TRUE
+607132,70.52043629,34.22283691,0,Zaara Vvillage Mosque,Nangarhar,2,Rodat,2,Meerjay Village,6,Village,7,2,0,TRUE
+607133,70.49033252,34.20967133,2,Mazeena Mosque,Nangarhar,3,Rodat,1,Mazeena,6,Village,7,3,0,TRUE
+607134,70.47448123,34.25527001,2,Zakhel Primary School,Nangarhar,3,Rodat,1,Zakhel,6,Village,7,3,0,TRUE
+607135,70.5014455,34.21373632,2,Hisarak High School,Nangarhar,3,Rodat,1,Hisarak Village,6,Village,7,3,0,TRUE
+607136,70.49906402,34.26837675,2,Kaan High School,Nangarhar,2,Rodat,0,Khan Village,6,Village,7,0,2,FALSE
+607137,70.49020182,34.26527727,0,Kaan Clinic,Nangarhar,2,Rodat,2,Khan Village,6,Village,7,0,2,FALSE
+607138,70.53136896,34.24595259,2,Roghano Girls' & Boys' School,Nangarhar,3,Rodat,1,Roghano,6,Building,7,3,0,TRUE
+607139,70.64133993,34.25609108,2,Barogaray Mosque,Nangarhar,2,Rodat,0,Barogaray,6,Village,7,2,0,TRUE
+607140,70.635419316,34.258085695,0,Barogaray Girls School,Nangarhar,2,Rodat,2,Barogaray,6,Building,7,2,0,TRUE
+607141,70.63287542,34.25829837,3,Baroo High School,Nangarhar,3,Rodat,0,Baroo,6,Building,7,3,0,TRUE
+607142,70.632974885,34.257729686,0,Girls School,Nangarhar,2,Rodat,2,Baroo,6,Building,7,2,0,TRUE
+607143,70.52432349,34.29199968,2,Katarghey Mosque,Nangarhar,2,Rodat,0,Katarghey,6,Building,7,2,0,TRUE
+607144,70.52398836,34.2947625,0,Open Space,Nangarhar,2,Rodat,2,Katarghey,6,Village,7,2,0,TRUE
+607145,70.51245226,34.2386694,2,Kadee Mosque,Nangarhar,2,Rodat,0,Kadee,6,Village,7,2,0,TRUE
+607146,70.51038949,34.23863968,0,Chenar Kadi Mosque,Nangarhar,2,Rodat,2,Kadee,6,Village,7,2,0,TRUE
+607148,70.56819905,34.25647954,3,Ahdad Primary School,Nangarhar,5,Rodat,2,Hesarshahee,6,Building,7,5,0,TRUE
+608276,70.1716778,34.2061295,6,Jihadi Boys High School,Nangarhar,6,Khugyani,0,Wazir Ahmad Khel Village,6,Village,8,3,3,TRUE
+608277,70.17337097,34.20894938,0,Jihadi Girls High School,Nangarhar,3,Khugyani,3,Wazir Ahmad Khel Village,6,Village,8,2,1,TRUE
+608278,70.1825022,34.2648328,2,Malak Yaar Hotak School,Nangarhar,3,Khugyani,1,Kaja Zor Bazaar,6,Building,8,3,0,TRUE
+608279,70.17849165,34.19977816,1,Abko Madrassa,Nangarhar,2,Khugyani,1,Peera Khel,6,Building,8,0,2,FALSE
+608280,70.18183201,34.22032949,2,Hakeem Abad Mosque,Nangarhar,3,Khugyani,1,Hakeem Abad,6,Village,8,2,1,TRUE
+608281,70.1441467,34.166722,2,Sangani Primary School,Nangarhar,3,Khugyani,1,Sangani,6,Village,8,0,3,FALSE
+608282,70.18978361,34.25515452,3,Nawi Bazaar Mosque,Nangarhar,3,Khugyani,0,Kaja Khogyany,6,Building,8,3,0,TRUE
+608283,70.19015844,34.25227636,2,Kaja Primary School,Nangarhar,3,Khugyani,1,Kaja Nawi Bazaar,6,Building,8,3,0,TRUE
+608284,70.17181719,34.25040981,2,Qilgho High School,Nangarhar,3,Khugyani,1,Qilgho,6,Building,8,3,0,TRUE
+608285,70.21476743,34.27750285,0,Bar Bahar High School,Nangarhar,3,Khugyani,3,Bar Bahar,6,Village,8,3,0,TRUE
+608286,70.20839579,34.28609326,3,Bar Bahar Maidan,Nangarhar,3,Khugyani,0,Bar Bahar,6,Village,8,2,1,TRUE
+608287,70.20491209,34.28827793,3,Koz Bahar High School,Nangarhar,4,Khugyani,1,Koz Bahar,6,Building,8,4,0,TRUE
+608288,70.19536774,34.30446616,2,Lokhay Maktab,Nangarhar,3,Khugyani,1,Lokhay,6,Building,8,3,0,TRUE
+608291,70.17620808,34.33324389,3,Chamtala Camp Clinic,Nangarhar,4,Khugyani,1,Chamtala Clinic,6,Village,8,4,0,TRUE
+608295,70.10030323,34.2863532,4,Ghulam Haidar Khan High School,Nangarhar,6,Khugyani,2,Memla,6,Building,8,0,6,FALSE
+608516,70.189873303,34.347362086,2,High School,Nangarhar,3,Khugyani,1,Chemtala,6,Building,8,3,0,TRUE
+609438,70.710405405,34.316214853,4,Barikaab School,Nangarhar,6,Bati Kot,2,Barikaab,6,District,9,6,0,TRUE
+609439,70.73978483,34.33586004,2,Mashwanai Clinic,Nangarhar,3,Bati Kot,1,Mashwanai,6,Village,9,0,3,FALSE
+609440,70.74259916,34.25723868,3,Lortai Mosque,Nangarhar,5,Bati Kot,2,Lortai,6,Building,9,5,0,TRUE
+609441,70.70985382,34.25910103,1,Jaame Mosque,Nangarhar,2,Bati Kot,1,Farm 4,6,Building,9,2,0,TRUE
+609442,70.71495063,34.2537639,2,Garatai Girls' School,Nangarhar,3,Bati Kot,1,Dagai Village,6,Building,9,3,0,TRUE
+609445,70.8221383,34.28522767,2,Anbar Khana Clinic,Nangarhar,3,Bati Kot,1,Anbar Khana,6,Village,9,0,3,FALSE
+609446,70.79654544,34.31081315,3,Takya School,Nangarhar,5,Bati Kot,2,Takya,6,Village,9,0,5,FALSE
+609448,70.77232554,34.32209253,2,Chahardi High School,Nangarhar,3,Bati Kot,1,Chahardi Village,6,Village,9,0,3,FALSE
+609449,70.77015988,34.31130997,2,Gandyani Mosque,Nangarhar,3,Bati Kot,1,Gandyani,6,Village,9,3,0,TRUE
+609450,70.76716649,34.31744358,2,Ziarat Mosque,Nangarhar,2,Bati Kot,0,Ghazi Abad,6,Village,9,0,2,FALSE
+609451,70.76914192,34.31579437,0,Ziarat Mosque Maidan,Nangarhar,2,Bati Kot,2,Ghazi Abad,6,Village,9,2,0,TRUE
+609452,70.73381737,34.26409305,2,Sepay Village Mosque,Nangarhar,3,Bati Kot,1,Sepay Village,6,Building,9,3,0,TRUE
+609453,70.73504652,34.26204085,0,Sofyano Village Mosque,Nangarhar,3,Bati Kot,3,Sofyano Village,6,Building,9,3,0,TRUE
+609455,70.74006967,34.23989202,2,Girls High School,Nangarhar,3,Bati Kot,1,Hajiyano Village,6,Building,9,3,0,TRUE
+609456,70.71941108,34.35577015,2,Boys High School,Nangarhar,3,Bati Kot,1,Lacha Poor,6,Village,9,0,3,FALSE
+609457,70.74114275,34.26714615,2,Bati Kot School,Nangarhar,3,Bati Kot,1,Shodyanai,6,Building,9,3,0,TRUE
+609459,70.707782968,34.303652452,1,Kochai Banda Mosque,Nangarhar,2,Bati Kot,1,Paas Barikaab,6,Village,9,2,0,TRUE
+609460,70.76938672,34.32102152,1,Lalma Bajgai Dera,Nangarhar,2,Bati Kot,1,Chardehi,6,Village,9,2,0,TRUE
+609461,70.7725,34.2625,1,Speen Khowar Mosque,Nangarhar,2,Bati Kot,1,Speen Khowar,6,Village,9,2,0,TRUE
+610327,70.46303899,34.11832727,4,Deh Bala High School,Nangarhar,6,Deh Bala,2,Kotwal,6,Building,10,6,0,TRUE
+610330,70.4765857,34.1904788,2,Shpola Boys High School,Nangarhar,3,Deh Bala,1,Shpola,6,Building,10,0,3,FALSE
+610331,70.46246523,34.16770104,1,Yaaghiband Primary School,Nangarhar,2,Deh Bala,1,Yaaghiband,6,Village,10,0,2,FALSE
+610332,70.47395218,34.12830101,2,Ghokht Maidan,Nangarhar,3,Deh Bala,1,Ghokht Dara,6,Village,10,0,3,FALSE
+611306,70.27504454,34.19160164,0,Morkay Primary School,Nangarhar,3,Pachir Wagam,3,Morkay,6,Village,11,3,0,TRUE
+611307,70.25994309,34.17940081,2,Pacheer Agam School,Nangarhar,2,Pachir Wagam,0,Morkay,6,Village,11,2,0,TRUE
+611308,70.297044861,34.239210488,0,Koz Sabr Chardewali,Nangarhar,3,Pachir Wagam,3,Koz Sabr,6,Building,11,3,0,TRUE
+611309,70.29450915,34.2184851,3,Koz Sabr Mosque,Nangarhar,3,Pachir Wagam,0,Koz Sabr,6,Building,11,3,0,TRUE
+611310,70.27354504,34.20534809,2,Veterinary Clinic,Nangarhar,2,Pachir Wagam,0,Landi Khel,6,Village,11,2,0,TRUE
+611311,70.27025198,34.2008652,0,Landi Khel School,Nangarhar,2,Pachir Wagam,2,Landi Khel,6,Building,11,2,0,TRUE
+611315,70.295,34.11472222,3,Pacheer Clinic,Nangarhar,3,Pachir Wagam,0,Paas Pacheer,6,Village,11,3,0,TRUE
+611317,70.27783956,34.19472182,2,Jaame Mosque,Nangarhar,3,Pachir Wagam,1,Zmarkhel,6,Village,11,3,0,TRUE
+612215,70.6003787,34.62445392,3,Koz Kalay Mosque,Nangarhar,5,Darah-E-Noor,2,Amla,6,Village,12,5,0,TRUE
+612216,70.59612898,34.6314471,2,Girls Secondary School,Nangarhar,3,Darah-E-Noor,1,Amla,6,Building,12,3,0,TRUE
+612217,70.59953018,34.63518922,2,Bar Kaley Mosque,Nangarhar,3,Darah-E-Noor,1,Daaga,6,Village,12,3,0,TRUE
+612218,70.59000763,34.65287115,0,Girls School,Nangarhar,2,Darah-E-Noor,2,Qalay Shahee,6,Building,12,2,0,TRUE
+612219,70.59217245,34.64718815,3,Qala-E- Shahee Boys High School,Nangarhar,3,Darah-E-Noor,0,Qalay Shahee,6,Building,12,3,0,TRUE
+612220,70.5460102,34.67604153,1,Sarwarr Mosque,Nangarhar,2,Darah-E-Noor,1,Sarwarr,6,Village,12,2,0,TRUE
+612221,70.57601007,34.695285,2,Shaheed Mahmood Shah Secondary School,Nangarhar,3,Darah-E-Noor,1,Safar Kala,6,Building,12,3,0,TRUE
+612222,70.61987312,34.72050466,1,Lama Tak Mosque,Nangarhar,2,Darah-E-Noor,1,Lama Tak,6,Village,12,2,0,TRUE
+612223,70.60873626,34.70155821,2,Bamba Kot Mosque,Nangarhar,3,Darah-E-Noor,1,Bama Kot,6,Village,12,3,0,TRUE
+612224,70.59578718,34.68390477,2,Hassan And Sarwar Shah Dera,Nangarhar,3,Darah-E-Noor,1,Shokalay,6,Village,12,3,0,TRUE
+612225,70.60552423,34.69332967,1,Umar Qala Mosque,Nangarhar,2,Darah-E-Noor,1,Omar Qala,6,Village,12,2,0,TRUE
+612226,70.58401698,34.67692482,2,Barkot School,Nangarhar,2,Darah-E-Noor,0,Kashmond Kala,6,Building,12,2,0,TRUE
+612227,70.58511691,34.68203571,1,Kashmond  Clinic,Nangarhar,3,Darah-E-Noor,2,Kashmond Kala,6,Building,12,3,0,TRUE
+612228,70.61672871,34.71195918,1,Sarkalak Mosque,Nangarhar,2,Darah-E-Noor,1,Sargkalak,6,Village,12,2,0,TRUE
+612229,70.60615799,34.73771237,1,Shemol Maidan,Nangarhar,3,Darah-E-Noor,2,Shemol,6,Village,12,3,0,TRUE
+612230,70.55333333,34.72805555,2,Waygal Maidan,Nangarhar,3,Darah-E-Noor,1,Waygal,6,Village,12,3,0,TRUE
+612231,70.62685163,34.71913591,1,Majangdol Maidan,Nangarhar,2,Darah-E-Noor,1,Majangdol,6,Village,12,2,0,TRUE
+612232,70.63013478,34.72295044,1,Watran School,Nangarhar,2,Darah-E-Noor,1,Watran,6,Village,12,2,0,TRUE
+612233,70.62268166,34.72081416,1,Areeman Mosque,Nangarhar,2,Darah-E-Noor,1,Areeman,6,District,12,2,0,TRUE
+612234,70.62356601,34.71500179,0,Sotan Maidan,Nangarhar,2,Darah-E-Noor,2,Sotan,6,Village,12,2,0,TRUE
+612235,70.62113009,34.71516241,3,Sotan Mosque,Nangarhar,3,Darah-E-Noor,0,Sotan,6,Building,12,3,0,TRUE
+612236,70.56439088,34.70668407,2,Odarak Maidan,Nangarhar,2,Darah-E-Noor,0,Odrak,6,Village,12,2,0,TRUE
+612237,70.56890507,34.70436043,0,Odarak School,Nangarhar,2,Darah-E-Noor,2,Odrak,6,Building,12,2,0,TRUE
+613338,70.596097199,34.134041648,0,Poorshah Khel Boys High School,Nangarhar,3,Kot,3,Laghorjay Village,6,Village,13,3,0,TRUE
+613339,70.55407158,34.12281481,2,Poorshah Khel Girls High School,Nangarhar,3,Kot,1,Laghorjay Village,6,Building,13,3,0,TRUE
+613343,70.60007097,34.14550959,2,Sayed Ahmad Khel Secondary School,Nangarhar,3,Kot,1,Sayed Ahmad Khel,6,Building,13,3,0,TRUE
+613344,70.6122661,34.15632949,3,Dwani Village Big Mosque,Nangarhar,3,Kot,0,Dwanai Village,6,Village,13,3,0,TRUE
+613345,70.60393146,34.1602237,0,Dwani Village Maidan,Nangarhar,2,Kot,2,Dwanai Village,6,Village,13,2,0,TRUE
+613346,70.6238452,34.17338764,4,Ata Khan Big Mosque,Nangarhar,4,Kot,0,Ata Khan,6,Village,13,4,0,TRUE
+613347,70.62096689,34.17217631,0,Ata Khan Maidan,Nangarhar,2,Kot,2,Ata Khan,6,Village,13,2,0,TRUE
+613348,70.64572348,34.19794686,2,Kot High School,Nangarhar,3,Kot,1,Jaba Village,6,Building,13,3,0,TRUE
+613349,70.65694346,34.20261339,2,Haidar Khani Mosque,Nangarhar,2,Kot,0,Haidar Khani,6,Village,13,2,0,TRUE
+613350,70.659586,34.20398868,0,Open Space,Nangarhar,3,Kot,3,Haidar Khani Village,6,Village,13,3,0,TRUE
+613351,70.6701433,34.24655658,2,Trelay Zawar  Mosque,Nangarhar,2,Kot,0,Trelay Village,6,Village,13,2,0,TRUE
+613352,70.67543168,34.24002364,0,Trelay Maidan,Nangarhar,2,Kot,2,Trelay Village,6,Village,13,2,0,TRUE
+613517,70.524061103,34.089318682,2,School,Nangarhar,3,Kot,1,Tangi Village,6,Village,13,3,0,TRUE
+614484,70.74896103,34.36931434,3,Sarband Primary School,Nangarhar,4,Goshta,1,Sarband Village,6,Building,14,4,0,TRUE
+614485,70.76661193,34.36750594,0,Koda Khel Mosque,Nangarhar,2,Goshta,2,Arkhai,6,Village,14,2,0,TRUE
+614486,70.76857975,34.3669206,2,Arkhai Mosque,Nangarhar,2,Goshta,0,Arkhai,6,Village,14,2,0,TRUE
+614487,70.79269937,34.35594179,3,Hameed Momand School,Nangarhar,3,Goshta,0,Goshta,6,Building,14,3,0,TRUE
+614488,70.78168177,34.35229229,0,Goshta Girls Secondary School,Nangarhar,2,Goshta,2,Goshta,6,Village,14,2,0,TRUE
+614489,70.79702167,34.34805464,0,Mula Rahmat Baba Girls High School,Nangarhar,2,Goshta,2,Khonero Village,6,Village,14,2,0,TRUE
+614490,70.79896798,34.34830071,2,Malak Suhail Hujra,Nangarhar,2,Goshta,0,Choorkhel,6,Village,14,2,0,TRUE
+614491,70.81273918,34.34276272,0,Warsak Mosque,Nangarhar,2,Goshta,2,Warsak,6,Village,14,2,0,TRUE
+614492,70.81022445,34.33990139,2,Warsak School,Nangarhar,2,Goshta,0,Warsak,6,Village,14,2,0,TRUE
+614493,70.80254086,34.34616604,4,Yaqoob Khel Mosque,Nangarhar,5,Goshta,1,Yaqoob Khel,6,Village,14,5,0,TRUE
+614494,70.8024589,34.35119562,0,Habib Khan House,Nangarhar,2,Goshta,2,Dor Khel,6,Village,14,0,2,FALSE
+614495,70.802447,34.35120751,2,Dor Khel Maidan,Nangarhar,2,Goshta,0,Dor Khel,6,Village,14,2,0,TRUE
+614496,70.91388217,34.49427979,2,Shah Lala Maidan,Nangarhar,2,Goshta,0,Khogakhel,6,Village,14,2,0,TRUE
+614497,70.91389287,34.49426908,0,Malem Ghani House,Nangarhar,2,Goshta,2,Khogakhel,6,Village,14,2,0,TRUE
+614498,70.92009011,34.47952462,2,Open Space,Nangarhar,2,Goshta,0,Ali Khel Village,6,Village,14,2,0,TRUE
+614499,70.92009011,34.47952462,0,Private House,Nangarhar,2,Goshta,2,Ali Khel Village,6,Village,14,2,0,TRUE
+614500,70.836110723,34.428332818,1,Mama Khel School,Nangarhar,2,Goshta,1,Mama Khel,6,Building,14,2,0,TRUE
+614501,70.830876,34.31921761,1,Ragha Village Mosque,Nangarhar,2,Goshta,1,Ragha Village,6,Village,14,2,0,TRUE
+614518,70.798976177,34.343970655,2,Yahqub Khil Mosque,Nangarhar,3,Goshta,1,Yaqob Khil,6,Building,14,3,0,TRUE
+615355,70.694153828,34.096795171,3,Koshtal Mainz Village Mosque,Nangarhar,3,Achin,0,Koshtal,6,Village,15,3,0,TRUE
+615356,70.69135103,34.09332612,0,Wach Kotyo & Dawlatkhelo Mosque,Nangarhar,3,Achin,3,Koshtal,6,Village,15,3,0,TRUE
+615357,70.73713687,34.12792111,1,Khadi Ragha Khawga Khel Mosque,Nangarhar,2,Achin,1,Khadi Ragha,6,Village,15,2,0,TRUE
+615362,70.758938,34.11713102,3,Perokhelo Tapa Mosque,Nangarhar,4,Achin,1,Zordeh Road,6,Village,15,4,0,TRUE
+615363,70.73537675,34.13147321,1,Deh Sarak Kuhna High School,Nangarhar,2,Achin,1,Shekh Mal Khel,6,Village,15,2,0,TRUE
+615366,70.69183802,34.16972233,2,Chehl Gaze High School,Nangarhar,3,Achin,1,Chehl Gaze,6,Village,15,3,0,TRUE
+615367,70.64857316,34.05610798,2,Pekhe Dokan Village Mosque,Nangarhar,2,Achin,0,Dokan Village,6,Village,15,2,0,TRUE
+615368,70.64513156,34.05708467,0,Gaawi Village Mosque,Nangarhar,4,Achin,4,Gaawi Village,6,Village,15,4,0,TRUE
+615369,70.68756248,34.19277871,2,Lokhe Bagh,Nangarhar,3,Achin,1,Lokhay,6,Building,15,3,0,TRUE
+615370,70.75034078,34.13778136,2,Khowar Akhonzadagan Jaame Mosque,Nangarhar,3,Achin,1,Pekha,6,Village,15,3,0,TRUE
+615371,70.70961324,34.19882951,1,Maroof Cheena Jaame Mosque,Nangarhar,2,Achin,1,Maroof Cheena,6,Building,15,2,0,TRUE
+615375,70.6901128,34.13027579,2,Medanak Sadeq Hujra,Nangarhar,3,Achin,1,Medanak,6,Building,15,3,0,TRUE
+615380,70.691613637,34.05538592,2,Bar Akbar Khel Mosque,Nangarhar,2,Achin,0,Bar Akbar Khel,6,Village,15,2,0,TRUE
+615381,70.7013445,34.0499987,0,Bar Akbar Khel Miyaji Mosque,Nangarhar,2,Achin,2,Bar Abdul Khel,6,Village,15,2,0,TRUE
+615382,70.7167134,34.09181181,3,Open Space,Nangarhar,3,Achin,0,Garoko,6,District,15,3,0,TRUE
+615383,71.043203701,34.241485828,0,Garoko Ziarat Madrassa,Nangarhar,2,Achin,2,Garoko,6,Village,15,2,0,TRUE
+615386,70.70803737,34.08188948,2,Milano Open Space,Nangarhar,2,Achin,0,Abdul Khel Cheena,6,Village,15,2,0,TRUE
+615387,70.71197018,34.08247542,0,Mirano Village Mosque,Nangarhar,2,Achin,2,Abdul Khel Cheena,6,Village,15,2,0,TRUE
+615388,70.70772818,34.12470217,1,Kahee High School,Nangarhar,2,Achin,1,Sra Qala,6,Building,15,2,0,TRUE
+615391,70.69558918,34.08477165,1,Shaheed Gul Asghar High School,Nangarhar,2,Achin,1,Abdul Khel Bazaar,6,Village,15,2,0,TRUE
+615519,70.696498721,34.106695422,2,Malik Gul Muhammad House,Nangarhar,3,Achin,1,Sanduq Village,6,Village,15,3,0,TRUE
+616420,70.79391183,34.22230073,4,26 Viyalai High School,Nangarhar,4,Shinwar,0,26 Viyala,6,Village,16,4,0,TRUE
+616421,70.78259511,34.23009309,0,Hazrat Bilal Mosque,Nangarhar,3,Shinwar,3,25 Viyala,6,Village,16,3,0,TRUE
+616422,70.8294856,34.22042249,0,Hayat Khan Mosque,Nangarhar,3,Shinwar,3,27 Viyala,6,Village,16,3,0,TRUE
+616423,70.84979792,34.23551517,3,Qaryan Mosque,Nangarhar,3,Shinwar,0,27 Viyala,6,Village,16,3,0,TRUE
+616424,70.8277867,34.1879008,3,Milano Mosque,Nangarhar,3,Shinwar,0,Katelay,6,Village,16,3,0,TRUE
+616425,70.82417499,34.18753056,0,Kangalan Mosque,Nangarhar,3,Shinwar,3,Katelay,6,Village,16,3,0,TRUE
+616426,70.81549116,34.21979367,0,Hospital Mosque,Nangarhar,3,Shinwar,3,26 Viyala,6,Village,16,3,0,TRUE
+616428,70.811266644,34.192262649,3,Daaga School,Nangarhar,5,Shinwar,2,Ghani Khel,6,Building,16,5,0,TRUE
+616429,70.79719643,34.19998276,3,Agricultural Office,Nangarhar,3,Shinwar,0,Sher Garh,6,Building,16,3,0,TRUE
+616430,70.79787441,34.19862025,0,Alfathi High School,Nangarhar,3,Shinwar,3,Sher Garh,6,Building,16,3,0,TRUE
+616431,70.72381802,34.17813824,0,Allah Mohammad Mosque,Nangarhar,2,Shinwar,2,Siya Chob,6,Village,16,0,2,FALSE
+616432,70.7264612,34.17707819,3,Siya Chob Mosque,Nangarhar,3,Shinwar,0,Siya Chob,6,Village,16,0,3,FALSE
+616434,70.76671418,34.20869628,2,Sray Mosque,Nangarhar,4,Shinwar,2,Golayee Village,6,Village,16,4,0,TRUE
+616435,70.79665438,34.20061661,3,Social Council Office,Nangarhar,3,Shinwar,0,Sher Garh,6,Building,16,3,0,TRUE
+616436,70.79574478,34.19355983,0,Hazrat Bilal Madrassa,Nangarhar,3,Shinwar,3,Sher Garh,6,Building,16,3,0,TRUE
+616437,70.84934737,34.21815028,4,28 Viyala School,Nangarhar,5,Shinwar,1,28 Viyala,6,Building,16,5,0,TRUE
+616520,70.808571947,34.249982773,2,Marko High School,Nangarhar,3,Shinwar,1,Marko,6,Building,16,3,0,TRUE
+617462,70.89086265,34.22176719,3,Amaan Village Speen Mosque,Nangarhar,4,Muhmand Dara,1,Damaan Village,6,Village,17,4,0,TRUE
+617463,71.04422899,34.20087095,4,Sulh Azadi Commerce High School,Nangarhar,4,Muhmand Dara,0,Loy Daka,6,Building,17,4,0,TRUE
+617464,71.05441768,34.21364059,1,Daka High School,Nangarhar,4,Muhmand Dara,3,Loy Daka,6,Building,17,4,0,TRUE
+617465,71.11896646,34.22852849,1,Kama Daka Mosque,Nangarhar,3,Muhmand Dara,2,Kama Daka,6,Village,17,3,0,TRUE
+617467,70.98901502,34.23250286,2,Otmanzai  Mosque,Nangarhar,4,Muhmand Dara,2,Gardee Otmanzai,6,Village,17,4,0,TRUE
+617468,70.96455148,34.23801508,5,Hazar Naaw Mosque,Nangarhar,5,Muhmand Dara,0,Hazar Naaw Village,6,Village,17,5,0,TRUE
+617469,70.91447847,34.23740308,1,Hazar Naaw  High School,Nangarhar,4,Muhmand Dara,3,Hazar Naaw Village,6,Building,17,4,0,TRUE
+617470,70.89947176,34.23301786,2,Hadeere Village Mosque,Nangarhar,3,Muhmand Dara,1,Hadeere Village,6,Village,17,3,0,TRUE
+617472,70.96880769,34.23503825,2,Gardee Ghows High  School,Nangarhar,4,Muhmand Dara,2,Garde Ghows,6,Building,17,4,0,TRUE
+617474,70.88198936,34.24384156,2,Aimal Khan High School,Nangarhar,6,Muhmand Dara,4,Paas Basool,6,Building,17,6,0,TRUE
+617475,70.93392389,34.23828044,2,Ghazgai Mosque,Nangarhar,2,Muhmand Dara,0,Ghazgai,6,Village,17,2,0,TRUE
+617476,70.93502362,34.23666412,0,Ghazgai High School,Nangarhar,2,Muhmand Dara,2,Ghazgai,6,Building,17,2,0,TRUE
+617477,70.95458821,34.23166864,1,Kolali Village Mosque,Nangarhar,2,Muhmand Dara,1,Kolali Village,6,Village,17,2,0,TRUE
+617478,70.86388177,34.24062593,1,Ali Jan Qala Mosque,Nangarhar,2,Muhmand Dara,1,Ali Jan Qala,6,Village,17,2,0,TRUE
+617479,70.86115583,34.25677308,2,Landy Basool Boys High School,Nangarhar,2,Muhmand Dara,0,Landy Basool,6,Village,17,0,2,FALSE
+617480,70.86142762,34.25637187,0,Basool Girls High School,Nangarhar,2,Muhmand Dara,2,Landy Basool,6,Village,17,0,2,FALSE
+617481,70.86568237,34.26803959,1,Belay High School,Nangarhar,2,Muhmand Dara,1,Belay Village,6,Building,17,0,2,FALSE
+617482,70.90781928,34.19515456,1,Saagai Speen Mosque,Nangarhar,2,Muhmand Dara,1,Saagai,6,Village,17,2,0,TRUE
+617483,71.09394423,34.12164985,3,Turkham Clinic,Nangarhar,5,Muhmand Dara,2,Torkham,6,Village,17,5,0,TRUE
+618502,71.04310101,34.23152656,5,Sher Abad High School,Nangarhar,7,Lalpoor,2,Lal Poora,6,Building,18,7,0,TRUE
+618503,71.042659,34.239255,4,Eid Gah Mosque,Nangarhar,6,Lalpoor,2,Malak Mohammad Omar Village,6,Building,18,6,0,TRUE
+618504,70.96236587,34.26818253,3,Gul Daag Village,Nangarhar,5,Lalpoor,2,Gul Daag Village,6,Building,18,5,0,TRUE
+618505,70.92561178,34.2811803,3,Cheknor High School,Nangarhar,5,Lalpoor,2,Cheknor Village,6,Building,18,5,0,TRUE
+619238,69.95073325,34.26154515,3,Toto High School,Nangarhar,5,Sher Zad,2,Luqman Khel,6,Village,19,5,0,TRUE
+619243,69.99698577,34.24672994,0,Mama Khel High School,Nangarhar,3,Sher Zad,3,Mama Khel,6,Village,19,3,0,TRUE
+619244,69.99665859,34.24721178,4,Mama Khel Clinic,Nangarhar,4,Sher Zad,0,Mama Khel,6,Village,19,4,0,TRUE
+620400,70.80951108,34.15132149,3,Nasrat Mosque,Nangarhar,4,Nazyan,1,Landai Village,6,Village,20,4,0,TRUE
+620402,70.79602604,34.0716142,2,Tarkhai Primary School,Nangarhar,3,Nazyan,1,Morchal Village,6,Village,20,3,0,TRUE
+620403,70.801014,34.06765394,2,Jay Sar Mosque,Nangarhar,3,Nazyan,1,Morchal Village,6,Village,20,3,0,TRUE
+620404,70.79450431,34.07863314,0,Morchal Village Maidan,Nangarhar,3,Nazyan,3,Morchal Village,6,Village,20,3,0,TRUE
+620408,70.80476175,34.11555897,2,Speen Mosque Maidan,Nangarhar,3,Nazyan,1,Sarobay Menz,6,Village,20,3,0,TRUE
+620409,70.81517996,34.12586273,2,Akhond Kaka Mosque,Nangarhar,3,Nazyan,1,Sarobay,6,Village,20,3,0,TRUE
+620410,70.80983796,34.12621724,3,Sarobay High School,Nangarhar,3,Nazyan,0,Sarobay,6,Building,20,3,0,TRUE
+620411,70.81058897,34.12724331,0,Sarobay Consultancy Office,Nangarhar,3,Nazyan,3,Sarobay,6,Village,20,3,0,TRUE
+621254,69.765559,34.3311088,0,Mohammadi Mosque,Nangarhar,3,Hesarak,3,Mohammadi Mosque,6,Village,21,0,3,FALSE
+621255,69.7689791,34.30674097,0,Zareef Khel School,Nangarhar,2,Hesarak,2,Zareef Khel,6,Village,21,0,2,FALSE
+621256,69.76901479,34.3081389,2,Open Space,Nangarhar,2,Hesarak,0,Zareef Khel,6,Village,21,0,2,FALSE
+621261,69.806385,34.297777,3,Raagha Mosque,Nangarhar,3,Hesarak,0,Ragha Village,6,Village,21,3,0,TRUE
+621262,69.806109,34.29722,0,Raagha School,Nangarhar,3,Hesarak,3,Ragha Village,6,Village,21,3,0,TRUE
+621265,69.85600375,34.31325682,0,Open Space,Nangarhar,3,Hesarak,3,Farzeena Village,6,Village,21,0,3,FALSE
+622412,70.96479851,34.07527803,3,Sra Gata Secondary School,Nangarhar,4,Dur Baba,1,Sra Gata,6,Village,22,4,0,TRUE
+622413,70.92893688,34.03917388,3,Ziarat Village Mosque,Nangarhar,5,Dur Baba,2,Ziarat Kaley Mosque,6,Village,22,5,0,TRUE
+622414,70.89739254,34.05517209,2,Soor Kandaw Daag,Nangarhar,3,Dur Baba,1,Soor Kandaw Daag,6,Village,22,3,0,TRUE
+622415,71.024484953,34.07127977,2,Sobay Mosque,Nangarhar,3,Dur Baba,1,Sobay,6,Village,22,3,0,TRUE
+622416,70.91755134,34.05212393,2,Shagay Dera,Nangarhar,3,Dur Baba,1,Shagay,6,Village,22,3,0,TRUE
+622417,71.025798,34.06823,2,Sosobi School,Nangarhar,3,Dur Baba,1,Sasobi,6,Village,22,3,0,TRUE
+622418,70.91111111,34.0743,3,Sholgar School,Nangarhar,3,Dur Baba,0,Sholgar School,6,Building,22,3,0,TRUE
+622419,70.91175378,34.07457911,0,Sholagr Mosque,Nangarhar,2,Dur Baba,2,Sholgar Mosque,6,Village,22,2,0,TRUE
+622507,71.03454798,34.14172874,2,Guroko Village Mosque,Nangarhar,3,Dur Baba,1,Kaley Garooko,6,Village,22,3,0,TRUE
+622521,70.933099367,34.100566734,2,Anjeer Village Secondary School,Nangarhar,3,Dur Baba,1,Ageer Village,6,Building,22,3,0,TRUE
+701001,70.20948154,34.66163463,13,Rokhan High School,Laghman,13,Mehtarlam,0,Mahtarlam,7,Building,1,16,1,TRUE
+701002,70.20605107,34.6630279,0,Mastory High School,Laghman,6,Mehtarlam,6,Mahtarlam,7,Building,1,6,0,TRUE
+701003,70.21160382,34.67417196,4,Shahr-E-Naw Exprimental School,Laghman,5,Mehtarlam,1,Mahtarlam,7,Building,1,9,0,TRUE
+701004,70.2054233,34.67248201,4,Public Health Hospital,Laghman,6,Mehtarlam,2,Mahtarlam,7,Building,1,7,0,TRUE
+701005,70.21744497,34.66112422,5,Gameen Village Mosque And School,Laghman,7,Mehtarlam,2,Gameen,7,Building,1,9,0,TRUE
+701006,70.21218056,34.64610277,3,Tergarayo Mosque,Laghman,4,Mehtarlam,1,Targaray,7,Village,1,4,0,TRUE
+701007,70.21509089,34.6240579,3,Chardhi School,Laghman,4,Mehtarlam,1,Chardhi,7,Building,1,4,0,TRUE
+701008,70.21472418,34.59965585,3,Haidarkhani Kalkot School,Laghman,4,Mehtarlam,1,Haidar Khan,7,Building,1,4,0,TRUE
+701009,70.23909379,34.6339062,3,Shamangal Mosque,Laghman,4,Mehtarlam,1,Shamangal,7,Building,1,4,0,TRUE
+701010,70.2443954,34.66607717,3,Shamatyo Mosque,Laghman,5,Mehtarlam,2,Shamtay,7,Building,1,5,0,TRUE
+701013,70.22164583,34.67643376,4,Chalmatayo School,Laghman,5,Mehtarlam,1,Chalmatayo Village,7,Village,1,5,0,TRUE
+701014,70.22440775,34.68562437,4,Se Sadi Boys & Girls School,Laghman,5,Mehtarlam,1,Palawan Baba Se Sadda,7,Building,1,6,0,TRUE
+701015,70.22951286,34.69599272,2,Harmal Boys & Girls School,Laghman,4,Mehtarlam,2,Harmal,7,Building,1,4,0,TRUE
+701016,70.24160233,34.71092282,3,Katal Girls School,Laghman,5,Mehtarlam,2,Katal,7,Building,1,5,0,TRUE
+701017,70.26237716,34.72699774,2,Shaheed Mawlawi Habib Rahman High School,Laghman,3,Mehtarlam,1,Basram,7,Building,1,3,0,TRUE
+701018,70.2774871,34.73978528,2,Bady Abad Village Hujra,Laghman,3,Mehtarlam,1,Kolalan,7,Village,1,3,0,TRUE
+701019,70.19995406,34.67903015,3,Alikhel School,Laghman,4,Mehtarlam,1,Alikhel,7,Building,1,4,0,TRUE
+701020,70.15771374,34.70603301,3,Alishang Village School,Laghman,5,Mehtarlam,2,Alishang Village,7,Building,1,5,0,TRUE
+701022,70.15015847,34.69354191,1,Sultankhelo Village Mosque,Laghman,2,Mehtarlam,1,Sultan Village,7,Building,1,2,0,TRUE
+701023,70.15109597,34.68716986,1,Diwa School,Laghman,2,Mehtarlam,1,Diwa,7,Building,1,2,0,TRUE
+701024,70.16472124,34.67422304,2,Khair Abad Village Mosque,Laghman,3,Mehtarlam,1,Khair Abad,7,Village,1,3,0,TRUE
+701025,70.16659754,34.66244829,3,Sher Garh School,Laghman,4,Mehtarlam,1,Sher Garh,7,Building,1,4,0,TRUE
+701026,70.19058712,34.63866423,3,Deh Ziarat School,Laghman,4,Mehtarlam,1,Deh Ziarat,7,Village,1,4,0,TRUE
+701030,70.26767316,34.73196125,2,Arsalah Qala Mosque,Laghman,3,Mehtarlam,1,Arsalah Qala,7,Village,1,3,0,TRUE
+701031,70.17700482,34.68644278,1,Kutubzai School,Laghman,2,Mehtarlam,1,Kutubzai,7,Building,1,2,0,TRUE
+701032,70.18175273,34.61843979,1,Refugees Camp School,Laghman,2,Mehtarlam,1,Refugees Camp,7,Village,1,2,0,TRUE
+702033,70.24380875,34.54898198,4,Qarghayee Boys High School And Girls Secondary School,Laghman,5,Qarghayee,1,Qarghayee,7,Building,2,5,0,TRUE
+702034,70.27226526,34.54715774,3,Sultan Wais Baba School,Laghman,4,Qarghayee,1,Qalhatak,7,Building,2,4,0,TRUE
+702035,70.28814457,34.5321453,3,Charbagh Boys & Girls High School,Laghman,5,Qarghayee,2,Charbagh,7,Building,2,5,0,TRUE
+702036,70.32719191,34.53067361,3,Nahr Karim School And De Kaley Hojra,Laghman,4,Qarghayee,1,Nahr Karim,7,Building,2,4,0,TRUE
+702037,70.29445087,34.52101105,2,Pacha Kala Mosque,Laghman,3,Qarghayee,1,Pacha Kala,7,Village,2,3,0,TRUE
+702038,70.26724847,34.53220047,2,Swati School,Laghman,3,Qarghayee,1,Swati,7,Building,2,3,0,TRUE
+702039,70.20810001,34.58111247,3,Masha Khel Boys High School,Laghman,4,Qarghayee,1,Mashakhel,7,Village,2,4,0,TRUE
+702040,70.21066065,34.55675084,4,Kharoto Village Hazrat Omar Mosque,Laghman,7,Qarghayee,3,Kharoty,7,Village,2,7,0,TRUE
+702041,70.21205345,34.54869146,2,Mandaror High School And Primary Lomlany School,Laghman,3,Qarghayee,1,Mandaror,7,Building,2,3,0,TRUE
+702042,70.21315768,34.53639465,3,Farman Khel Village Mosque And Hojra,Laghman,4,Qarghayee,1,Farmankhel,7,Building,2,5,0,TRUE
+702043,70.2111132,34.50797103,3,Surkhakan High School,Laghman,5,Qarghayee,2,Surkhakan,7,Building,2,5,0,TRUE
+702044,70.2985932,34.49361998,3,Gul Pacha Olfat High School,Laghman,5,Qarghayee,2,Aziz Khan Kas,7,Building,2,5,0,TRUE
+702045,70.03448784,34.50706683,4,Ka Kass School,Laghman,6,Qarghayee,2,Ka Kass,7,Building,2,6,0,TRUE
+702046,70.00714734,34.51001589,2,Sarkando Baba Hotel Hujra,Laghman,3,Qarghayee,1,Sarkando Baba,7,Building,2,3,0,TRUE
+702047,70.24770225,34.52606163,2,Kamalpoor Jaame Mosque,Laghman,3,Qarghayee,1,Kamalpoor,7,Village,2,3,0,TRUE
+702048,70.23352572,34.53284253,2,Baloch Abad Mosque,Laghman,3,Qarghayee,1,Baloch Abad,7,Village,2,4,0,TRUE
+702049,70.22918747,34.51035674,3,Ghondai Abdul Rahimzayo Mosque,Laghman,5,Qarghayee,2,Abdul Rahimzai,7,Building,2,7,0,TRUE
+702050,70.26626819,34.50593931,2,Dara Ghar School,Laghman,3,Qarghayee,1,Dara Ghar,7,Building,2,3,0,TRUE
+702051,70.33439333,34.52827678,1,Gambiri Ahmadzayo Kuchano Mosque,Laghman,3,Qarghayee,2,Ahmadzai Village,7,Village,2,3,0,TRUE
+702052,70.21267797,34.57354646,2,Kandi Village Nsp Building,Laghman,3,Qarghayee,1,Kandi,7,Village,2,3,0,TRUE
+702053,70.2230984,34.55529307,2,Logar Lam Khan Qala School,Laghman,3,Qarghayee,1,Logarlam,7,Village,2,3,0,TRUE
+702127,70.13672493,34.51863929,2,Zeranai Village Mosque & Clinic,Laghman,3,Qarghayee,1,Zeranai Village,7,Building,2,3,0,TRUE
+702130,70.367793482,34.489307546,3,Gul Ghondi School,Laghman,5,Qarghayee,2,Chapa Dara,7,Building,2,7,0,TRUE
+703086,70.14883198,34.72203766,2,Shakarman School,Laghman,3,Alishing,1,Shakarman,7,Village,3,3,0,TRUE
+703087,70.11551917,34.75047395,2,Tarang School,Laghman,3,Alishing,1,Trang,7,Building,3,3,0,TRUE
+703088,70.10567938,34.78612555,3,Mia Abdul Karim High School,Laghman,5,Alishing,2,Distirct Compound,7,Building,3,5,0,TRUE
+703089,70.10315981,34.82674711,2,Ghazi Abad Village Open Space,Laghman,3,Alishing,1,Ghazi Abad Village,7,Building,3,3,0,TRUE
+703090,70.10804498,34.78342501,3,Watangato School,Laghman,4,Alishing,1,Alishang,7,Building,3,4,0,TRUE
+703091,70.11134261,34.78198677,3,Najel School,Laghman,4,Alishing,1,Alishang,7,Village,3,4,0,TRUE
+703093,70.11452913,34.77972019,2,Kotwal Khando Village Mosque,Laghman,3,Alishing,1,Alishang,7,Village,3,0,3,FALSE
+703095,70.13208175,34.71915733,3,Barakzai Boys & Girls School,Laghman,4,Alishing,1,Barakzai,7,Building,3,0,4,FALSE
+703097,70.09641297,34.75210534,3,Islam Abad Boys & Girls School,Laghman,4,Alishing,1,Islam Abad,7,Building,3,4,0,TRUE
+703101,70.1039518,34.79015679,2,Dera Mia Sahib Village Mosque,Laghman,4,Alishing,2,Miya Sahib Dera,7,Building,3,2,2,TRUE
+703103,70.1445562,34.84830365,2,Masmod Village Mosque,Laghman,3,Alishing,1,Masmod,7,Building,3,0,3,FALSE
+703105,70.13072663,34.7704157,1,Areenai Kochi Village Mosque,Laghman,2,Alishing,1,Areenai,7,Building,3,0,2,FALSE
+703107,70.03575253,34.78875712,2,Abdullah Ibn Masood High School,Laghman,3,Alishing,1,Salab Sufla,7,Village,3,0,3,FALSE
+704055,70.31981619,34.78391656,2,Kandi Mosque,Laghman,3,Alingar,1,Kanda,7,Village,4,3,0,TRUE
+704056,70.32620038,34.79886396,1,Rajayee School,Laghman,2,Alingar,1,Rajayee,7,Building,4,2,0,TRUE
+704057,70.35195386,34.81761017,1,Sakhre Village Mosque,Laghman,2,Alingar,1,Sakhra,7,Village,4,2,0,TRUE
+704062,70.36418466,34.83222799,3,Engineer Sher Mohammad High School And Girls School,Laghman,5,Alingar,2,Alingar Center,7,Building,4,5,0,TRUE
+704063,70.36172175,34.8719219,1,Tondrod School,Laghman,2,Alingar,1,Tondrod,7,Village,4,2,0,TRUE
+704064,70.37145222,34.88177115,2,Waronta Village Mosque,Laghman,3,Alingar,1,Waronta,7,Building,4,3,0,TRUE
+704065,70.28918522,34.72855785,2,Qasaba Village Mosque,Laghman,4,Alingar,2,Qasaba,7,Building,4,0,4,FALSE
+704066,70.30807329,34.75060376,2,Qalatak School,Laghman,3,Alingar,1,Qalatak Niazai,7,Building,4,3,0,TRUE
+704067,70.3133339,34.76171157,3,Nimnaye Village Mosque,Laghman,5,Alingar,2,Nimnaye Niazai,7,Village,4,3,2,TRUE
+704068,70.33307657,34.78086096,2,Shekhano High School,Laghman,4,Alingar,2,Shekhano Village,7,Building,4,0,4,FALSE
+704076,70.36992997,34.86126123,2,Parwayee School,Laghman,4,Alingar,2,Parwayee,7,Building,4,4,0,TRUE
+704080,70.37945197,34.88661829,2,Mango School And Tent,Laghman,3,Alingar,1,Mango,7,Building,4,2,1,TRUE
+704081,70.39196032,34.92327418,1,Kotaly Islamic Madrassa,Laghman,2,Alingar,1,Kotaly,7,Building,4,0,2,FALSE
+704085,70.37172834,34.89166361,1,Adhar Village Dera,Laghman,2,Alingar,1,Adhar,7,Village,4,2,0,TRUE
+704131,70.377063666,34.906862353,2,School,Laghman,3,Alingar,1,Lokar,7,Building,4,3,0,TRUE
+704132,70.297346097,34.75865579,2,Mosque,Laghman,3,Alingar,1,Chinchar Pol,7,Building,4,3,0,TRUE
+705110,70.00169688,34.99449891,4,Kel Mosque,Laghman,4,Dawlat Shah,0,Kel,7,Village,5,4,0,TRUE
+705111,69.96229837,35.02122974,2,Nil Khan Mosque,Laghman,4,Dawlat Shah,2,Nil Khan,7,Building,5,4,0,TRUE
+705112,69.89378153,34.99639712,2,Gamndok Mosque,Laghman,4,Dawlat Shah,2,Gandomak,7,Village,5,2,2,TRUE
+705113,69.95627748,35.02868824,1,Kark Mosque,Laghman,4,Dawlat Shah,3,Kark,7,Village,5,4,0,TRUE
+705114,69.93662656,35.02412097,3,Petak Mosque,Laghman,4,Dawlat Shah,1,Petak,7,Building,5,4,0,TRUE
+705115,70.06950746,34.95033525,3,Dawlat Shah Mosque,Laghman,4,Dawlat Shah,1,Dawlat Shah Center,7,Village,5,4,0,TRUE
+705116,70.09510531,34.92585131,1,Darangee Village Mosque,Laghman,4,Dawlat Shah,3,Darangee,7,Building,5,4,0,TRUE
+705117,70.08184873,34.95474361,2,Afghan Colony School,Laghman,3,Dawlat Shah,1,Afghan Colony,7,Building,5,3,0,TRUE
+705120,70.05929834,34.96310983,1,Wais Mosque,Laghman,3,Dawlat Shah,2,Wais Sema Dawlat Shah,7,Building,5,3,0,TRUE
+705121,70.05826924,34.96025475,1,Mor Anaywa Village Mosque,Laghman,2,Dawlat Shah,1,Wais Sema Dawlat Shah,7,Village,5,0,2,FALSE
+705122,69.93956243,35.02571003,1,Baladeh Village Mosque,Laghman,2,Dawlat Shah,1,Dah Bala,7,Village,5,2,0,TRUE
+705123,70.10153455,34.91791311,2,Zarkamar  Mosque,Laghman,3,Dawlat Shah,1,Mandol,7,Building,5,3,0,TRUE
+705124,69.94387644,35.04768618,2,Chashdar School,Laghman,3,Dawlat Shah,1,Chashdar,7,Village,5,3,0,TRUE
+705125,70.08241143,35.01083285,1,New Balady School,Laghman,2,Dawlat Shah,1,New Balady,7,Building,5,0,2,FALSE
+705126,70.09175942,34.92756633,2,Nora Village Mosque,Laghman,3,Dawlat Shah,1,Nora Village,7,Building,5,3,0,TRUE
+705136,70.078401868,35.002723575,2,Mosque,Laghman,3,Dawlat Shah,1,Kasheedor,7,Building,5,0,3,FALSE
+706027,69.890980595,34.667656831,2,Akhunzada Village Mosque,Laghman,3,Badpakh,1,Meterlam,7,Building,6,3,0,TRUE
+801001,69.51479723,35.31158834,3,Bazarak High School,Panjshir,4,Bazarak,1,Bazarak,8,Building,1,5,0,TRUE
+801002,69.591068,35.35154211,2,Sangana Mosque,Panjshir,4,Bazarak,2,Sangana,8,Building,1,4,0,TRUE
+801003,69.54164514,35.32241771,2,Malsapa Mosque,Panjshir,4,Bazarak,2,Malsapa,8,Building,1,4,0,TRUE
+801004,69.55157916,35.33327911,3,Malsapa Secondar School,Panjshir,4,Bazarak,1,Malsapa,8,Building,1,4,0,TRUE
+801005,69.49857222,35.29325779,2,Khan Khez Madrassa,Panjshir,4,Bazarak,2,Khan Khez,8,Building,1,4,0,TRUE
+801006,69.49858248,35.29328435,3,Khan Khez Mosque,Panjshir,4,Bazarak,1,Khan Khez,8,Building,1,4,0,TRUE
+801007,69.55580584,35.30510577,2,Manjhor Mosque,Panjshir,3,Bazarak,1,Manjhor,8,Building,1,3,0,TRUE
+801008,69.55580584,35.30510577,1,Manjhor Village  Mosque,Panjshir,2,Bazarak,1,Manjhor,8,Building,1,2,0,TRUE
+801097,69.546815897,35.30975224,2,Koh Manjahoor Secondary School,Panjshir,3,Bazarak,1,Dashtak,8,Building,1,3,0,TRUE
+801098,69.47956859,35.277739142,2,Marshal Faheem Mosque,Panjshir,3,Bazarak,1,Province Center_Bazarak,8,Building,1,3,0,TRUE
+802020,69.46344811,35.26015086,3,Rukha Boys High School,Panjshir,4,Rukha,1,Shekhan,8,Building,2,4,0,TRUE
+802021,69.47058457,35.26407496,2,Daka Girls Secondary School,Panjshir,3,Rukha,1,Daka,8,Building,2,3,0,TRUE
+802022,69.46889939,35.26499436,4,Rukha Hospital,Panjshir,6,Rukha,2,Shast,8,Building,2,6,0,TRUE
+802023,69.46524204,35.25589922,2,Qabidan Girls High School,Panjshir,3,Rukha,1,Qabidan,8,Building,2,3,0,TRUE
+802024,69.5024826,35.23199563,1,Hasarak Mosque,Panjshir,2,Rukha,1,Hasarak,8,Building,2,2,0,TRUE
+802025,69.48606145,35.25798656,1,Marshtan Mosque,Panjshir,2,Rukha,1,Marshtan,8,Building,2,2,0,TRUE
+802026,69.47370884,35.25983443,1,Dar Khel Mosque,Panjshir,2,Rukha,1,Dar Khel,8,Building,2,2,0,TRUE
+802027,69.47419631,35.291318,1,Kanda School,Panjshir,2,Rukha,1,Kanda Wagut,8,Building,2,2,0,TRUE
+802028,69.44716186,35.27028123,1,Peyawesht Girls High School,Panjshir,2,Rukha,1,Peyawesht,8,Building,2,2,0,TRUE
+802099,69.424468827,35.30317036,2,Chamal Warda Mosque,Panjshir,3,Rukha,1,Chamal Warda,8,Village,2,3,0,TRUE
+803043,69.65585894,35.29300792,3,Kraman Boys School,Panjshir,4,Darah,1,Kraman,8,Building,3,4,0,TRUE
+803044,69.65398056,35.29590464,2,Kraman Girls School,Panjshir,4,Darah,2,Kraman,8,Building,3,4,0,TRUE
+803045,69.65668624,35.28068355,2,Pasgaran School,Panjshir,3,Darah,1,Pasgaran,8,Building,3,3,0,TRUE
+803046,69.61355314,35.2424039,2,Malek Merza Shaheed School,Panjshir,3,Darah,1,Bazara Abdullh Khel,8,Building,3,3,0,TRUE
+803047,69.60255364,35.23615384,2,Deh Khwaja Mosque,Panjshir,3,Darah,1,Khwaja Abdullh Khel,8,Building,3,3,0,TRUE
+803054,69.63753418,35.31429497,2,Malima Boys School,Panjshir,3,Darah,1,Malima,8,Building,3,3,0,TRUE
+803055,69.63475132,35.31975955,2,Malima Mosque,Panjshir,4,Darah,2,Malima,8,Building,3,4,0,TRUE
+803056,69.64342888,35.32221526,1,Tambina Girls School,Panjshir,2,Darah,1,Tambina,8,Building,3,2,0,TRUE
+803059,69.63815201,35.26939324,1,Tund Kho Clinic,Panjshir,2,Darah,1,Tund Kho,8,Building,3,2,0,TRUE
+803060,69.63670319,35.2667659,1,Tund Kho School,Panjshir,2,Darah,1,Tund Kho,8,Village,3,2,0,TRUE
+803061,69.65621924,35.32867385,1,Pojawa Mosque,Panjshir,2,Darah,1,Pojawa,8,Building,3,2,0,TRUE
+803062,69.63964523,35.32064689,2,Deh Pojawa Old Mosque,Panjshir,3,Darah,1,Pojawa,8,Village,3,3,0,TRUE
+803100,69.673054936,35.293694487,2,Askan Yar Mosque,Panjshir,3,Darah,1,Askanyar,8,Building,3,3,0,TRUE
+803101,69.606808269,35.24118133,2,Abdullah Khil Female Mosque,Panjshir,3,Darah,1,Marjan Abdullah Khil,8,Building,3,3,0,TRUE
+804009,69.72406618,35.42521117,4,Khanj Madrassa,Panjshir,5,Hissa-E-Awal Khinj,1,Markaz Khanj,8,Building,4,5,0,TRUE
+804010,69.75981845,35.45433036,2,Safid Cheher High School,Panjshir,3,Hissa-E-Awal Khinj,1,Safid Cheher,8,Village,4,3,0,TRUE
+804011,69.69620161,35.39838804,1,Peshghur Mosque,Panjshir,2,Hissa-E-Awal Khinj,1,Peshghur,8,Building,4,2,0,TRUE
+804012,69.64997991,35.38525184,2,Shaba Mosque,Panjshir,3,Hissa-E-Awal Khinj,1,Omarzai,8,Building,4,3,0,TRUE
+804013,69.6444577,35.38588845,6,Omarz School,Panjshir,8,Hissa-E-Awal Khinj,2,Omarz,8,Building,4,8,0,TRUE
+804014,69.82032055,35.4893834,2,Dasht -E-Reut High School,Panjshir,3,Hissa-E-Awal Khinj,1,Dasht-E-Reut,8,Building,4,3,0,TRUE
+804015,69.69812179,35.42473347,1,Kharo Madrassa,Panjshir,2,Hissa-E-Awal Khinj,1,Kharo,8,Building,4,2,0,TRUE
+804016,69.83944444,35.50138888,2,Darnama Mosque,Panjshir,3,Hissa-E-Awal Khinj,1,Darnama,8,Village,4,4,0,TRUE
+804017,69.79620142,35.47466509,1,Ghanjo Mosque,Panjshir,2,Hissa-E-Awal Khinj,1,Ghanjo,8,Village,4,2,0,TRUE
+804018,69.7506414,35.44496797,2,Mata Madrassa,Panjshir,3,Hissa-E-Awal Khinj,1,Mata,8,Building,4,3,0,TRUE
+804019,69.75303921,35.44591674,2,Mata Mosque,Panjshir,3,Hissa-E-Awal Khinj,1,Mata,8,Building,4,3,0,TRUE
+804092,69.83166666,35.49472222,1,Dasht -E-Rewet Clinic,Panjshir,2,Hissa-E-Awal Khinj,1,Dasht-E-Rewet,8,Village,4,2,0,TRUE
+804102,69.697688548,35.40950574,2,Khatam Alanbia School,Panjshir,3,Hissa-E-Awal Khinj,1,Khenj Center_Shah Chehra,8,Building,4,3,0,TRUE
+804103,69.762265053,35.468576038,2,Muhammad Pana Shaheed School,Panjshir,3,Hissa-E-Awal Khinj,1,Zarian Shahr,8,Building,4,3,0,TRUE
+805029,69.34577853,35.23058207,2,Zamankor Secondary School,Panjshir,3,Unaba,1,Zamankor,8,Building,5,3,0,TRUE
+805030,69.36979817,35.23067234,3,Boys School,Panjshir,3,Unaba,0,Unaba,8,Building,5,3,0,TRUE
+805031,69.37082729,35.23234986,3,Hanaba Girls School,Panjshir,4,Unaba,1,Unaba,8,Building,5,5,0,TRUE
+805032,69.36775494,35.20851067,3,Faraj Boys School,Panjshir,3,Unaba,0,Faraj,8,Building,5,3,0,TRUE
+805033,69.36163332,35.20661785,1,Faraj Girls School,Panjshir,2,Unaba,1,Faraj,8,Building,5,2,0,TRUE
+805034,69.40164773,35.2392763,2,Baghcha Kalan Bazar Tawakh,Panjshir,3,Unaba,1,Tawaakh,8,Building,5,3,0,TRUE
+805035,69.39800091,35.24799281,2,Madrassa Tawaakh,Panjshir,3,Unaba,1,Tawaakh,8,Building,5,3,0,TRUE
+805036,69.44241994,35.23019414,1,Madrassa Gana,Panjshir,2,Unaba,1,Gana Village,8,Building,5,2,0,TRUE
+805037,69.41849404,35.21994721,1,Ladies Clinic,Panjshir,2,Unaba,1,Kargeem,8,Building,5,2,0,TRUE
+805038,69.43732923,35.25014859,1,Dashtak Girls School,Panjshir,2,Unaba,1,Dashtak,8,Building,5,2,0,TRUE
+805039,69.45525807,35.21541682,1,Shofa Secondary School,Panjshir,2,Unaba,1,Shfa-E- Aabdara,8,Building,5,2,0,TRUE
+805040,69.33761683,35.18309907,1,Dar Band  Boys Secondary School,Panjshir,2,Unaba,1,Dar Band Faraj,8,Building,5,2,0,TRUE
+805041,69.34851918,35.21660997,1,Sangeen Mosque,Panjshir,2,Unaba,1,Sangeen,8,Building,5,2,0,TRUE
+805042,69.37429231,35.22452796,1,Chaman Qala,Panjshir,2,Unaba,1,Qalaja,8,Building,5,2,0,TRUE
+806084,69.27361111,35.19388888,2,Deh Kalan Mosque,Panjshir,3,Shutul,1,Deh Kalan,8,Village,6,3,0,TRUE
+806085,69.27988971,35.20292979,1,Sagha War Mosque,Panjshir,2,Shutul,1,Sagha War,8,Building,6,2,0,TRUE
+806086,69.28274939,35.20183414,1,Mara Mosque,Panjshir,2,Shutul,1,Mara,8,Village,6,2,0,TRUE
+806087,69.29842467,35.24411294,2,Roye Dara Mosque,Panjshir,3,Shutul,1,Roye Dara,8,Village,6,3,0,TRUE
+806088,69.26196667,35.18855094,2,Janan Joy Mosque,Panjshir,3,Shutul,1,Janan Joy,8,Village,6,3,0,TRUE
+806089,69.27777777,35.20027777,1,Andarosat Mosque,Panjshir,2,Shutul,1,Andarosat,8,Village,6,2,0,TRUE
+806090,69.30486777,35.20855665,2,Koraba School,Panjshir,3,Shutul,1,Koraba,8,Building,6,3,0,TRUE
+806091,69.31201673,35.20898692,1,Koraba,Panjshir,2,Shutul,1,Koraba,8,Village,6,2,0,TRUE
+806093,69.315965545,35.265917897,1,Du Aabi Murghi And Arwe Shutul,Panjshir,2,Shutul,1,Du Aabi Murghi And Arzo Shutul,8,Village,6,2,0,TRUE
+806104,69.308147151,35.247201089,2,Estofalo Mosque,Panjshir,3,Shutul,1,Astofalo,8,Building,6,3,0,TRUE
+806105,69.292513774,35.227219096,2,Sang Lakhshan Mosque,Panjshir,3,Shutul,1,Sang Lakhshan,8,Building,6,3,0,TRUE
+807066,70.095854,35.6960058,3,Balaye Kucha Mosque,Panjshir,3,Paryan,0,Karpitab,8,Village,7,3,0,TRUE
+807067,70.09296619,35.69702883,0,Bardama Mosque,Panjshir,2,Paryan,2,Karpitab,8,Village,7,2,0,TRUE
+807068,70.04847267,35.64637185,1,Kojan High School,Panjshir,2,Paryan,1,Kojan Wajshta,8,Building,7,2,0,TRUE
+807069,70.00523055,35.62131111,2,Qala Mosque,Panjshir,3,Paryan,1,Qala,8,Village,7,3,0,TRUE
+807070,70.004375,35.62391111,1,Nawdang Mosque,Panjshir,2,Paryan,1,Nawdang,8,Building,7,2,0,TRUE
+807071,70.00344439,35.62256784,1,Sarshakh Nawdang,Panjshir,2,Paryan,1,Sarshakh Nawdang,8,Village,7,2,0,TRUE
+807072,69.99008661,35.60824137,1,Kohsar Mosque,Panjshir,2,Paryan,1,Kohsar,8,Village,7,2,0,TRUE
+807073,69.90917096,35.64437665,1,Deh Khawak School,Panjshir,2,Paryan,1,Deh Khawak,8,Building,7,2,0,TRUE
+807074,69.86552859,35.56285397,2,Tal Secondary School,Panjshir,2,Paryan,0,Tal,8,Village,7,2,0,TRUE
+807075,69.94444444,35.53008611,1,Khwaja Arif School,Panjshir,2,Paryan,1,Aryob,8,Village,7,2,0,TRUE
+807076,70.08305324,35.68795377,1,Kalkoa Mosque,Panjshir,2,Paryan,1,Kalkoa,8,Village,7,2,0,TRUE
+807077,70.051992856,35.681880008,1,Shal Kacha Mosque,Panjshir,2,Paryan,1,Shal Kacha,8,Village,7,2,0,TRUE
+807078,69.90588669,35.56957484,1,Du Aabi Khawaak School,Panjshir,2,Paryan,1,Du Aabi Khawaak,8,Village,7,2,0,TRUE
+807079,70.08194743,35.67568394,1,Shahr-E- Beland Mosque,Panjshir,2,Paryan,1,Shahr-E-Beland,8,Village,7,2,0,TRUE
+807080,70.01431528,35.62516205,1,Deh Paryan Mosque,Panjshir,2,Paryan,1,Deh Paryan,8,Building,7,2,0,TRUE
+807081,70.12066242,35.68464421,1,Chamar Bala Mosque,Panjshir,2,Paryan,1,Chamar Bala,8,Village,7,2,0,TRUE
+807082,69.97307222,35.60623333,1,Shaniz Mosque,Panjshir,2,Paryan,1,Shaniz Village,8,Village,7,2,0,TRUE
+807083,70.11460332,35.70442869,1,Pasmazar Mosque,Panjshir,2,Paryan,1,Pasmazar,8,Village,7,2,0,TRUE
+807094,69.87859672,35.64107319,1,Choni Village Tent,Panjshir,2,Paryan,1,Choni Village,8,Village,7,2,0,TRUE
+807095,70.16594444,35.74056111,1,Dara-E-Shalzor Tent,Panjshir,2,Paryan,1,Dara-E-Shalzor,8,Village,7,2,0,TRUE
+807096,70.082968733,35.690634925,1,Chaman Bosee,Panjshir,2,Paryan,1,Bosee,8,Village,7,2,0,TRUE
+807106,70.00519028,35.620500472,2,Tent,Panjshir,3,Paryan,1,Qala,8,Village,7,3,0,TRUE
+807107,70.103281933,35.698133394,2,Chamar Mosque,Panjshir,3,Paryan,1,Chamar Paien,8,Village,7,3,0,TRUE
+807108,69.880302232,35.640124196,2,Chawni School,Panjshir,3,Paryan,1,Chaoni,8,Village,7,3,0,TRUE
+808048,69.70887624,35.25244577,2,Baba Ali School,Panjshir,3,Abshar,1,Baba Ali,8,Village,8,3,0,TRUE
+808049,69.72551533,35.24956364,1,Mosque,Panjshir,2,Abshar,1,Sangee Khan,8,Village,8,2,0,TRUE
+808050,69.74699822,35.25109876,1,Girls High  School,Panjshir,3,Abshar,2,Dost Ali,8,Village,8,3,0,TRUE
+808051,69.76879519,35.25380345,2,Abdul Wodod Shaheed Boys High School,Panjshir,2,Abshar,0,Dost Ali,8,Village,8,2,0,TRUE
+808052,69.89291975,35.28629625,1,Astana Girls School,Panjshir,2,Abshar,1,Astana,8,Village,8,2,0,TRUE
+808053,69.84799809,35.24283653,1,Astana Boys School,Panjshir,2,Abshar,1,Astana Kalan,8,Village,8,2,0,TRUE
+808057,69.69813316,35.24685413,1,Jar A+J1748Li Schoo,Panjshir,2,Abshar,1,Jarali,8,Village,8,2,0,TRUE
+808058,69.87683062,35.26703777,1,Ahlee Shafi Mosque,Panjshir,2,Abshar,1,Ahlee Shafi,8,Village,8,2,0,TRUE
+808063,69.86932016,35.26048036,1,Gulabkhel Mosque,Panjshir,2,Abshar,1,Gulabkhel,8,Village,8,2,0,TRUE
+808064,69.74933087,35.22968986,1,Rueebi Salah Mosque,Panjshir,2,Abshar,1,Parngan,8,Village,8,2,0,TRUE
+808065,69.74468233,35.23369697,3,Parngan Boys School,Panjshir,3,Abshar,0,Parngan,8,Village,8,3,0,TRUE
+901001,68.71069825,35.95033657,5,Hawa Girls High School,Baghlan,9,Pul-E-Khumri,4,Third Nahia,9,Building,1,9,0,TRUE
+901002,68.69729193,35.97097369,3,Hazrat Hamza High School,Baghlan,6,Pul-E-Khumri,3,Third Nahia,9,Building,1,6,0,TRUE
+901003,68.73363533,35.92155705,3,Tasady # 5 Department,Baghlan,5,Pul-E-Khumri,2,Second Nahia,9,Building,1,5,0,TRUE
+901004,68.71722165,35.93518448,3,Fatema Alzahra High School,Baghlan,5,Pul-E-Khumri,2,Secondanahia,9,Building,1,5,0,TRUE
+901005,68.70363677,35.94964639,4,Takia Khana Farahd  Mosque,Baghlan,6,Pul-E-Khumri,2,First Nahia,9,Building,1,6,0,TRUE
+901006,68.7239271,35.92570524,3,Pol-E-Khomri Selo,Baghlan,5,Pul-E-Khumri,2,Second Nahia,9,Building,1,5,0,TRUE
+901007,68.75141838,35.89977154,4,Shamaroq Gate,Baghlan,7,Pul-E-Khumri,3,Shamaroq Park,9,Building,1,7,0,TRUE
+901008,68.7242224,35.92839906,3,Mollah Eshaq Takia Khana,Baghlan,5,Pul-E-Khumri,2,Second Nahia,9,Building,1,5,0,TRUE
+901009,68.70687026,35.94656487,3,Hazrat Zaid School,Baghlan,6,Pul-E-Khumri,3,First Nahia,9,Building,1,6,0,TRUE
+901010,68.70713634,35.95981008,3,Number 2 School,Baghlan,5,Pul-E-Khumri,2,Third Nahia,9,Building,1,5,0,TRUE
+901011,68.68621851,35.98679726,3,Band Du High School,Baghlan,5,Pul-E-Khumri,2,Third Nahia,9,Building,1,5,0,TRUE
+901012,68.68072769,35.98081719,3,Khwaja Kamal Wali School,Baghlan,5,Pul-E-Khumri,2,Ghory Sement Familiies Building,9,Building,1,5,0,TRUE
+901013,68.62925516,35.98070353,2,Haji Baz Gul Mosque,Baghlan,3,Pul-E-Khumri,1,Qarghan Village,9,Building,1,3,0,TRUE
+901014,68.60103725,35.96017874,2,Qala Khwaja School,Baghlan,4,Pul-E-Khumri,2,Qala -E-Khawja,9,Building,1,4,0,TRUE
+901015,68.65249069,35.97498666,3,Qazi Village,Baghlan,5,Pul-E-Khumri,2,Qazi Village,9,Building,1,5,0,TRUE
+901016,68.66792997,35.97776011,2,Wazir Abad Village Mosque,Baghlan,4,Pul-E-Khumri,2,Wazir Abad Village,9,Building,1,4,0,TRUE
+901017,68.61618384,35.9890486,2,Safid Khan Ghoroshakh Village,Baghlan,4,Pul-E-Khumri,2,Safid Khan Village,9,Building,1,4,0,TRUE
+901018,68.66403235,35.96450088,3,Niazullah Village,Baghlan,5,Pul-E-Khumri,2,Niazullah Village,9,Building,1,5,0,TRUE
+901019,68.6454205,35.9950519,2,Said Jamalluddin Afghan School,Baghlan,4,Pul-E-Khumri,2,Bagh Shamal,9,Building,1,4,0,TRUE
+901020,68.55878136,36.10198181,2,Khawaja Alvan Camp,Baghlan,4,Pul-E-Khumri,2,Khwaja Alvan Old Camp,9,Building,1,4,0,TRUE
+901021,68.68593646,35.99491264,3,Zaman Khil Gaw Sovar Mosque,Baghlan,5,Pul-E-Khumri,2,Third Nahia,9,Building,1,5,0,TRUE
+901022,68.6763862,36.02409563,3,Hussain Khel  High School,Baghlan,5,Pul-E-Khumri,2,Third Nahia,9,Building,1,5,0,TRUE
+901023,68.67174934,36.04612115,3,Bala Dori School,Baghlan,4,Pul-E-Khumri,1,Third Nahia,9,Building,1,4,0,TRUE
+901024,68.66211993,36.07283475,3,Toor Shaheed School,Baghlan,4,Pul-E-Khumri,1,Khalazai Village,9,Building,1,4,0,TRUE
+901025,68.64740155,35.93832931,3,Ahmadzai High School,Baghlan,4,Pul-E-Khumri,1,Joy Naw Ahmadzai,9,Building,1,4,0,TRUE
+901026,68.65063284,35.92591736,3,Abdul Razaq Shaheed High School,Baghlan,4,Pul-E-Khumri,1,Wardak Ha,9,Building,1,4,0,TRUE
+901027,68.62417764,35.95226743,3,Loogari Near To Joy-E-Naw River,Baghlan,4,Pul-E-Khumri,1,Logari,9,Building,1,4,0,TRUE
+901028,68.5772684,35.94565291,3,Near To Shahr-E-Naw Kharoti Gorgan,Baghlan,4,Pul-E-Khumri,1,Shahr-E-Naw Kharoti Gorgan,9,Building,1,4,0,TRUE
+901029,68.55020041,35.96902562,3,Tajikan Sher Ali School,Baghlan,4,Pul-E-Khumri,1,Tajikan Sher Ali,9,Building,1,4,0,TRUE
+901030,68.56272715,35.97281936,2,Hazrat Imam Hussain School,Baghlan,3,Pul-E-Khumri,1,See Bia U Sad Bia Behind Gorgan,9,Building,1,3,0,TRUE
+901031,68.56501469,36.01679952,3,Omar Khel Jalad Khan,Baghlan,5,Pul-E-Khumri,2,Omar Khil Jalad Khan,9,Building,1,5,0,TRUE
+901032,68.59146194,36.02755894,2,Old Mosque,Baghlan,3,Pul-E-Khumri,1,Sorkh Kotal Village,9,Building,1,3,0,TRUE
+901033,68.55877333,36.06423667,2,Ali Khel School,Baghlan,3,Pul-E-Khumri,1,Ali Khil Village,9,Building,1,3,0,TRUE
+901034,68.71722019,35.93869787,2,Pul-E-Khomri  Mosque,Baghlan,4,Pul-E-Khumri,2,Center Of The City,9,Building,1,6,0,TRUE
+901035,68.72099558,35.92445546,2,Karta-E-Etifaq School,Baghlan,3,Pul-E-Khumri,1,"First Nahia -House, Opposite To Café Shop Left Of River",9,Building,1,4,0,TRUE
+901036,68.67572299,36.06090859,2,Number 2 School,Baghlan,3,Pul-E-Khumri,1,Bala Dori Baba Nazar,9,Building,1,3,0,TRUE
+901037,68.63705357,36.07817585,2,Omarkhel Bebi Aiyana School,Baghlan,3,Pul-E-Khumri,1,Third Nahia,9,Building,1,4,0,TRUE
+901038,68.59737482,36.05524935,2,Chesma Shir School,Baghlan,3,Pul-E-Khumri,1,Eisa Bai Village,9,Building,1,3,0,TRUE
+901039,68.49578535,36.10849884,2,Qura Sai School,Baghlan,3,Pul-E-Khumri,1,"Qura Saiee Payin, Near To Rubatak",9,Building,1,3,0,TRUE
+901040,68.65928913,36.0433474,2,Aka Khel Mosque Garden,Baghlan,3,Pul-E-Khumri,1,Aka Khel Village,9,Building,1,3,0,TRUE
+901041,68.56937253,36.09086726,2,Aljehad Muhajreen School,Baghlan,3,Pul-E-Khumri,1,Hazardo Village,9,Building,1,3,0,TRUE
+901227,68.7645338,35.85377293,2,Mazar Dara Mosque,Baghlan,3,Pul-E-Khumri,1,Mazar Dara School,9,Building,1,3,0,TRUE
+901228,68.72187212,35.93890289,2,Qul Qasabi Mosque,Baghlan,4,Pul-E-Khumri,2,Second Nahia,9,Building,1,4,0,TRUE
+901229,68.71766302,35.94202491,2,Panjsheriha Mosque,Baghlan,3,Pul-E-Khumri,1,First Nahia,9,Building,1,3,0,TRUE
+901230,68.71628097,35.94822566,2,Haji Abdul Ghafar Mosque,Baghlan,3,Pul-E-Khumri,1,Third Nahia,9,Building,1,3,0,TRUE
+901231,68.65149537,36.01912837,2,Abdul Qadeer Okhonzada School,Baghlan,3,Pul-E-Khumri,1,Third Nahia,9,Building,1,4,0,TRUE
+901232,68.59888768,35.9918164,2,Gheroshakh Nafil Mosque,Baghlan,3,Pul-E-Khumri,1,Gheroshakh Nafil,9,Building,1,3,0,TRUE
+902075,68.43967394,35.99461941,1,Jangaghli School,Baghlan,4,Dahana-E-Ghuri,3,Jangaghli,9,Building,2,4,0,TRUE
+902076,68.52373428,35.74944433,2,Shalakto Boys High School,Baghlan,3,Dahana-E-Ghuri,1,Shalakto,9,Building,2,3,0,TRUE
+902077,68.56672584,35.87815881,2,Malaka Soria Girls School,Baghlan,3,Dahana-E-Ghuri,1,Bekh Village,9,Building,2,3,0,TRUE
+902078,68.43665319,35.87191652,2,Sayad And  Khoshk High School,Baghlan,3,Dahana-E-Ghuri,1,Sayad And Khoshak,9,Building,2,3,0,TRUE
+902079,68.48881355,35.81815887,1,Ibn Neqa Mosque,Baghlan,2,Dahana-E-Ghuri,1,Tondara,9,Building,2,2,0,TRUE
+902080,68.67967922,35.77968628,1,Dasht-E-Ali Jum School,Baghlan,2,Dahana-E-Ghuri,1,Ali Jam Desert,9,Building,2,2,0,TRUE
+902081,68.58556145,35.80935149,1,Kalta Qul Mosque,Baghlan,2,Dahana-E-Ghuri,1,Charm Aab Bala,9,Building,2,2,0,TRUE
+902082,68.51152029,35.90772426,1,Tapa-E-Sangak Mosque,Baghlan,2,Dahana-E-Ghuri,1,Tapa-E-Qul Sangak,9,Building,2,2,0,TRUE
+902083,68.60419967,35.91957547,1,Larkhwabi Mosque,Baghlan,2,Dahana-E-Ghuri,1,Haji Naiem Village,9,Building,2,2,0,TRUE
+902084,68.43190947,35.84516712,1,Pasha Qul High School,Baghlan,2,Dahana-E-Ghuri,1,Pasha Qul,9,Building,2,2,0,TRUE
+902085,68.49606629,35.91227684,2,Azizan Baba High School,Baghlan,3,Dahana-E-Ghuri,1,Dahana-E-Ghuri District Capital,9,Building,2,3,0,TRUE
+902086,68.35072241,35.86579764,2,Dara Turan Secondary School,Baghlan,3,Dahana-E-Ghuri,1,Toran Khawaja Pak Village,9,Building,2,3,0,TRUE
+902087,68.46644947,35.90047338,2,Tajikaha Dahana Bala School,Baghlan,3,Dahana-E-Ghuri,1,Tajikha Dahana Bala,9,Building,2,3,0,TRUE
+902088,68.59047672,35.72006497,2,Kamperak Bala High School,Baghlan,3,Dahana-E-Ghuri,1,Kaperak Bala,9,Building,2,3,0,TRUE
+902089,68.51429175,35.73543789,2,Shalkato Mosque,Baghlan,3,Dahana-E-Ghuri,1,Ash Khawaja,9,Building,2,3,0,TRUE
+902090,68.637112,35.78680874,2,Qambar Ali Mohammad Mosque,Baghlan,3,Dahana-E-Ghuri,1,Qambar Ali Mohammad Near School,9,Building,2,3,0,TRUE
+902091,68.503031036,35.92003274,1,Qandari Mosque,Baghlan,2,Dahana-E-Ghuri,1,Qeshlaq,9,Building,2,2,0,TRUE
+902092,68.484142509,35.946809812,1,Tent,Baghlan,2,Dahana-E-Ghuri,1,Haji Bashar Village,9,Building,2,2,0,TRUE
+902238,68.58323991,35.69533941,2,Sorkhak Mosque,Baghlan,3,Dahana-E-Ghuri,1,Sorkhak,9,Building,2,3,0,TRUE
+902239,68.39643419,35.79974353,2,Khwaja Jaroob,Baghlan,3,Dahana-E-Ghuri,1,Khwaja Jaroob,9,Building,2,3,0,TRUE
+902258,68.523883248,35.801266292,2,Open Field,Baghlan,3,Dahana-E-Ghuri,1,Zir Kotal Omaki,9,Village,2,3,0,TRUE
+902259,68.616557211,35.930389315,2,Larkhwab Madrasa,Baghlan,3,Dahana-E-Ghuri,1,Lar Khwabi,9,Building,2,3,0,TRUE
+902260,68.498323224,35.751902467,2,Nawamad Mosque,Baghlan,3,Dahana-E-Ghuri,1,Naw Amad Qara Khwal Shakar To,9,Building,2,3,0,TRUE
+903093,68.52987702,35.59312499,3,Rawnaq Naderi High School,Baghlan,4,Dushi,1,Rubat,9,Building,3,4,0,TRUE
+903094,68.52412067,35.48427332,2,Talkhan School,Baghlan,3,Dushi,1,Talkhan Village,9,Village,3,3,0,TRUE
+903095,68.33050565,35.5150074,2,Shotor Jangal High School,Baghlan,3,Dushi,1,Shutor Jungle,9,Building,3,3,0,TRUE
+903096,68.43360231,35.56997383,2,Kalan Guzar Boys High School,Baghlan,3,Dushi,1,Kalan Guzar Village,9,Building,3,3,0,TRUE
+903097,68.81673596,35.82782689,2,Chehl Kapa School,Baghlan,3,Dushi,1,Chehl Kapa,9,Building,3,3,0,TRUE
+903098,68.40979349,35.63053222,2,Keyan School,Baghlan,3,Dushi,1,Keyan Center,9,Building,3,3,0,TRUE
+903099,68.80664772,35.57469851,2,Koro Village Mosque,Baghlan,4,Dushi,2,Koro Village,9,Building,3,4,0,TRUE
+903100,68.78668269,35.83832865,3,Hazrat Ali Doshi High School,Baghlan,4,Dushi,1,Doshi District Center,9,Building,3,4,0,TRUE
+903101,68.78280565,35.59055699,3,Doshi School,Baghlan,4,Dushi,1,Doshi Near Bid Dara,9,Building,3,4,0,TRUE
+903102,68.76200422,35.79044378,2,Zahrabi Village School,Baghlan,4,Dushi,2,Zahrabi Village,9,Village,3,4,0,TRUE
+903103,68.80297982,35.79462379,2,Kela Gai,Baghlan,4,Dushi,2,Kela Gai Village,9,Building,3,4,0,TRUE
+903104,68.59888888,35.59472222,3,Poshta Konda Sang High School,Baghlan,4,Dushi,1,Poshta Konda Sang,9,Building,3,4,0,TRUE
+903105,68.60979543,35.39629789,2,Char Dar Clinic,Baghlan,4,Dushi,2,Char Dar Village,9,Village,3,4,0,TRUE
+903106,68.74057045,35.68198236,2,Zard Sang Social Saloon,Baghlan,4,Dushi,2,Zard Sang,9,Building,3,4,0,TRUE
+903107,68.83979376,35.76453716,3,Lar Khawb School,Baghlan,4,Dushi,1,Dara-E-Lar Khawb,9,Building,3,4,0,TRUE
+903108,68.702203,35.572194,3,Khwaja Zaid Madrassa,Baghlan,4,Dushi,1,Khwaja Zaid,9,Building,3,4,0,TRUE
+903109,68.791952,35.838627,2,Qura Daka High School,Baghlan,4,Dushi,2,Qura Daka,9,Building,3,4,0,TRUE
+903110,68.68373468,35.60991367,3,Chehl Ghori Doshi Girls High School,Baghlan,4,Dushi,1,Doshi,9,Building,3,4,0,TRUE
+903111,68.79938645,35.82940454,2,"Khan Mohammad Naseri, Open Space",Baghlan,4,Dushi,2,Khan Mohammad Naseri Village,9,Building,3,4,0,TRUE
+903240,68.58317081,35.56164054,3,Zargha Village Mosque,Baghlan,4,Dushi,1,Zargha Village,9,Village,3,4,0,TRUE
+903261,68.730003688,35.59830178,2,Abo Hanifa Madrasa,Baghlan,3,Doshi,1,Khwaja Zaid Sufla,9,Building,3,3,0,TRUE
+903262,68.769196919,35.758910542,2,Sang Sorakh Secondary School,Baghlan,3,Doshi,1,Sang Sorakh,9,Building,3,3,0,TRUE
+903263,68.805076824,35.837026663,2,Nasri Secondary School,Baghlan,3,Doshi,1,Naseri Ha,9,Building,3,3,0,TRUE
+903264,68.647883396,35.598126999,2,School,Baghlan,3,Doshi,1,Dara Gai,9,Building,3,3,0,TRUE
+904128,69.04472548,36.06794074,2,Hazrat Osman High School,Baghlan,4,Nahreen,2,Turksayad,9,Building,4,4,0,TRUE
+904129,68.99274753,35.94394164,2,Salangi Mosque,Baghlan,3,Nahreen,1,Badam Dara Salengi,9,Building,4,3,0,TRUE
+904130,69.01029016,35.91592871,2,Dar Jami And Sayed Tent,Baghlan,3,Nahreen,1,Barem Wa Sayed Jami,9,Building,4,3,0,TRUE
+904131,69.02856577,35.96147935,2,Almato High School,Baghlan,3,Nahreen,1,Almato,9,Building,4,3,0,TRUE
+904132,69.02114351,36.0438265,2,Ara Kash School,Baghlan,3,Nahreen,1,Arakash,9,Building,4,3,0,TRUE
+904133,68.96207303,36.0693105,2,Hazrat Abas School,Baghlan,3,Nahreen,1,Baraqi,9,Building,4,3,0,TRUE
+904134,69.02068944,36.09549998,3,Lakan Khel School,Baghlan,5,Nahreen,2,Lakan Khel,9,Building,4,5,0,TRUE
+904135,69.07888806,35.91090264,2,Sobhan School,Baghlan,3,Nahreen,1,Sobhan Village,9,Building,4,3,0,TRUE
+904136,69.08651836,35.98997844,2,Khwaja Khezr High School,Baghlan,3,Nahreen,1,Khwja Khezr,9,Building,4,3,0,TRUE
+904137,69.12829738,36.01194133,2,Du Aabi School,Baghlan,3,Nahreen,1,Do Aabi,9,Building,4,3,0,TRUE
+904138,69.11777777,36.05944444,2,Gul Meran Shaheed High School,Baghlan,3,Nahreen,1,Logari Ha Village,9,Building,4,3,0,TRUE
+904139,69.10484894,36.06533498,2,Bibi Ameena Girls School,Baghlan,3,Nahreen,1,Shahr-E-Jadid,9,Building,4,3,0,TRUE
+904140,69.13276106,36.06817211,2,Shahr-E-Qadim Grils School,Baghlan,3,Nahreen,1,Shahri Qadim Nahreen,9,Building,4,3,0,TRUE
+904141,68.98044262,36.1146491,2,Taliha School,Baghlan,3,Nahreen,1,Tali Ha,9,Building,4,3,0,TRUE
+904142,69.15451111,36.05511391,2,Shindara School,Baghlan,3,Nahreen,1,Shindara Village,9,Building,4,3,0,TRUE
+904143,69.11889716,36.07592176,2,Sar Kateb Lal Mohammad Mosque,Baghlan,3,Nahreen,1,Tawa Shakh,9,Building,4,3,0,TRUE
+904144,69.08858996,35.96852027,2,Alhaqia Khawaja Khezr School,Baghlan,3,Nahreen,1,Boz Dara,9,Building,4,3,0,TRUE
+904145,68.95936441,35.91703247,2,Woterchi Village Jamae Mosque,Baghlan,3,Nahreen,1,Wetr Chi,9,Building,4,3,0,TRUE
+904146,69.01438141,36.09575274,1,Haji Omar Lakan Khel Mosque,Baghlan,3,Nahreen,2,Lakan Khel Village,9,Building,4,3,0,TRUE
+904243,69.10497978,36.03997192,2,Joy Kalan Haji Fazel School,Baghlan,3,Nahreen,1,Joy Kalan,9,Building,4,3,0,TRUE
+904244,69.075556,36.08367311,2,Agari Mosque,Baghlan,3,Nahreen,1,Agri,9,Building,4,3,0,TRUE
+904245,69.07745097,36.05881249,2,Hafiz Bacha Mosque,Baghlan,3,Nahreen,1,Hafiz Bacha,9,Building,4,3,0,TRUE
+904246,69.00103095,36.04271601,2,Lozok Madressa,Baghlan,3,Nahreen,1,Madrassa Lozok,9,Building,4,3,0,TRUE
+904265,69.003424525,36.089925676,2,Khwaja Gul Khar School,Baghlan,3,Nahreen,1,Khwaja Gul Khor,9,District,4,3,0,TRUE
+904266,69.043562531,36.090081326,2,Mosque,Baghlan,3,Nahreen,1,Qozi Bala,9,Building,4,3,0,TRUE
+904267,68.960966709,36.109720213,2,School,Baghlan,3,Nahreen,1,Qara Ghaj Saka,9,Building,4,3,0,TRUE
+905042,68.74891126,36.17475711,4,Baghlan-E- Jadeed Sport Club,Baghlan,5,Baglan-E-Jadeed,1,Baghlan City,9,Building,5,5,0,TRUE
+905043,68.82709703,36.31331788,2,Chahar Shanba Tapa School,Baghlan,3,Baglan-E-Jadeed,1,Taheri Ha Village,9,Building,5,3,0,TRUE
+905044,68.85606647,36.24444469,2,Basharha Clinic,Baghlan,3,Baglan-E-Jadeed,1,Bashar Ha Hassan Tal,9,Building,5,3,0,TRUE
+905045,68.85254523,36.23459075,2,Hasan Tal High School,Baghlan,4,Baglan-E-Jadeed,2,Hoofyani Hassan Tal,9,Building,5,4,0,TRUE
+905046,68.69723318,36.22774785,2,Mangalha Boys High School,Baghlan,4,Baglan-E-Jadeed,2,Mangal Ha Village,9,Building,5,4,0,TRUE
+905047,68.68556858,36.12323619,3,Baghlan Sanhaty Clinic,Baghlan,4,Baglan-E-Jadeed,1,Kotehai Sherkat Qand,9,Building,5,4,0,TRUE
+905048,68.68552318,36.16563965,2,Qaisir Khel High School,Baghlan,3,Baglan-E-Jadeed,1,Qaisar Khel,9,Building,5,3,0,TRUE
+905049,68.80910289,36.28554985,2,Abuhad Jarkhoshk School,Baghlan,3,Baglan-E-Jadeed,1,Jarkhoshkak,9,Building,5,3,0,TRUE
+905050,68.92038616,36.41935702,2,Jelawgir Secondary School,Baghlan,3,Baglan-E-Jadeed,1,Central Jelawgir,9,Building,5,3,0,TRUE
+905051,68.75241942,36.25601236,2,Shahi Khel Secondary School,Baghlan,4,Baglan-E-Jadeed,2,Shahi Khel,9,Building,5,4,0,TRUE
+905052,68.70277777,36.27027777,1,Allawuddin Mosque,Baghlan,2,Baglan-E-Jadeed,1,Shahi Khel Village,9,Building,5,2,0,TRUE
+905053,68.77241501,36.21851065,2,Shair Qadem Baghlan  Clinic,Baghlan,3,Baglan-E-Jadeed,1,Allawuddin  Village,9,Building,5,3,0,TRUE
+905054,68.73850708,36.13276995,2,Meya Gul Shahid Secondary School,Baghlan,4,Baglan-E-Jadeed,2,Road 11,9,Building,5,4,0,TRUE
+905055,68.85929142,36.10168107,2,Shaikh Jalal School,Baghlan,3,Baglan-E-Jadeed,1,Shaikh Jalal,9,Building,5,3,0,TRUE
+905056,68.7505911,36.17443214,2,Baghlan Jadeed Girls School,Baghlan,4,Baglan-E-Jadeed,2,Shahr-E-Baghlan Jadeed,9,Building,5,4,0,TRUE
+905057,68.74323044,36.17523657,2,Baghlan Jadeed Municipality Clop,Baghlan,3,Baglan-E-Jadeed,1,Shahr-E-Baghlan Jadeed,9,Building,5,3,0,TRUE
+905058,68.76947796,36.22303853,2,Shahr-E-Baghlan Qadim Mosque,Baghlan,4,Baglan-E-Jadeed,2,Shahr-E-Baghlan Jadeed,9,Building,5,4,0,TRUE
+905059,68.68456665,36.12250999,2,Baghlan  Sanhaty Boys High School,Baghlan,3,Baglan-E-Jadeed,1,Shahr Fabrika,9,Building,5,3,0,TRUE
+905060,68.68665928,36.11283076,2,Zeerina School,Baghlan,4,Baglan-E-Jadeed,2,Bagh-E-Zaraut,9,Building,5,4,0,TRUE
+905061,68.71932958,36.15744804,2,Khwaja Khan Baba School,Baghlan,3,Baglan-E-Jadeed,1,Khawaja Khan Street 12,9,Building,5,3,0,TRUE
+905062,68.74810959,36.18056534,2,Central Baghlan Mosque,Baghlan,4,Baglan-E-Jadeed,2,Shahr-E-Jadeed,9,Building,5,4,0,TRUE
+905063,68.751468,36.18389765,2,Baghlan Jadeedhealth Department,Baghlan,3,Baglan-E-Jadeed,1,Shahr-E-Baghlan Jadeed,9,Building,5,3,0,TRUE
+905064,68.54272161,36.23842111,1,Baisqal,Baghlan,2,Baglan-E-Jadeed,1,Baisqal Village,9,Village,5,2,0,TRUE
+905065,68.69626682,36.19472415,1,Qeshlaq Arab Ha Leftside Of Qasarkhel,Baghlan,2,Baglan-E-Jadeed,1,Qeshlaq Arab Ha,9,Building,5,2,0,TRUE
+905066,68.72638888,36.30305555,1,Qara Barq Aabqul School,Baghlan,2,Baglan-E-Jadeed,1,Qora Barq Aabqul,9,Building,5,2,0,TRUE
+905067,68.70721641,36.14567694,2,Naz Kamir Shaheed School,Baghlan,4,Baglan-E-Jadeed,2,Eighth Street,9,Building,5,4,0,TRUE
+905068,68.54505851,36.25178672,1,Qandari Abdullah Jan,Baghlan,2,Baglan-E-Jadeed,1,Zarif Qandari Baisqal Village,9,Village,5,2,0,TRUE
+905069,68.73731742,36.1312021,2,Mowlawe Allahdad Mosque,Baghlan,2,Baglan-E-Jadeed,0,Allah Dad Dasht-E-Kbr Village,9,District,5,2,0,TRUE
+905070,68.76439509,36.3297732,1,Molla Najeeb Mosque,Baghlan,2,Baglan-E-Jadeed,1,Molla Najib Village,9,Village,5,2,0,TRUE
+905071,68.79133667,36.19350884,2,Ghulam Moheddin Yakatoot Mosque,Baghlan,3,Baglan-E-Jadeed,1,Qandahari,9,Building,5,3,0,TRUE
+905072,68.547028082,36.433865478,2,Azim Shor,Baghlan,3,Baglan-E-Jadeed,1,Molla Qadir Village,9,Village,5,3,0,TRUE
+905073,68.73463626,36.12736064,4,Cham Qala,Baghlan,7,Baglan-E-Jadeed,3,Patan Khil,9,Building,5,7,0,TRUE
+905074,68.85808029,36.36316514,3,Abobakr Jamae Mosque,Baghlan,5,Baglan-E-Jadeed,2,Abobakr Village,9,Building,5,5,0,TRUE
+905233,68.663040273,36.103951649,2,Raes Payanda Jan School,Baghlan,3,Baglan-E-Jadeed,1,Ghurbandi,9,Building,5,3,0,TRUE
+905234,68.89102338,36.36405373,2,Safid Mosque Primary School,Baghlan,4,Baglan-E-Jadeed,2,Masjid Safid Uzbek Ha Village,9,Building,5,4,0,TRUE
+905235,68.86553706,36.35873602,2,Haji Delawar Village Mosque,Baghlan,3,Baglan-E-Jadeed,1,Haji Delawar Village,9,Building,5,0,3,FALSE
+905236,68.77452104,36.28049239,2,Hemat Khel Mosque,Baghlan,4,Baglan-E-Jadeed,2,Hemat Khel Village,9,Village,5,4,0,TRUE
+905237,68.75440413,36.15374023,2,Torani Ha Mosque,Baghlan,3,Baglan-E-Jadeed,1,Torani Ha Village,9,Building,5,3,0,TRUE
+905268,68.774389751,36.187898774,2,Mosque,Baghlan,3,Baglan-E-Jadeed,1,Arbab Yahya,9,Building,5,3,0,TRUE
+905269,68.835266733,36.158274333,2,Primary School,Baghlan,3,Baglan-E-Jadeed,1,Shotur Ghalt,9,Building,5,3,0,TRUE
+905270,68.733553909,36.193763873,2,Gharo Shakh School,Baghlan,3,Baglan-E-Jadeed,1,Gharo Shakh Tajik Ha,9,Building,5,3,0,TRUE
+905271,68.767864132,36.170825831,2,Secondary School,Baghlan,3,Baglan-E-Jadeed,1,Laqha,9,Building,5,3,0,TRUE
+905272,68.748494954,36.208890356,2,Mualah Khil Mosque,Baghlan,3,Baglan-E-Jadeed,1,Mulah Khil,9,Building,5,3,0,TRUE
+905273,68.763676834,36.197166156,2,Chiabi Mdrasa,Baghlan,3,Baglan-E-Jadeed,1,Chihbi Ha,9,Building,5,3,0,TRUE
+905274,68.780142149,36.223219738,2,Haji Nabei Mosque,Baghlan,3,Baglan-E-Jadeed,1,Haji Nabi,9,Building,5,3,0,TRUE
+905275,68.735631698,36.290958017,2,Mulah Khal Muhammad Mosque,Baghlan,3,Baglan-E-Jadeed,1,Larkhwabi,9,Building,5,3,0,TRUE
+906112,68.90135044,35.59924237,3,Khenjan Boys High School,Baghlan,5,Khinjan,2,Khenjan City Capital,9,Building,6,5,0,TRUE
+906113,68.88276846,35.55934513,3,Haris School,Baghlan,4,Khinjan,1,Waliyan Village,9,Building,6,4,0,TRUE
+906114,69.05937834,35.5223889,2,Ahmad Shah Masoud School,Baghlan,3,Khinjan,1,Khoshkak Village,9,Building,6,3,0,TRUE
+906115,68.93041497,35.50614657,2,Lalmaie Primary School,Baghlan,3,Khinjan,1,Lalmaie Village,9,Building,6,3,0,TRUE
+906116,68.85893659,35.60451848,1,Gazan Mosque,Baghlan,2,Khinjan,1,Guzan Payan,9,Building,6,2,0,TRUE
+906117,69.02109946,35.58569539,1,Bajgah High School,Baghlan,2,Khinjan,1,Bajgah Village,9,Building,6,2,0,TRUE
+906118,68.96559553,35.60101269,1,Amrod School,Baghlan,2,Khinjan,1,Dasht-E-Amrod,9,Building,6,2,0,TRUE
+906119,68.88294371,35.49784721,1,School,Baghlan,2,Khinjan,1,Khoob Dara Village,9,Building,6,2,0,TRUE
+906241,68.91678711,35.60065362,2,Feraq Dara Mosque,Baghlan,3,Khinjan,1,Turkan,9,Building,6,3,0,TRUE
+907120,69.04595753,35.60097124,3,Youch High School,Baghlan,4,Andarab,1,Youch Village,9,Building,7,4,0,TRUE
+907121,69.27934285,35.62488246,2,Sari Pul Village Tent,Baghlan,3,Andarab,1,Saripul Village,9,Building,7,3,0,TRUE
+907122,69.21299212,35.6180178,3,Keshan Abad Village Mosque,Baghlan,4,Andarab,1,Keshan Abad Village,9,Building,7,4,0,TRUE
+907123,69.25744711,35.63392228,3,Beno Boys School,Baghlan,5,Andarab,2,Center Of Bano City,9,Building,7,5,0,TRUE
+907124,69.10871673,35.61800535,2,Khoshdara Secondary School,Baghlan,3,Andarab,1,Khoshdara Center,9,Building,7,3,0,TRUE
+907125,69.1394656,35.62697115,2,Kafter Khana High School,Baghlan,3,Andarab,1,Kaftar Khana Village,9,Building,7,3,0,TRUE
+907126,69.31722235,35.62348832,2,Daragi Village Mosque,Baghlan,3,Andarab,1,Daragi,9,Building,7,3,0,TRUE
+907127,69.0077917,35.71060623,2,Speech Mosque,Baghlan,3,Andarab,1,Speech Village,9,Village,7,3,0,TRUE
+907242,69.2728371,35.5604334,1,Laghak Mosque,Baghlan,3,Andarab,2,Laghak,9,Building,7,3,0,TRUE
+908181,69.3429755,35.71182387,2,Kar Gard Tent,Baghlan,3,Deh Salah,1,Kar Gard,9,Building,8,3,0,TRUE
+908182,69.3032412,35.6631639,1,Uroznegan Village Mosque,Baghlan,2,Deh Salah,1,Uroznegan Village,9,Building,8,2,0,TRUE
+908183,69.22879551,35.70093944,2,Kamekhlar Mosque,Baghlan,3,Deh Salah,1,Kamekhlar,9,Building,8,3,0,TRUE
+908184,69.33108558,35.78028071,2,Shahshan Big Clinic,Baghlan,3,Deh Salah,1,Eilnag Kalan Shahshan,9,Building,8,3,0,TRUE
+908185,69.42887567,35.7361235,2,Amam Qutbia Madrassa,Baghlan,3,Deh Salah,1,Pashayee,9,Building,8,3,0,TRUE
+908186,69.3244011,35.67573367,1,Sangbaran Madrassa,Baghlan,2,Deh Salah,1,Sang Baran,9,Building,8,2,0,TRUE
+908187,69.31149006,35.68630856,1,Deh Salah  Bazar School,Baghlan,2,Deh Salah,1,Deh Salah Bazaar,9,Building,8,2,0,TRUE
+908188,69.31331295,35.75558451,1,Tel Merghazi School,Baghlan,2,Deh Salah,1,Tel Merghazi,9,Building,8,2,0,TRUE
+908189,69.39003621,35.7269177,2,Gudali Sharif Mosque,Baghlan,3,Deh Salah,1,Gadali,9,Building,8,3,0,TRUE
+908251,69.31744193,35.71495333,1,Saka Sharif Moaque,Baghlan,2,Deh Salah,1,Saka,9,Building,8,2,0,TRUE
+908276,69.331092615,35.780268958,2,Shahshan High School,Baghlan,3,Deh Salah,1,Deh Now,9,Building,8,3,0,TRUE
+909190,69.31471458,36.07081141,2,Sangee Ghuri School,Baghlan,4,Jalga,2,Gadree,9,Building,9,4,0,TRUE
+909191,69.27588823,35.8819216,1,Zard Aspan Mosque,Baghlan,3,Jalga,2,Zard Aspan,9,Building,9,3,0,TRUE
+909192,69.25170609,35.94787906,2,Maolawe Sayed Ahmad High School,Baghlan,3,Jalga,1,Mherdad Village,9,Building,9,3,0,TRUE
+909193,69.26522714,35.93190219,1,Yarm Ulya High School,Baghlan,3,Jalga,2,Yarm Ulya,9,Building,9,3,0,TRUE
+909194,69.25325913,35.86050888,2,Hamidullah Shaheed High School,Baghlan,3,Jalga,1,Siah Rieg,9,Building,9,3,0,TRUE
+909195,69.25109427,36.04119475,2,Khwaja Hejran Primary School,Baghlan,3,Jalga,1,Khwaja Hajran,9,Building,9,3,0,TRUE
+909196,69.36542801,36.05963317,2,Primary School,Baghlan,3,Jalga,1,Gadree,9,Building,9,3,0,TRUE
+909197,69.23738564,35.86646849,2,Chardeh Mosque,Baghlan,3,Jalga,1,Chardeh,9,Building,9,3,0,TRUE
+909198,69.2585123,35.97428164,2,Warichi Mosque And Madrassa,Baghlan,4,Jalga,2,Warichi,9,Building,9,4,0,TRUE
+909199,69.2517169,35.92660605,2,Yarm Sufla Madrassa,Baghlan,4,Jalga,2,Yarm Sufla,9,Building,9,4,0,TRUE
+909200,69.28714327,36.06219648,2,Gadree Mosque,Baghlan,4,Jalga,2,Gardree,9,Building,9,4,0,TRUE
+909252,69.27501425,35.85370617,1,Khawja Awliya Mosque,Baghlan,2,Jalga,1,Khwaja Awliya,9,Building,9,2,0,TRUE
+909277,69.254129595,35.829595023,2,Masan Mosque,Baghlan,3,Jalga,1,Masan,9,Building,9,3,0,TRUE
+909278,69.281944463,35.936658664,2,Yarm Ulia Mosque,Baghlan,3,Jalga,1,Yarm Hulya,9,Building,9,3,0,TRUE
+910147,69.09144191,36.25576289,3,Deh Bash School,Baghlan,4,Burka,1,Deh Bash,9,Building,10,4,0,TRUE
+910148,69.00633726,36.29354378,2,Haji Momen Mosque,Baghlan,3,Burka,1,Hazar Qaq,9,Building,10,3,0,TRUE
+910149,69.01274282,36.3947839,2,Shor Qudoq Madrassa,Baghlan,3,Burka,1,Shor Qudoq,9,Building,10,3,0,TRUE
+910150,69.323069806,36.174816222,2,Sai Hezada Secondary School,Baghlan,4,Burka,2,Haji Hazrat Shah,9,Building,10,4,0,TRUE
+910151,69.24132203,36.21844866,2,Falol High School,Baghlan,4,Burka,2,Felol,9,Building,10,4,0,TRUE
+910152,69.13339855,36.20021729,2,Chapa School,Baghlan,3,Burka,1,Chapa,9,Building,10,3,0,TRUE
+910153,69.15123749,36.22069508,2,Markaz Girls School,Baghlan,3,Burka,1,Barka District Center,9,Building,10,3,0,TRUE
+910154,69.18747914,36.14538473,2,Sharshar School,Baghlan,3,Burka,1,Shar Shar,9,Building,10,3,0,TRUE
+910155,69.12629517,36.30222882,2,Abdulmomin Shaheed School,Baghlan,3,Burka,1,Yaka Toot,9,Building,10,3,0,TRUE
+910156,69.2513294,36.21740403,2,Khalifa Mosque,Baghlan,3,Burka,1,Felol Ulya,9,Building,10,3,0,TRUE
+910157,69.00869453,36.35015046,2,Boolak High School,Baghlan,3,Burka,1,Boolak Poshta,9,Building,10,3,0,TRUE
+910158,69.00489116,36.32439439,2,Jamali Arab Sai Mosque,Baghlan,3,Burka,1,Jomali,9,Building,10,3,0,TRUE
+910159,69.00124473,36.23668586,2,Mariam Cheshma Mosque,Baghlan,4,Burka,2,Mariam Cheshma,9,Building,10,4,0,TRUE
+910160,69.13346914,36.10855794,2,Shorcha School,Baghlan,3,Burka,1,Shorcha,9,Building,10,3,0,TRUE
+910161,69.1816802,36.2846094,2,Tangi Murch Girls School,Baghlan,3,Burka,1,Tangi Murch,9,Building,10,3,0,TRUE
+910162,69.12092362,36.22711135,2,Baba Aayeb Secondary School,Baghlan,3,Burka,1,Shash Gul,9,Building,10,3,0,TRUE
+910247,69.2042646,36.24082593,2,Naw Abad School,Baghlan,3,Burka,1,Folol Dasht,9,Building,10,3,0,TRUE
+910248,69.11497271,36.344416,2,Tash Cheshma,Baghlan,3,Burka,1,Qarcha And Tash Cheshma,9,Building,10,3,0,TRUE
+911163,68.21418021,35.38125668,3,Tala Boys High School,Baghlan,4,Tala Wa Barfak,1,Tala District,9,Building,11,4,0,TRUE
+911164,68.14751869,35.34609275,3,Numania Madrassa,Baghlan,4,Tala Wa Barfak,1,Zer Bagh,9,Building,11,4,0,TRUE
+911165,68.15679333,35.35476506,2,Poshta Qara Madrassa,Baghlan,3,Tala Wa Barfak,1,Poshta Qara,9,Building,11,3,0,TRUE
+911166,68.34173269,35.39774079,1,Angar School,Baghlan,2,Tala Wa Barfak,1,Angar,9,Building,11,2,0,TRUE
+911167,68.28213369,35.4032055,2,Bolandi Ashraf Madrassa,Baghlan,4,Tala Wa Barfak,2,Bolandi Ashraf Village,9,Building,11,4,0,TRUE
+911168,68.24970708,35.41812031,2,Dahana Astma Tent,Baghlan,4,Tala Wa Barfak,2,Dahana Astma,9,Building,11,4,0,TRUE
+911169,68.29675765,35.48145984,2,Vado High School,Baghlan,3,Tala Wa Barfak,1,Vado,9,Building,11,3,0,TRUE
+911170,68.14243346,35.35715368,2,Barfak Secondary School,Baghlan,3,Tala Wa Barfak,1,Surkhjoy,9,Building,11,3,0,TRUE
+911171,68.04871204,35.09442759,1,Amir Nazia Mosque,Baghlan,2,Tala Wa Barfak,1,Dahana Rashqab,9,Building,11,2,0,TRUE
+911172,68.29024332,35.53243159,1,Tarmesh Mosque,Baghlan,2,Tala Wa Barfak,1,Termesh,9,Building,11,2,0,TRUE
+911249,68.13344506,35.18493345,2,Har Do Aab Mosque,Baghlan,3,Tala Wa Barfak,1,Har Do Aab,9,Building,11,3,0,TRUE
+911279,68.398160378,35.390254981,2,Klola Sang Mosque,Baghlan,3,Tala Wa Barfak,1,Klola Sang,9,Building,11,3,0,TRUE
+912173,69.34369932,35.66985921,2,Naw Bahar School,Baghlan,3,Pul-E-Hisar,1,Naw Bahar,9,Building,12,3,0,TRUE
+912174,69.45047622,35.62778169,1,Deh Yak  Mosque,Baghlan,2,Pul-E-Hisar,1,Dehyak,9,Building,12,2,0,TRUE
+912175,69.50296035,35.61251858,1,Lakarmar Mosque,Baghlan,2,Pul-E-Hisar,1,Lakarmar,9,Building,12,2,0,TRUE
+912176,69.6322353,35.6286386,1,Samandan School,Baghlan,2,Pul-E-Hisar,1,Samandan,9,Building,12,2,0,TRUE
+912177,69.44192205,35.56506548,1,Taghanak Mosque,Baghlan,2,Pul-E-Hisar,1,Taghanak,9,Building,12,0,2,FALSE
+912178,69.4797005,35.55251998,1,Deresho Mosque,Baghlan,2,Pul-E-Hisar,1,Daresho,9,Building,12,0,2,FALSE
+912179,69.66356222,35.63255114,1,Qalakha Mosque,Baghlan,2,Pul-E-Hisar,1,Qalakha,9,Building,12,2,0,TRUE
+912180,69.46450725,35.61978272,1,Pul-E-Hesar Tent,Baghlan,2,Pul-E-Hisar,1,Pul-E-Hesar District Center,9,Building,12,2,0,TRUE
+912250,69.36798397,35.65474123,1,As-Hab-E-Kahf School,Baghlan,2,Pul-E-Hisar,1,As-Hab-E-Kahf,9,Building,12,2,0,TRUE
+913201,69.60519098,36.01674254,2,Du Aabi Girls High School,Baghlan,3,Khost Wa Firing,1,Qarghan,9,Building,13,3,0,TRUE
+913202,69.66067918,36.02657342,2,Sabz Mohammad Khan High School,Baghlan,3,Khost Wa Firing,1,Far Ghanbal,9,Building,13,3,0,TRUE
+913203,69.7283867,36.03196626,1,Mohammad Afzal Shaheed School,Baghlan,2,Khost Wa Firing,1,Char Qeshlaq,9,Building,13,2,0,TRUE
+913204,69.76800462,35.99929177,1,Malam Secondary School,Baghlan,2,Khost Wa Firing,1,Sangan Village,9,Building,13,2,0,TRUE
+913205,69.63918983,35.97184231,1,Konjak Secondary School,Baghlan,2,Khost Wa Firing,1,Konjak,9,Building,13,2,0,TRUE
+913206,69.66387703,35.99903401,2,Zakor Khoshdara School,Baghlan,3,Khost Wa Firing,1,Meyan Deh,9,Building,13,3,0,TRUE
+913207,69.68032314,35.90012733,1,Gozar School,Baghlan,2,Khost Wa Firing,1,Gozar,9,Building,13,2,0,TRUE
+913208,69.50966427,35.96509964,2,Bazaar School,Baghlan,3,Khost Wa Firing,1,Bazaar,9,Building,13,3,0,TRUE
+913209,69.52591259,36.04842209,1,Meyan Shahr School,Baghlan,2,Khost Wa Firing,1,Meyan Shahr,9,Building,13,2,0,TRUE
+913210,69.51993321,36.10798656,1,Yakha Primary School,Baghlan,2,Khost Wa Firing,1,Yakha,9,Building,13,2,0,TRUE
+913211,69.49925132,35.9096527,2,Dahana High School,Baghlan,3,Khost Wa Firing,1,Dahana,9,Building,13,3,0,TRUE
+913212,69.51644041,36.00701467,2,Baharak Secondary School,Baghlan,3,Khost Wa Firing,1,Baharak,9,Building,13,3,0,TRUE
+913213,69.52598634,35.95520713,1,Abdul Haq Narzo School,Baghlan,2,Khost Wa Firing,1,Deh Mollah Khatib,9,Building,13,2,0,TRUE
+913214,69.54817676,35.83259863,2,Khahosh Primary School,Baghlan,3,Khost Wa Firing,1,Shekhan,9,Building,13,3,0,TRUE
+913215,69.4654617,35.98753128,1,Wach Primary School,Baghlan,2,Khost Wa Firing,1,Wach,9,Building,13,2,0,TRUE
+913216,69.56053814,36.02679803,1,Garm Aaba School,Baghlan,2,Khost Wa Firing,1,Garm Aaba,9,Building,13,2,0,TRUE
+913217,69.62185896,35.98800112,1,Gardan Tal School,Baghlan,2,Khost Wa Firing,1,Pul-E- Asad,9,Building,13,2,0,TRUE
+913253,69.50456051,35.93088122,2,Deh Merak Madressa,Baghlan,3,Khost Wa Firing,1,Daragee,9,Building,13,3,0,TRUE
+913254,69.79588669,36.02302714,2,Deh Kalan Madressa,Baghlan,3,Khost Wa Firing,1,Deh Kalan,9,Building,13,3,0,TRUE
+913255,69.48184605,35.88487582,1,Sechi Secondary School,Baghlan,2,Khost Wa Firing,1,Sechi,9,Building,13,2,0,TRUE
+913256,69.64807401,35.95462398,1,Qala-E-Mir Primary School,Baghlan,2,Khost Wa Firing,1,Qala-E-Mir,9,Building,13,2,0,TRUE
+914224,69.5774482,36.20769808,3,Gharo Boys High School,Baghlan,5,Gozargah-E-Noor,2,Gharo,9,Building,14,5,0,TRUE
+914225,69.53443012,36.20502281,2,Jerab Secondary School,Baghlan,3,Gozargah-E-Noor,1,Jar Aab Village,9,Building,14,3,0,TRUE
+914226,69.54555688,36.2350411,1,Yahoor Mosque,Baghlan,3,Gozargah-E-Noor,2,Yahoor,9,Building,14,3,0,TRUE
+914280,69.621380875,36.223162655,2,Muhammad Hanif Femal School,Baghlan,3,Firing Wa Gharu,1,Jryan Gharo,9,Village,14,3,0,TRUE
+915218,69.58636593,36.12806391,2,Mahan Rameen High School,Baghlan,3,Firing Wa Gharu,1,Dahana Farang,9,Building,15,3,0,TRUE
+915219,69.60760908,36.11779326,1,Deh Mir Mosque,Baghlan,2,Firing Wa Gharu,1,Char Qarya,9,Building,15,2,0,TRUE
+915220,69.64221932,36.11640062,1,Sawq Centeral High School,Baghlan,2,Firing Wa Gharu,1,Sawq,9,Building,15,2,0,TRUE
+915221,69.66401823,36.1234938,1,Hazrat Saheb Mosque,Baghlan,2,Firing Wa Gharu,1,Murad Shahr,9,Building,15,2,0,TRUE
+915222,69.68128445,36.1351708,1,Morad Shahr Mosque,Baghlan,2,Firing Wa Gharu,1,Asfahan,9,Building,15,2,0,TRUE
+915223,69.61973766,36.11108262,1,Haji Mohammad Alam Khan Mosque,Baghlan,2,Firing Wa Gharu,1,Hazara,9,Building,15,2,0,TRUE
+915257,69.65878025,36.13079599,1,Dasht-E-Shehan Mosque,Baghlan,2,Firing Wa Gharu,1,Arbab Mulla Murad Shahr,9,Building,15,2,0,TRUE
+915281,69.651194015,36.121359051,2,Mosque,Baghlan,3,Firing Wa Gharu,1,Saoq,9,Village,15,3,0,TRUE
+1001001,67.84394758,34.82370301,6,Bamyan Center Boys High School,Bamyan,9,Bamyan,3,Bamyan Center,10,Building,1,11,0,TRUE
+1001002,67.83520339,34.81105938,0,Sayed Abad Girls School,Bamyan,6,Bamyan,6,Sayed Abad,10,Building,1,6,0,TRUE
+1001003,67.65521591,34.92907686,2,Aaq Rubat School,Bamyan,4,Bamyan,2,Aaq Rubat,10,Building,1,4,0,TRUE
+1001004,67.84938857,34.73206817,1,Dokani School,Bamyan,3,Bamyan,2,Dokani,10,Building,1,3,0,TRUE
+1001005,67.87140673,34.81214191,2,Lala Khel School,Bamyan,4,Bamyan,2,Lala Khel,10,Building,1,4,0,TRUE
+1001006,67.73594397,34.73682192,2,Qazan School,Bamyan,4,Bamyan,2,Qazan-E-Nawrozi,10,Building,1,4,0,TRUE
+1001007,67.71286762,34.74959256,2,Zekria Mosque,Bamyan,4,Bamyan,2,Zekria,10,Building,1,4,0,TRUE
+1001008,67.74150962,34.77702118,0,Shinia Girls School,Bamyan,3,Bamyan,3,Shinia,10,Building,1,3,0,TRUE
+1001009,67.74522709,34.77870666,4,Shinia Madrassa,Bamyan,4,Bamyan,0,Shinia,10,Building,1,4,0,TRUE
+1001010,67.89627546,34.78539642,1,Samora Mosque,Bamyan,3,Bamyan,2,Samora,10,Building,1,3,0,TRUE
+1001011,67.90530076,34.70601474,1,Dakdan School,Bamyan,3,Bamyan,2,Dakdan-E-Ahangaran,10,Building,1,3,0,TRUE
+1001012,67.94796635,34.81605935,1,Topchi Mosque,Bamyan,3,Bamyan,2,Topchi,10,Building,1,3,0,TRUE
+1001013,67.5885302,34.80600165,2,Shaheedan School,Bamyan,4,Bamyan,2,Bazar-E-Shaheedan,10,Building,1,4,0,TRUE
+1001014,67.57861506,34.76255591,1,Naul Shera Mosque,Bamyan,3,Bamyan,2,Naul Shera Sufla,10,Building,1,3,0,TRUE
+1001015,67.415112,34.7713111,1,Toop Ali School,Bamyan,3,Bamyan,2,"Toop Ali, Char Cheshma Qarghantu",10,Building,1,3,0,TRUE
+1001016,67.50294848,34.80134672,1,Peerdad School,Bamyan,3,Bamyan,2,Peerdad Shebarto,10,Building,1,3,0,TRUE
+1001017,67.53253152,34.85498153,2,Monbar Jeem Qala,Bamyan,4,Bamyan,2,Jeem Qala-E-Petaw,10,Building,1,4,0,TRUE
+1001018,67.76683174,34.75691408,2,Bam Sarai School,Bamyan,4,Bamyan,2,Bam Sarai,10,Building,1,4,0,TRUE
+1001019,67.78994943,34.74396949,1,Chap Dara Mosque,Bamyan,3,Bamyan,2,Chap Dara,10,Building,1,3,0,TRUE
+1001020,67.64003789,34.73364184,1,Sialayak School,Bamyan,3,Bamyan,2,Sialayak,10,Building,1,3,0,TRUE
+1001167,67.810420423,34.825060523,2,School,Bamyan,3,Bamyan,1,Tiboti,10,Building,1,4,0,TRUE
+1001168,67.781931516,34.833747317,2,Karte Solh High School,Bamyan,3,Bamyan,1,Mulah Ghulam,10,Building,1,4,0,TRUE
+1001169,67.51523845,34.878602828,2,Mosque,Bamyan,3,Bamyan,1,Dahan Jaopalan,10,Building,1,3,0,TRUE
+1002021,68.08324467,34.87759572,1,Wata Poor School,Bamyan,3,Shebar,2,Dahan Khushk,10,Building,2,3,0,TRUE
+1002022,68.04652213,34.82765466,1,Shinia Iraq School,Bamyan,2,Shebar,1,Shinia Iraq,10,Building,2,2,0,TRUE
+1002023,68.18117059,34.88927726,1,Shanbol Boys School,Bamyan,2,Shebar,1,Khak Baba,10,Building,2,2,0,TRUE
+1002024,68.16806666,34.90994528,2,Berglej Girls School,Bamyan,3,Shebar,1,Zee Sultan,10,Building,2,3,0,TRUE
+1002025,68.15678421,34.87418629,1,Shanbol Girls High School,Bamyan,2,Shebar,1,Dahan-E-Shanbol,10,Building,2,2,0,TRUE
+1002026,68.00779562,34.75475731,1,Sabz Aab Mosque,Bamyan,2,Shebar,1,Sabz Aab,10,Building,2,2,0,TRUE
+1002027,68.00962804,34.67811273,2,Dahan-E-Dewalak High School,Bamyan,3,Shebar,1,Dahan-E-Dewalak,10,Building,2,3,0,TRUE
+1002028,68.05934471,35.00960274,1,Jalmash School,Bamyan,2,Shebar,1,Jalmash,10,Building,2,2,0,TRUE
+1002029,67.9033024,34.98400116,1,Kangor School,Bamyan,2,Shebar,1,Dahan-E-Kangor,10,Building,2,2,0,TRUE
+1002030,68.01703962,34.98957945,3,Dahan-E-Ghundak Boys School,Bamyan,3,Shebar,0,Dahan-E-Ghundak Bazar,10,Building,2,3,0,TRUE
+1002031,68.02214134,34.99379976,0,Dahan-E-Ghundak Girls School,Bamyan,2,Shebar,2,Dahan-E-Ghundak,10,Building,2,2,0,TRUE
+1002032,67.94029919,35.1345854,2,Sare Qandi Baghak Madrassa,Bamyan,3,Shebar,1,"Aymandab, Sar-E-Qandi Baghak",10,Building,2,3,0,TRUE
+1002170,68.04621479,34.657094818,2,Sar Kalo Female School,Bamyan,3,Shebar,1,Ghar Gharae Sar Kalo,10,Building,2,3,0,TRUE
+1002171,67.971625391,35.180494333,2,Baghak Mosque,Bamyan,3,Shebar,1,Baghak,10,Building,2,3,0,TRUE
+1003033,67.67025336,35.1865346,2,Khudadad Khell Center Boys High School,Bamyan,4,Saighan,2,Khudadad Khel,10,Building,3,4,0,TRUE
+1003034,67.65481067,35.17241124,2,Qarona Male Mosque,Bamyan,2,Saighan,0,Qaron-E-Sufla,10,Building,3,2,0,TRUE
+1003035,67.64527445,35.16665475,0,Qarona Female Mosque,Bamyan,3,Saighan,3,Qaron-E-Ulya,10,Building,3,3,0,TRUE
+1003036,67.72687425,35.18652689,1,Boghundi Qarghan Mosque,Bamyan,2,Saighan,1,Qarghan,10,Building,3,2,0,TRUE
+1003037,67.749139,35.205579,3,Kalantarha Council Office,Bamyan,3,Saighan,0,Kalantarha,10,Building,3,3,0,TRUE
+1003038,67.75042924,35.20577801,0,Ghorchi Girls School,Bamyan,2,Saighan,2,Ghorchi,10,Building,3,2,0,TRUE
+1003039,67.78607956,35.19468496,1,Bianqali Mosque,Bamyan,2,Saighan,1,Bianqali,10,Building,3,2,0,TRUE
+1003040,67.48204019,35.12324591,1,Qalacha Mosque,Bamyan,2,Saighan,1,Qalacha,10,Building,3,2,0,TRUE
+1003041,67.55025279,35.19236003,2,Khwaja Ganj Mosque,Bamyan,3,Saighan,1,Khwaja Ganj,10,Building,3,3,0,TRUE
+1003042,67.94482718,35.22778686,2,Pasheng Mosque,Bamyan,2,Saighan,0,Pasheng,10,Building,3,2,0,TRUE
+1003043,67.9457312,35.2284785,0,Pasheng School,Bamyan,2,Saighan,2,Pasheng,10,Building,3,2,0,TRUE
+1003044,67.77844459,35.21219666,2,Pushtawaz Mosque,Bamyan,3,Saighan,1,Pushtawaz,10,Building,3,3,0,TRUE
+1003045,67.71544907,35.0161694,1,Ghurab Mosque,Bamyan,2,Saighan,1,Ghurab,10,Building,3,2,0,TRUE
+1003046,67.87541976,35.07186725,1,Jawdarah Mosque,Bamyan,2,Saighan,1,Jawdarah,10,Building,3,2,0,TRUE
+1003047,67.76469641,35.18643023,1,Cheraaghdan Mosque,Bamyan,2,Saighan,1,Cheraaghdan,10,Building,3,2,0,TRUE
+1003048,67.63878535,35.02934631,1,Kogdaay Mosque,Bamyan,2,Saighan,1,Kogdaay,10,Building,3,2,0,TRUE
+1003049,67.69132763,35.11784712,1,Sokhta Chenar Council Office,Bamyan,2,Saighan,1,Sokhta Chenar,10,Building,3,2,0,TRUE
+1003163,67.44945999,35.2001518,1,Munbar Umomi Qala-E-Begal,Bamyan,2,Saighan,1,Qala-E-Begal,10,Building,3,2,0,TRUE
+1003172,67.616923909,35.196563586,2,Samuch Ha Mosque,Bamyan,3,Saighan,1,Samuch Ha,10,Building,3,3,0,TRUE
+1003173,67.477593806,35.120996074,2,Kado Khana Mosque,Bamyan,3,Saighan,1,Kado Khana,10,Building,3,3,0,TRUE
+1004050,67.62043915,35.31499699,1,Roy Sang School,Bamyan,3,Kahmard,2,Roy Sang,10,Building,4,3,0,TRUE
+1004051,67.68282033,35.32957224,1,Payan Baagh Mosque,Bamyan,2,Kahmard,1,Payan Baagh,10,Building,4,2,0,TRUE
+1004052,67.78701397,35.37230091,1,Du Shaakh Mosque,Bamyan,2,Kahmard,1,Du Shaakh,10,Building,4,2,0,TRUE
+1004053,67.75964315,35.36737647,2,Duro Boys School,Bamyan,3,Kahmard,1,Doro,10,Building,4,3,0,TRUE
+1004054,67.81231026,35.39933023,1,Madar Mosque,Bamyan,2,Kahmard,1,Madar,10,Building,4,2,0,TRUE
+1004055,67.59553536,35.31849887,1,Beneq School,Bamyan,2,Kahmard,1,Beneq,10,Building,4,2,0,TRUE
+1004056,67.50675646,35.36291221,2,Aajar School,Bamyan,2,Kahmard,0,Aajar,10,Building,4,2,0,TRUE
+1004057,67.50556043,35.36243266,1,Yalgah Mosque,Bamyan,2,Kahmard,1,Yalgah,10,Building,4,2,0,TRUE
+1004058,67.93870236,35.28195147,1,Darband Mosque,Bamyan,2,Kahmard,1,Darband,10,Building,4,2,0,TRUE
+1004059,67.97158876,35.27338154,1,Kalach Mosque,Bamyan,2,Kahmard,1,Kalach,10,Building,4,2,0,TRUE
+1004060,67.99159766,35.26018083,2,Do Aab Madrassa,Bamyan,3,Kahmard,1,Do Aab,10,Building,4,3,0,TRUE
+1004061,67.87022063,35.33801297,2,Andaab Madrassa,Bamyan,3,Kahmard,1,Andaab,10,Building,4,3,0,TRUE
+1004062,67.89193464,35.38349881,1,Chokri Dara Mosque,Bamyan,2,Kahmard,1,Chokri Dara,10,Building,4,2,0,TRUE
+1004063,67.91448731,35.31249491,2,Dasht-E-Safid School,Bamyan,3,Kahmard,1,Dasht-E-Safid,10,Building,4,3,0,TRUE
+1004064,68.08132528,35.31545285,1,Eshpeshta School,Bamyan,2,Kahmard,1,Eshpeshta,10,Building,4,2,0,TRUE
+1004065,67.58295478,35.3982152,1,Lorenj School,Bamyan,2,Kahmard,1,Lorenj,10,Building,4,2,0,TRUE
+1004066,67.62050793,35.30050519,1,Laghaki Mosque,Bamyan,2,Kahmard,1,Laghaki,10,Building,4,2,0,TRUE
+1004067,68.09021143,35.37945221,1,Sargali School,Bamyan,2,Kahmard,1,Sargali,10,Building,4,2,0,TRUE
+1004068,67.83859751,35.34962217,1,Bajga School,Bamyan,2,Kahmard,1,Bajga,10,Building,4,2,0,TRUE
+1005069,66.96535089,34.73724629,3,Naik Madrassa,Bamyan,6,Yakawlang,3,Nayak,10,Building,5,6,0,TRUE
+1005070,67.05057659,34.68856997,1,Munbar-E-Naishar,Bamyan,3,Yakawlang,2,Naishar,10,Building,5,3,0,TRUE
+1005071,66.882715193,34.671965478,2,Zaarin Boys High School,Bamyan,3,Yakawlang,1,Zaarin,10,Building,5,3,0,TRUE
+1005072,66.84244182,34.67231445,1,Munbar-E-Sarkanak,Bamyan,2,Yakawlang,1,Sarkanak,10,Building,5,2,0,TRUE
+1005073,66.74750431,34.61724298,1,Munbar-E-Surkhake Payeen,Bamyan,2,Yakawlang,1,Surkhak,10,Building,5,2,0,TRUE
+1005074,66.82387715,34.72329531,2,Deh Surkh School,Bamyan,4,Yakawlang,2,Dahane Chardeh,10,Building,5,4,0,TRUE
+1005075,66.77626464,34.74759497,1,Tangi Safidak School,Bamyan,3,Yakawlang,2,Tangi Safidak,10,Building,5,3,0,TRUE
+1005076,67.17779205,34.81967706,1,Qala-E-Jafar School,Bamyan,2,Yakawlang,1,Qala-E-Jafar,10,Building,5,2,0,TRUE
+1005077,67.26881812,34.87443849,1,Munbar-E-Kaparak,Bamyan,2,Yakawlang,1,Abqol Ulya,10,Building,5,2,0,TRUE
+1005078,67.14728879,34.70489235,1,Munar-E-Sarqol Boys School,Bamyan,2,Yakawlang,1,Munar Sarqol,10,Building,5,2,0,TRUE
+1005079,67.31114893,34.72815729,1,Munbar-E-Kalta Toop,Bamyan,2,Yakawlang,1,Kalta Toup Paas Roya,10,Building,5,2,0,TRUE
+1005080,67.2223632,34.67231053,1,Sheerdosh Madrassa,Bamyan,2,Yakawlang,1,Sheerdosh,10,Building,5,2,0,TRUE
+1005081,66.7849851,34.54338987,2,Syah Dara Madrassa,Bamyan,3,Yakawlang,1,Shahre Naw Syah Dara,10,Building,5,3,0,TRUE
+1005082,66.89024194,34.60776325,1,Baghalak-E-Rustam Girls School,Bamyan,2,Yakawlang,1,Baghalake Rustam,10,Building,5,2,0,TRUE
+1005083,66.96754855,34.61564408,1,Anda Girls High School,Bamyan,2,Yakawlang,1,Anda,10,Building,5,2,0,TRUE
+1005084,67.05287208,34.98463891,1,Munbar-E-Kushkak Naqshi,Bamyan,2,Yakawlang,1,Kushkak Naqshi,10,Building,5,2,0,TRUE
+1005085,67.04438173,35.31514607,1,Duzdan Cheshma School,Bamyan,2,Yakawlang,1,Duzdan Cheshma,10,Building,5,2,0,TRUE
+1005086,66.55124526,34.95714352,1,Dara-E-Chasht School,Bamyan,2,Yakawlang,1,Dahane Dara-E-Chasht,10,Building,5,2,0,TRUE
+1005087,66.6163623,35.00804226,1,Munbar-E-Ali Jan,Bamyan,2,Yakawlang,1,Sare Dara-E-Chasht Ali Jan,10,Building,5,2,0,TRUE
+1005088,66.41648248,35.08781791,1,Dara-E-Mazar Madrassa,Bamyan,2,Yakawlang,1,Sapey Daarak,10,Building,5,2,0,TRUE
+1005089,66.44328043,35.04726013,2,Khamya Dasht-E-Sokhta,Bamyan,3,Yakawlang,1,"Zeri Dakhma Jungle, Gahwara Sang",10,Building,5,3,0,TRUE
+1005090,66.64161674,34.84258149,1,Sachak High School,Bamyan,2,Yakawlang,1,Sachak,10,Building,5,2,0,TRUE
+1005091,66.59965667,34.87617007,1,Munbar-E-Khamya Syah Khaak,Bamyan,2,Yakawlang,1,Syah Khaak Chehel Burj,10,Building,5,2,0,TRUE
+1005092,66.5321856,34.87990329,1,Ghur Ghurake Sare Zulech School,Bamyan,2,Yakawlang,1,Ghur Ghurake Sare Zurich,10,Building,5,2,0,TRUE
+1005093,66.46149527,34.93232507,1,Munbar-E-Shenia Sare Murghi,Bamyan,2,Yakawlang,1,Shenia Sare Murghi,10,Building,5,2,0,TRUE
+1005094,66.66990142,34.82137997,2,Munbar-E-Dam Dasht Sabz Dara,Bamyan,3,Yakawlang,1,Dam Dasht-E-Sabz Dara,10,Building,5,3,0,TRUE
+1005095,66.73138888,34.75805555,1,Dasht-E-Sufla Naitaaq Boys School,Bamyan,2,Yakawlang,1,Dasht-E-Sufla Naitaaq,10,Building,5,2,0,TRUE
+1005164,67.16480194,34.99685996,1,Munbar-E-Naw Shora,Bamyan,2,Yakawlang,1,Zard Giyah,10,Building,5,2,0,TRUE
+1005165,66.74436064,34.72868903,1,Munbar-E-Shahrestan,Bamyan,2,Yakawlang,1,Shahrestan-E-Kokeng,10,Building,5,2,0,TRUE
+1005166,67.0625512,34.74355224,1,Feroz Bahar School,Bamyan,2,Yakawlang,1,Feroz Bahar,10,Building,5,2,0,TRUE
+1005174,66.694398439,35.095926872,2,Pai Wcha Mosque,Bamyan,3,Yakawlang,1,Sartosari,10,Building,5,3,0,TRUE
+1005175,66.692519606,34.862422573,2,Dara Chasht Sokhtagi Femal High School,Bamyan,3,Yakawlang,1,Sarak Sokhtagi,10,Building,5,3,0,TRUE
+1005176,66.776238339,34.747572547,2,Sar Tarnok School,Bamyan,3,Yakawlang,1,Sar Tarnok,10,Building,5,3,0,TRUE
+1005177,66.865055511,34.789502314,2,Baghalak Sufla Mosque,Bamyan,3,Yakawlang,1,Baghalak Sufla,10,Building,5,3,0,TRUE
+1005178,66.461486995,34.932332993,2,Kaligan Femal High School,Bamyan,3,Yakawlang,1,Kaligan,10,Building,5,3,0,TRUE
+1005179,67.050646451,34.954907781,2,Kushkak Naqshi School,Bamyan,3,Yakawlang,1,Kushkak Sukhta,10,Building,5,3,0,TRUE
+1006096,67.02192364,34.39197718,2,Pusht-E-Telegraph Girls School,Bamyan,4,Panjab,2,Dasht-E-Ghujoor,10,Building,6,4,0,TRUE
+1006097,66.99912355,34.34001183,2,Munbar-E-Dahan Beldar Ghotu,Bamyan,3,Panjab,1,"Beldar Ghotu, Dahan-E-Syah Dara",10,Building,6,3,0,TRUE
+1006098,66.73351097,34.34894175,1,Shenia Akhzarat School,Bamyan,2,Panjab,1,Shenia,10,Building,6,2,0,TRUE
+1006099,66.66480563,34.41742688,2,Munbar-E-Naw Altarghaan Ulya,Bamyan,3,Panjab,1,Naw Altarghaan Ulya,10,Building,6,3,0,TRUE
+1006100,67.17038842,34.38255353,1,Saray-E-Zard Sang Boys School,Bamyan,2,Panjab,1,Dahan-E-Qoorighak Marka Ulya,10,Building,6,2,0,TRUE
+1006101,67.35843203,34.3864567,1,Elmia Kazimia Madrassa,Bamyan,2,Panjab,1,Ghar Ghar-E-Daraz Qol,10,Building,6,2,0,TRUE
+1006102,67.21463234,34.47842821,2,Kaf Qol Mosque,Bamyan,3,Panjab,1,Kaf Qol,10,Building,6,3,0,TRUE
+1006103,67.2817202,34.54112779,1,Imam-E-Kazim Madrassa,Bamyan,2,Panjab,1,Targhaay,10,Building,6,2,0,TRUE
+1006104,67.1334178,34.46572866,2,Munbar-E-Shenia Turaps,Bamyan,3,Panjab,1,Shenia Turaps,10,Building,6,3,0,TRUE
+1006105,67.06079174,34.47729777,1,Surkak Mosque,Bamyan,3,Panjab,2,Lagzayee,10,Building,6,3,0,TRUE
+1006106,66.57164362,34.35791564,1,Jaame Kharqol School,Bamyan,2,Panjab,1,Kharqol,10,Building,6,2,0,TRUE
+1006107,66.64881534,34.47327899,1,Naw Daraz-E-Kerman Mosque,Bamyan,3,Panjab,2,Naw Daraz,10,Building,6,3,0,TRUE
+1006108,66.78524749,34.40601544,1,Dahan-E-Qalach Mosque,Bamyan,2,Panjab,1,Dahan-E-Qalacha,10,Building,6,2,0,TRUE
+1006109,66.81555842,34.46125297,1,Baarghosang School,Bamyan,2,Panjab,1,Baargho Sang,10,Building,6,2,0,TRUE
+1006110,66.93314364,34.49042884,1,Ghur Ghuri Boys High School,Bamyan,2,Panjab,1,Ghur Ghuri,10,Building,6,2,0,TRUE
+1006111,66.8998528,34.32706546,2,Girdenay Mosque,Bamyan,3,Panjab,1,Yanqol,10,Building,6,3,0,TRUE
+1006112,66.65535975,34.30592109,2,Char Deh Mosque,Bamyan,3,Panjab,1,Char Deh,10,Building,6,3,0,TRUE
+1006113,66.62343968,34.24814021,1,Shenia Miyan Kawak Mosque,Bamyan,2,Panjab,1,Shenia,10,Building,6,2,0,TRUE
+1006114,66.93389364,34.5268592,1,Dahan-E-Ghawch Naw Girls School,Bamyan,2,Panjab,1,Dahan-E-Ghawch Naw,10,Building,6,2,0,TRUE
+1006115,66.82717085,34.44302688,1,Shenia Gandab Mosque,Bamyan,2,Panjab,1,Shenia,10,Building,6,2,0,TRUE
+1006116,66.55350207,34.22511026,1,Pyazan Secondary School,Bamyan,2,Panjab,1,Shenia Pyazan,10,Building,6,2,0,TRUE
+1006117,66.72143722,34.43426338,2,Lashkar Rah-E-Akhzarab Girls School,Bamyan,3,Panjab,1,Miana Deh,10,Building,6,3,0,TRUE
+1006118,66.61147821,34.4959852,1,Munbar-E-Altarghaan Kerman,Bamyan,2,Panjab,1,Qala-E-Qasim Beg,10,Building,6,2,0,TRUE
+1006180,66.625855766,34.314482898,2,Dahan Taher Madrasa,Bamyan,3,Panjab,1,Dahan Zaher,10,Building,6,3,0,TRUE
+1006181,66.772121398,34.370082016,2,Dahan Kohdar Madrasa,Bamyan,3,Panjab,1,Dahan Kahdar,10,Building,6,3,0,TRUE
+1006182,67.131806222,34.429049929,2,Do Abi Secondary School,Bamyan,3,Panjab,1,Do Abi,10,Building,6,3,0,TRUE
+1006183,66.989621356,34.447176158,2,Qala Ashor Secondary School,Bamyan,3,Panjab,1,Dahan Sabz Chobak,10,Village,6,3,0,TRUE
+1006184,67.069787,34.351432722,2,Zira Gak Secondary School,Bamyan,3,Panjab,1,Ziragak Marka Sufla,10,Building,6,3,0,TRUE
+1007119,66.8744809,34.20450663,1,Waras Central Mosque,Bamyan,3,Waras,2,Waras Center,10,Building,7,3,0,TRUE
+1007120,66.91171084,34.22707394,1,Shahr-E-Naw School,Bamyan,2,Waras,1,Pusht-E-Dahane Waras,10,Building,7,2,0,TRUE
+1007121,67.0037842,34.18242146,1,Dahan-E-Padgag High School,Bamyan,2,Waras,1,Dahan-E-Padgag Sultan Rubat,10,Building,7,2,0,TRUE
+1007122,67.1421123,34.21459573,2,Jawqol Mosque,Bamyan,3,Waras,1,Jawqol,10,Building,7,3,0,TRUE
+1007123,66.83304608,34.26609121,1,Kharaba Qol Mosque,Bamyan,2,Waras,1,Kharaba Qol,10,Building,7,2,0,TRUE
+1007124,66.77106596,34.2997626,2,Qala-E-Sokhta Mosque,Bamyan,3,Waras,1,Qala-E-Sokhta,10,Building,7,3,0,TRUE
+1007125,66.80013337,34.20219913,2,Chijin High School,Bamyan,3,Waras,1,Shokoor Daad,10,Building,7,3,0,TRUE
+1007126,66.83385337,34.17060566,2,Shenia Qawm-E-Barfi Mosque,Bamyan,3,Waras,1,Shenia Qawm-E-Barfi,10,Building,7,3,0,TRUE
+1007127,66.67624,34.20021,2,Shenia Takht High School,Bamyan,3,Waras,1,Shenia Takht,10,Building,7,3,0,TRUE
+1007128,66.6238811,34.21306271,2,Sabz Joy Primary School,Bamyan,3,Waras,1,Sabz Joy,10,Building,7,3,0,TRUE
+1007129,66.56074981,34.17910172,1,Sabzak Mosque,Bamyan,2,Waras,1,Dahan-E-Sabzak,10,Building,7,2,0,TRUE
+1007130,66.57621051,34.08104841,1,Dahan-E-Nawagag Mosque,Bamyan,2,Waras,1,Nawgag,10,Building,7,2,0,TRUE
+1007131,66.73250624,34.10594174,1,Band-E-Kosa Boys High School,Bamyan,2,Waras,1,Band-E-Kosa,10,Building,7,2,0,TRUE
+1007132,66.68010574,34.02409349,2,Regjoy-E-Qonaaq Mosque,Bamyan,3,Waras,1,Regjoy-E-Qonaaq,10,Building,7,3,0,TRUE
+1007133,66.61715195,34.05195621,2,Zardak Berana Qol-E-Masot Mosque,Bamyan,3,Waras,1,Dahan-E-Naw Shadi Qol-E-Masot,10,Building,7,3,0,TRUE
+1007134,66.63104206,34.14804172,2,Meyan Malik Dahan-E-Surkh Kangag School,Bamyan,3,Waras,1,Dahan-E-Surkh Kangag,10,Building,7,3,0,TRUE
+1007135,66.76590614,34.18639686,1,Dahan-E-Dewalak Mosque,Bamyan,2,Waras,1,Dahan-E-Dewalak,10,Building,7,2,0,TRUE
+1007136,67.0064171,34.25162441,2,Seab Joy Mosque,Bamyan,3,Waras,1,Seab Joy,10,Building,7,3,0,TRUE
+1007137,67.19669969,34.25777448,1,Dahan-E-Mangos Shenia Awba Mosque,Bamyan,2,Waras,1,Dahan-E-Mangos Shenia Awba,10,Building,7,2,0,TRUE
+1007138,67.26085068,34.27786753,1,Seab Barik Mosque,Bamyan,2,Waras,1,Seab Barik,10,Building,7,2,0,TRUE
+1007139,67.38915001,34.28737388,1,Girdbed Tagab Galeqol Mosque,Bamyan,2,Waras,1,Tagab Galeqol,10,Building,7,2,0,TRUE
+1007140,67.28032779,34.21443153,1,Chob-E-Taman Mosque,Bamyan,2,Waras,1,Chob Taamaan,10,Building,7,2,0,TRUE
+1007141,67.23367412,33.98445045,1,Petaab-E-Kandook Mosque,Bamyan,2,Waras,1,Petaab,10,Building,7,2,0,TRUE
+1007142,67.07009942,34.12569847,1,Shenia Bastook Mosque,Bamyan,2,Waras,1,Shenia Bastook,10,Building,7,2,0,TRUE
+1007143,67.08714322,34.09114109,1,Razak Mosque,Bamyan,2,Waras,1,Razak,10,Building,7,2,0,TRUE
+1007144,67.14372961,34.15583664,1,Derandar Mosque,Bamyan,2,Waras,1,Derandar,10,Building,7,2,0,TRUE
+1007145,67.25349075,34.11276868,1,Ghorzelaw Mosque,Bamyan,2,Waras,1,Ghor Zalaab,10,Building,7,2,0,TRUE
+1007146,67.18121245,34.06707043,1,Dewan Mosque,Bamyan,2,Waras,1,Dewan,10,Building,7,2,0,TRUE
+1007147,67.221210872,34.036086456,1,Warzang Mosque,Bamyan,2,Waras,1,Warzang,10,Building,7,2,0,TRUE
+1007148,67.12970552,33.98787731,1,New Melik Shenia Pachandoor Mosque,Bamyan,2,Waras,1,Naw Melik,10,Building,7,2,0,TRUE
+1007149,67.013763476,33.946197621,2,Sadmani Legan School,Bamyan,3,Waras,1,Sadmani,10,Building,7,3,0,TRUE
+1007150,66.92585335,34.08106757,1,Takhta Ha Mosque,Bamyan,2,Waras,1,Takhta Ha,10,Building,7,2,0,TRUE
+1007151,66.97161039,34.03167321,1,Waaz Darghan Mosque,Bamyan,2,Waras,1,Waaz Darghan,10,Building,7,2,0,TRUE
+1007152,67.008861864,33.861310754,1,Awcha Sanginag Legan Mosque,Bamyan,2,Waras,1,Awcha,10,Building,7,2,0,TRUE
+1007153,66.88667713,34.02585061,1,Band-E-Haidarak Secondary School,Bamyan,2,Waras,1,Band-E-Haidarak,10,Building,7,2,0,TRUE
+1007154,66.89348856,34.15483762,2,Dahan-E-Teenal Mosque,Bamyan,3,Waras,1,Dahan-E-Teenal,10,Building,7,3,0,TRUE
+1007155,66.86597024,34.12045105,2,Pesh Deh Mosque,Bamyan,3,Waras,1,Altar Ghana Gak,10,Building,7,3,0,TRUE
+1007156,66.80598207,34.29248217,2,Aacha Mazaar Madrassa,Bamyan,3,Waras,1,Aacha Mazaar,10,Building,7,3,0,TRUE
+1007157,66.76256285,34.04832343,2,Shenia Tangi Spi Mosque,Bamyan,3,Waras,1,Shenia Tangi Spi,10,Building,7,3,0,TRUE
+1007158,67.087462188,34.061811605,1,Warzagh School,Bamyan,2,Waras,1,Warzagh,10,Building,7,2,0,TRUE
+1007159,66.96819418,34.11790565,2,Toop-E-Ismael Mosque,Bamyan,3,Waras,1,Nas Patan,10,Building,7,3,0,TRUE
+1007160,67.33516818,34.11731164,1,Khaima-E-Kalan Zamen Mosque,Bamyan,2,Waras,1,Khaima-E-Kalan Zamen,10,Building,7,2,0,TRUE
+1007161,67.12117832,33.92261914,1,Tubak Zer Kohe Pajankwar Mosque,Bamyan,2,Waras,1,Turbak,10,Building,7,2,0,TRUE
+1007162,66.53844397,34.08476505,1,Eljem Mosque,Bamyan,2,Waras,1,Eljem,10,Building,7,2,0,TRUE
+1007185,66.968293314,34.117859291,2,Sang Sorakh School,Bamyan,3,Waras,1,Sang Surakh,10,Building,7,3,0,TRUE
+1007186,67.067175607,34.13035484,2,Dara Ghol Sia Mosque,Bamyan,3,Waras,1,Dara Ghol Sia,10,Building,7,3,0,TRUE
+1007187,67.211662075,34.245956475,2,Nik Pai Secondary School,Bamyan,3,Waras,1,Nik Pai Qawm Yari,10,District,7,3,0,TRUE
+1007188,66.928750303,34.274728609,2,Mosque,Bamyan,3,Waras,1,Qala Sia,10,Village,7,3,0,TRUE
+1101001,68.42094577,33.54558527,5,Mastofiat,Ghazni,5,Ghazni,0,Markaz Shahar,11,Building,1,5,0,TRUE
+1101002,68.42610588,33.54391267,6,Municipality Department,Ghazni,6,Ghazni,0,Department Of Municipality,11,Building,1,6,0,TRUE
+1101003,68.42177073,33.54431594,0,Women'S Affairs Department,Ghazni,4,Ghazni,4,Provincial Center,11,Building,1,4,0,TRUE
+1101004,68.40651256,33.53706496,4,Sayed Shuhada Mosque,Ghazni,4,Ghazni,0,Haider Abad Village,11,Building,1,4,0,TRUE
+1101005,68.39725351,33.5373778,0,Haider Abad Bala Girls School,Ghazni,5,Ghazni,5,Near To First Road Of Qala E Qadam Khan,11,Building,1,5,0,TRUE
+1101006,68.41557042,33.54274027,6,Shams-Ul-Arefeen High School,Ghazni,6,Ghazni,0,Plan-E-Sewam Shahar,11,Building,1,7,0,TRUE
+1101007,68.41719759,33.54224266,0,Tawheed Mosque,Ghazni,5,Ghazni,5,Plan-E-Sewam Shahar,11,Building,1,5,0,TRUE
+1101008,68.42044704,33.54834915,5,Sayed Ahmad Maki High School,Ghazni,5,Ghazni,0,Adah Qara Bagh,11,Building,1,5,0,TRUE
+1101009,68.41964397,33.54758178,0,Sayed Ahmad Maki Mosque,Ghazni,5,Ghazni,5,Nahia 1 Markaz-E-Shahar,11,Building,1,5,0,TRUE
+1101010,68.40392772,33.5598861,6,Wali Asar Mosque,Ghazni,6,Ghazni,0,Khak-E-Ghariban Village,11,Building,1,6,0,TRUE
+1101011,68.40190678,33.56004862,3,Wali Asar School,Ghazni,5,Ghazni,2,Khak-E-Ghariban Village,11,Village,1,5,0,TRUE
+1101012,68.40803927,33.52093694,3,Khan Kalan Mosque,Ghazni,4,Ghazni,1,Qala-E-Amir Mohammad Khan,11,Building,1,4,0,TRUE
+1101013,68.4289005,33.54818212,4,Shah Meer Mosque,Ghazni,4,Ghazni,0,Nahia 2,11,Building,1,3,1,TRUE
+1101014,68.4263061,33.5508457,0,Malika Jahan High School,Ghazni,6,Ghazni,6,Saha-E-Shamer,11,Building,1,6,0,TRUE
+1101015,68.42047858,33.55349006,5,Burj-E-Barq Mosque,Ghazni,5,Ghazni,0,Nahia 2,11,Building,1,5,0,TRUE
+1101016,68.4233599,33.55336691,6,Khatem Ul Mursaleen Mosque,Ghazni,6,Ghazni,0,Kala-E-Sabz,11,Building,1,6,0,TRUE
+1101017,68.42520807,33.55578998,0,Kala-E-Sabz Mosque,Ghazni,6,Ghazni,6,Kala-E-Sabz,11,Village,1,6,0,TRUE
+1101018,68.42398991,33.53072687,4,Qala-E-Naw Khwaja Roshnayee High School,Ghazni,5,Ghazni,1,Qala-E-Naw Khwaja Roshnayee,11,Village,1,5,0,TRUE
+1101019,68.43565332,33.56457023,5,Ahmadi Mosque,Ghazni,5,Ghazni,0,Shahr-E-Kohna,11,Village,1,5,0,TRUE
+1101020,68.43434362,33.56052267,0,Mofti Mosque,Ghazni,4,Ghazni,4,Shahr-E-Kohna,11,Village,1,4,0,TRUE
+1101021,68.44774803,33.56716888,5,Sultan Mahmood Ghaznawi School,Ghazni,5,Ghazni,0,Rawza Village,11,Building,1,5,0,TRUE
+1101022,68.45874903,33.5864236,4,General Clinic,Ghazni,6,Ghazni,2,Rawza Village,11,Building,1,6,0,TRUE
+1101023,68.38105436,33.6008818,4,Emam Qeyam High School,Ghazni,6,Ghazni,2,Bakawol Village,11,Building,1,6,0,TRUE
+1101024,68.40600692,33.58430089,5,Alberoni School,Ghazni,7,Ghazni,2,Nawabad Village,11,Building,1,7,0,TRUE
+1101025,68.39919439,33.58760003,6,Sarwar-E-Kaenat Mosque,Ghazni,6,Ghazni,0,Nawabad Village,11,Building,1,6,0,TRUE
+1101026,68.40742535,33.57977192,0,Aman Zaman Mosque,Ghazni,5,Ghazni,5,Nawabad Village,11,Building,1,5,0,TRUE
+1101027,68.41784814,33.56538425,4,Sanayee High School,Ghazni,4,Ghazni,0,Qala-E-Raees,11,Building,1,4,0,TRUE
+1101028,68.43091681,33.54800937,0,Maghulan Girls School,Ghazni,4,Ghazni,4,Moghlan-E-Shahr Village,11,Building,1,4,0,TRUE
+1101029,68.41162068,33.57021082,4,Khalafay-E-Rashedeen Mosque,Ghazni,5,Ghazni,1,Qala-E-Ahangaran,11,Village,1,5,0,TRUE
+1101030,68.40804454,33.57322089,0,Hazrat-E-Dawood Mosque,Ghazni,4,Ghazni,4,Qala-E-Ahangaran,11,Village,1,4,0,TRUE
+1101031,68.40295515,33.54088843,5,Haider Abad Bala Mosque,Ghazni,8,Ghazni,3,Haider Abad Bala Village,11,Building,1,8,0,TRUE
+1101032,68.4149682,33.56466026,6,Sayed Jafar Mosque,Ghazni,6,Ghazni,0,Qala-E-Rais,11,Village,1,6,0,TRUE
+1101033,68.41540803,33.56051788,0,Hakim Mosque,Ghazni,4,Ghazni,4,Khwaja Hakim Village,11,Building,1,4,0,TRUE
+1101034,68.39542635,33.55652577,8,Qala-E-Qazi Mosque,Ghazni,9,Ghazni,1,Qala-E-Qazi,11,Village,1,9,0,TRUE
+1101035,68.40224151,33.59854108,9,Qala-E-Shahada High School,Ghazni,11,Ghazni,2,Qala-E-Shahada,11,Building,1,11,0,TRUE
+1101036,68.40515253,33.59536612,0,Hazrat-E-Ali Mosque,Ghazni,7,Ghazni,7,Qala-E-Shahada,11,Building,1,7,0,TRUE
+1101042,68.42808046,33.56315799,3,Bala Bahlool Mosque,Ghazni,3,Ghazni,0,Bahlool Sahib Village,11,Building,1,3,0,TRUE
+1101043,68.42776634,33.56072937,0,Paeen Mosque,Ghazni,3,Ghazni,3,Bahlool Saheb,11,Village,1,3,0,TRUE
+1101044,68.48377723,33.46953127,4,Urzo Mosque,Ghazni,4,Ghazni,0,Urzo Village,11,Village,1,4,0,TRUE
+1101045,68.49319056,33.45616008,0,Urzo Clinic,Ghazni,3,Ghazni,3,Urzo Village,11,Building,1,3,0,TRUE
+1101046,68.39564431,33.47531222,3,Esfandah Clinic,Ghazni,3,Ghazni,0,Esfandah Village,11,Building,1,3,0,TRUE
+1101047,68.39854098,33.47918511,0,Espandah School,Ghazni,3,Ghazni,3,Esfandah Village,11,Building,1,3,0,TRUE
+1101048,68.3739946,33.4912283,2,Zargar Mosque,Ghazni,3,Ghazni,1,Zargar Village,11,Building,1,3,0,TRUE
+1101052,68.41841848,33.52422445,1,Mohammad Jan Khan Kuchi High School,Ghazni,3,Ghazni,2,"Nahia 1, Kanj-E-Ghazni",11,Building,1,3,0,TRUE
+1101053,68.3622718,33.54461661,1,Qala-E-Kochi Mosque,Ghazni,3,Ghazni,2,Qala-E-Kuchi,11,Village,1,3,0,TRUE
+1101054,68.36204028,33.54419742,1,Haji Alakh Mosque,Ghazni,3,Ghazni,2,Qala-E-Kuchi,11,Village,1,2,1,TRUE
+1101055,68.48723852,33.54126984,1,Qala-E-Jowz Mosque,Ghazni,3,Ghazni,2,Qala-E-Jowz,11,Building,1,2,1,TRUE
+1101056,68.42434967,33.55325728,1,Mohammad Noor Guest House,Ghazni,3,Ghazni,2,Markaz-E-Shahar,11,Village,1,3,0,TRUE
+1101057,68.41747044,33.52526043,3,Pashtoon Abad School,Ghazni,4,Ghazni,1,Pashtoon Abad,11,Building,1,4,0,TRUE
+1101058,68.37942932,33.5311198,3,Shahrak-E-Muhajerin School,Ghazni,4,Ghazni,1,Shahrak-E-Muhajerin,11,Village,1,4,0,TRUE
+1102096,68.33987749,33.58143949,4,Sayed Alam Village Mosque,Ghazni,5,Wali Mohammad Shahid,1,Sayed Alam Village,11,Building,2,5,0,TRUE
+1103081,68.40421589,33.68890897,3,Tormi Boys High School,Ghazni,4,Khwaja Omari,1,Tormi Village,11,Building,3,4,0,TRUE
+1103082,68.39222101,33.70822667,2,Deh Darat Mosque,Ghazni,3,Khwaja Omari,1,Deh Darat,11,Village,3,3,0,TRUE
+1103085,68.420386,33.637879,3,Qala-E-Naw Chahar Burja Mosque,Ghazni,3,Khwaja Omari,0,Qala-E-Naw Chahar Burja,11,Village,3,3,0,TRUE
+1103086,68.39053542,33.70936387,0,Qala-E-Naw Chahar Burja School,Ghazni,3,Khwaja Omari,3,Qala-E-Naw Payen,11,Building,3,3,0,TRUE
+1104124,68.26733374,33.4526389,4,Sher Ahmad School,Ghazni,6,Waghaz,2,Distric Compound,11,Building,4,1,5,TRUE
+1104127,68.24781458,33.46144592,3,Qala-E-Mohammad Khan Mosque,Ghazni,4,Waghaz,1,Qala-E-Mohammad Khan,11,Village,4,0,4,FALSE
+1104128,68.2984811,33.41128402,3,Mawlana Abdul Hai School,Ghazni,4,Waghaz,1,Ziarat Village,11,Village,4,0,4,FALSE
+1104130,68.22371648,33.35701441,2,Qala-E-Mohammad Sadiq Mosque,Ghazni,4,Waghaz,2,Qala-E-Mohammad Sadiq,11,Village,4,4,0,TRUE
+1104131,68.11087326,33.35636823,2,Gadoly Village Mosque,Ghazni,3,Waghaz,1,Gadoly Village,11,Building,4,1,2,TRUE
+1105059,68.53625666,33.46131814,3,Laghawat School,Ghazni,4,Deh Yak,1,Laghawat,11,Village,5,4,0,TRUE
+1105060,68.51531295,33.45721948,2,Anwar-Ul-Uloom School,Ghazni,3,Deh Yak,1,Anwar-Ul-Uloom,11,Village,5,3,0,TRUE
+1105062,68.588421,33.49430502,3,Tesani School,Ghazni,4,Deh Yak,1,Tesani,11,Village,5,4,0,TRUE
+1105063,68.61949094,33.42988793,2,Sulaiman Zai School,Ghazni,3,Deh Yak,1,Sulaiman Zai,11,Village,5,3,0,TRUE
+1105064,68.65245466,33.47570832,2,Deh Yak Mosque,Ghazni,3,Deh Yak,1,Deh Yak,11,Village,5,3,0,TRUE
+1105066,68.68890756,33.46453382,2,Kandar Mosque,Ghazni,3,Deh Yak,1,Kandar,11,Village,5,3,0,TRUE
+1105067,68.70004585,33.56796761,2,Rubat Zed-E-Zareel Mosque,Ghazni,3,Deh Yak,1,Rubat Zed-E-Zareel,11,Village,5,3,0,TRUE
+1105068,68.62016063,33.500859,2,Ramak Village Mosque,Ghazni,3,Deh Yak,1,Ramak Village,11,Village,5,3,0,TRUE
+1105070,68.62364826,33.49386252,2,Primary School,Ghazni,3,Deh Yak,1,Sulaiman Beik,11,District,5,2,1,TRUE
+1106104,68.096276132,33.529094622,3,Balagh Village Mosque,Ghazni,4,Jaghatu,1,Balagh Village,11,Village,6,0,4,FALSE
+1106105,68.09317692,33.64512528,2,Senayee Qala-E-Yousuf High School,Ghazni,3,Jaghatu,1,Godol Khan Mohammad Village,11,Building,6,3,0,TRUE
+1106106,68.016201761,33.52228128,3,Qoul Asil New School,Ghazni,3,Jaghatu,0,Qabaq Village,11,Building,6,3,0,TRUE
+1106107,68.01160705,33.521499454,1,Qoul Asel Old School,Ghazni,4,Jaghatu,3,Qabaq Jay Village,11,Building,6,4,0,TRUE
+1106108,68.16897415,33.63930817,3,Deh Ramzi Mosque,Ghazni,3,Jaghatu,0,Deh Ramzi,11,Building,6,3,0,TRUE
+1106109,68.16912373,33.63880723,0,Abdul Hussain Guest House,Ghazni,3,Jaghatu,3,Deh Ramzi,11,Village,6,3,0,TRUE
+1106110,68.15819453,33.62149191,0,Alberooni Jarmato High School,Ghazni,3,Jaghatu,3,Sorkhi Village,11,Building,6,3,0,TRUE
+1106111,68.15175803,33.62075388,5,Bibi Hajera High School,Ghazni,5,Jaghatu,0,Sorkhi Village,11,Building,6,5,0,TRUE
+1106112,68.02114051,33.57911358,3,Faqeer Shah Mosque,Ghazni,3,Jaghatu,0,Gero-E-Faqeer Shah Village,11,Building,6,3,0,TRUE
+1106113,68.02214026,33.57882709,0,Yaqoobi Guest House,Ghazni,3,Jaghatu,3,Gero-E-Faqeer Shah Village,11,Building,6,3,0,TRUE
+1106115,68.20373246,33.52349875,4,Deh Noorullah Mosque,Ghazni,4,Jaghatu,0,Deh Noorullah Torgan,11,Village,6,4,0,TRUE
+1106116,68.20389427,33.52425542,0,Azizullah Guest House,Ghazni,3,Jaghatu,3,Deh Noorullah Torgan,11,Village,6,3,0,TRUE
+1106117,68.13561728,33.54554507,5,Deh Shashi New Mosque,Ghazni,5,Jaghatu,0,Deh Shashi,11,Building,6,4,1,TRUE
+1106118,68.13462164,33.54637807,0,Deh Shashi Old Mosque,Ghazni,3,Jaghatu,3,Deh Shahshi,11,Village,6,1,2,TRUE
+1106120,67.96672343,33.55125796,3,Shuhada-E-Sar Aab School,Ghazni,3,Jaghatu,0,Kafshi Village,11,Building,6,3,0,TRUE
+1106121,67.97596077,33.55020251,0,Bibi Fatema Zuhra School,Ghazni,4,Jaghatu,4,Jaja Saraab,11,Building,6,4,0,TRUE
+1106122,68.026929342,33.452615743,1,Shaki High School,Ghazni,3,Jaghatu,2,"Janan Village, Shaki Region",11,Building,6,0,3,FALSE
+1106123,68.19068863,33.57463227,2,Gulburi School,Ghazni,3,Jaghatu,1,Dah Noori,11,Building,6,3,0,TRUE
+1107219,68.54994452,33.37351179,3,Mehtar Qodali Village School,Ghazni,4,Andar,1,Mehtar Qoodali Village,11,Building,7,4,0,TRUE
+1107223,68.28636254,33.29312289,0,Mazo Sufla Village Mosque,Ghazni,3,Andar,3,Mazo Sufla Village,11,Building,7,3,0,TRUE
+1107224,68.353988131,33.397353938,3,Qari Sahib Jan School,Ghazni,4,Andar,1,Nani Village,11,Village,7,4,0,TRUE
+1107225,68.43124557,33.36706445,2,Bakhtiar Village Mosque,Ghazni,2,Andar,0,Bakhtiar Village,11,Building,7,2,0,TRUE
+1107226,68.43221934,33.36771092,0,Bakhtiar Village Lower Mosque,Ghazni,2,Andar,2,Bakhtiar Village,11,Village,7,2,0,TRUE
+1107229,68.4410195,33.32943197,3,Meeri Bazar School,Ghazni,4,Andar,1,Meeri Bazar,11,Building,7,4,0,TRUE
+1107230,68.44294805,33.32333936,1,Sultan Shahabuddin Andar School,Ghazni,3,Andar,2,Meeri Bazar,11,Building,7,3,0,TRUE
+1107231,68.43244237,33.26806901,3,Medadwal Village Mosque,Ghazni,3,Andar,0,Medadwal Village,11,Village,7,3,0,TRUE
+1107232,68.43858383,33.29253737,0,Malangi Sufla Village Mosque,Ghazni,2,Andar,2,Malangi Sufla Village,11,Building,7,2,0,TRUE
+1107234,68.39086763,33.38233334,0,Yaqoob Village Clinic,Ghazni,3,Andar,3,Yaqoob Village,11,Building,7,3,0,TRUE
+1107235,68.51058549,33.3265497,3,Khani Qala Mosque,Ghazni,3,Andar,0,Khani Qala,11,Village,7,3,0,TRUE
+1107236,68.51458886,33.32977486,0,Khani Qala New Mosque,Ghazni,3,Andar,3,Khani Qala,11,Village,7,3,0,TRUE
+1107237,68.50579109,33.34358299,2,Sarferaz Village Mosque,Ghazni,2,Andar,0,Qala-E-Sarferaz,11,Building,7,2,0,TRUE
+1107238,68.49731715,33.37937043,0,Sarferaz Payen Village Mosque,Ghazni,2,Andar,2,Qala-E-Sarferaz Payen,11,Village,7,2,0,TRUE
+1107239,68.3968229,33.24445697,3,Kanasf Village Clinic,Ghazni,3,Andar,0,Kanasf Village,11,Village,7,2,1,TRUE
+1107240,68.39660768,33.25062358,0,Kanasf Village School,Ghazni,2,Andar,2,Kanasf Village,11,Building,7,2,0,TRUE
+1107241,68.53162031,33.35502705,3,Shamshi Village Mosque,Ghazni,3,Andar,0,Shamshai Village,11,Village,7,3,0,TRUE
+1107242,68.53625921,33.35910752,0,Shamshai Sufla Village Mosque,Ghazni,3,Andar,3,Shamshai Sufla Village,11,Village,7,3,0,TRUE
+1107243,68.58471309,33.34119207,2,Changah Village Mosque,Ghazni,2,Andar,0,Changah Village,11,Village,7,2,0,TRUE
+1107244,68.55271447,33.3422879,0,Changah Sufla Village Mosque,Ghazni,2,Andar,2,Changah Sufla Village,11,Building,7,2,0,TRUE
+1107245,68.58252401,33.27545689,3,Sardah Village Mosque,Ghazni,3,Andar,0,Sardah Village,11,Village,7,3,0,TRUE
+1107246,68.58298999,33.27635181,0,Chini Sardah Mosque,Ghazni,3,Andar,3,Sardah Village,11,Building,7,3,0,TRUE
+1107247,68.40230538,33.3236838,3,Hazrat-E-Bilal School,Ghazni,3,Andar,0,Narmi Village,11,Building,7,3,0,TRUE
+1107248,68.41580553,33.32478982,0,Sahib Khan Village Mosque,Ghazni,3,Andar,3,Sahib Khan Village,11,Building,7,3,0,TRUE
+1107249,68.49610447,33.32041737,3,Abdul Wal Village Mosque,Ghazni,4,Andar,1,Abdul Wal Village,11,Building,7,4,0,TRUE
+1107250,68.5420551,33.3415959,4,Qala-E-Sardar School,Ghazni,5,Andar,1,Qala-E-Sardar Bazar,11,Building,7,3,2,TRUE
+1107252,68.40714756,33.27616071,1,Molla Mohammad Gadali School,Ghazni,3,Andar,2,Mula Mohammad Gadali Village,11,Building,7,3,0,TRUE
+1107253,68.53892142,33.32111773,2,Sarki Village Mosque,Ghazni,4,Andar,2,Sarki Village,11,Village,7,4,0,TRUE
+1108071,68.60902224,33.68272715,3,Commissionar House,Ghazni,5,Zanakhan,2,District Compound,11,Village,8,5,0,TRUE
+1108072,68.60945768,33.68107581,2,District Mosque,Ghazni,3,Zanakhan,1,District Compound,11,Village,8,3,0,TRUE
+1109087,68.21370861,33.70473046,4,District Commissioner Office,Ghazni,4,Rashidan,0,Hussain Khel,11,Village,9,3,1,TRUE
+1109093,68.15017367,33.67602767,2,Laghari Village Mosque,Ghazni,3,Rashidan,1,Laghari Village,11,Village,9,3,0,TRUE
+1109094,68.15013798,33.67606336,2,Laghari Village Lower Mosque,Ghazni,3,Rashidan,1,Laghari Village,11,Village,9,3,0,TRUE
+1110254,67.99631683,33.7192971,4,Shaheed Ghulam Haider High School,Ghazni,5,Nawur,1,Darwaish Ali War Kolokh,11,Building,10,5,0,TRUE
+1110255,68.10798113,33.74055065,2,Meyana Sokhta Mosque,Ghazni,3,Nawur,1,Meyana Sokhtah Village,11,Village,10,3,0,TRUE
+1110256,68.20242116,33.74801599,2,Shaheed Sayed Esa Khan Secondary School,Ghazni,3,Nawur,1,Janbieg Village,11,Building,10,3,0,TRUE
+1110257,68.19612038,33.95473387,1,Kaka Dana Mosque,Ghazni,2,Nawur,1,Shenia Village,11,Village,10,2,0,TRUE
+1110258,68.16294855,33.84407456,1,Shaheed Murad Ali High School,Ghazni,2,Nawur,1,Qala-E-Langar,11,Building,10,2,0,TRUE
+1110259,67.9909684,34.11222761,1,Imam-E- Baqir Madrass,Ghazni,2,Nawur,1,Kata Qala,11,Building,10,0,2,FALSE
+1110260,68.05489992,34.0468501,2,Torgha Primary School,Ghazni,3,Nawur,1,Torgha Village,11,Building,10,3,0,TRUE
+1110261,68.01448687,34.0678102,3,Khawat High School,Ghazni,4,Nawur,1,Chah Asp Village,11,Building,10,4,0,TRUE
+1110262,67.88867064,33.89640531,2,Etifaq High School,Ghazni,3,Nawur,1,Do Aabi Village,11,Building,10,3,0,TRUE
+1110263,67.73495481,33.82643098,1,Koralah Village Mosque,Ghazni,2,Nawur,1,Korala Village,11,Village,10,2,0,TRUE
+1110264,67.68858912,33.59989508,3,Wagh Village High School,Ghazni,4,Nawur,1,Wagh Village,11,Building,10,4,0,TRUE
+1110265,67.71216558,33.47634558,2,Qoria Village School,Ghazni,3,Nawur,1,Qoria Village,11,Building,10,3,0,TRUE
+1110266,67.52268259,33.75052779,2,Aama Chali Village Mosque,Ghazni,3,Nawur,1,Chal Village,11,Village,10,3,0,TRUE
+1110267,67.40937605,33.73986585,2,Baqir-Ul-Ulom Madrass,Ghazni,3,Nawur,1,Dahana-E-Ghaundi Village,11,Building,10,3,0,TRUE
+1110268,67.41880328,33.69514585,1,Petab Mohammad Yar Mosque,Ghazni,2,Nawur,1,Sang-E-Almas Village,11,Village,10,2,0,TRUE
+1110269,67.77867116,34.10995003,1,Tarbolaq Village Mosque,Ghazni,2,Nawur,1,Tarbolaq Village,11,Village,10,2,0,TRUE
+1110270,67.37406479,34.08510888,1,Mianqol Village Mosque,Ghazni,2,Nawur,1,Mianqol Village,11,Village,10,2,0,TRUE
+1110271,67.58491393,34.0915556,2,Seka Nawer High School,Ghazni,3,Nawur,1,Band-E-Aabdara Shaberdi,11,Building,10,3,0,TRUE
+1110272,67.53666919,34.08735219,2,Ahl-E-Bayt Madrassa,Ghazni,3,Nawur,1,Sartoop Village,11,Building,10,3,0,TRUE
+1110273,67.64698002,34.09454981,3,Sia Zameen Village Mosque,Ghazni,4,Nawur,1,Sia Zameen Village,11,Building,10,4,0,TRUE
+1110274,67.56128998,34.10845331,2,Sayed Jamaluddin Shakhal Kar High School,Ghazni,3,Nawur,1,Daaman Village,11,Building,10,3,0,TRUE
+1110275,67.46808849,33.95401535,1,Jahan Noma High School,Ghazni,2,Nawur,1,Shenia Village,11,Building,10,2,0,TRUE
+1110276,67.535087,33.955449,1,Toobie Village Mosque,Ghazni,2,Nawur,1,Toobi Village,11,Village,10,2,0,TRUE
+1110277,67.43033557,33.97168671,1,Danhan-E-Naw Village Mosque,Ghazni,2,Nawur,1,Danhan-E-Naw Talkhak Village,11,Village,10,2,0,TRUE
+1110278,67.42349149,34.0642144,3,Shaibar Village Mosque,Ghazni,4,Nawur,1,Shaibar Village,11,Building,10,4,0,TRUE
+1110279,67.315149139,33.950747475,1,Gulchin Deh Village Madrassa,Ghazni,2,Nawur,1,Gulchin Dah Village,11,Village,10,2,0,TRUE
+1110280,67.83258707,33.89502678,2,Payen Daman Village Madrass,Ghazni,3,Nawur,1,Wasa-E-Payen Daaman Village,11,Village,10,3,0,TRUE
+1110281,67.80428516,34.0032273,1,Miana Bad Village Mosque,Ghazni,2,Nawur,1,Miana Bed Village,11,Building,10,2,0,TRUE
+1110282,67.57861111,33.81305555,1,Farkhtala Mosque,Ghazni,2,Nawur,1,Farakhtala Village,11,Building,10,2,0,TRUE
+1110283,67.7257937,33.7261256,1,Bahayee Village School,Ghazni,2,Nawur,1,Qara-E-Bahaye Village,11,Building,10,2,0,TRUE
+1110284,68.099128,33.92437487,1,Alem Ahadi Madrass,Ghazni,2,Nawur,1,Bur Qala/Qarnala Village,11,Building,10,2,0,TRUE
+1110285,67.98837095,33.70497648,2,Shaheed Mohammad Ali Primary School,Ghazni,3,Nawur,1,Qaash Village,11,Building,10,3,0,TRUE
+1110286,67.99162395,33.97648453,2,Ghulam Sakhi Shaheed School,Ghazni,3,Nawur,1,Yakhshi Village,11,Building,10,3,0,TRUE
+1111132,68.12316456,33.17776709,5,Qara Bagh District Central Clinic,Ghazni,5,Qara Bagh,0,District Bazar,11,Building,11,5,0,TRUE
+1111133,68.10392751,33.19190769,0,Abdullah Khaliq Mosque,Ghazni,2,Qara Bagh,2,Godol Village,11,Building,11,2,0,TRUE
+1111134,68.06663037,33.19441673,2,Sheer Khan School,Ghazni,2,Qara Bagh,0,Pangeer Village,11,Building,11,2,0,TRUE
+1111135,68.05100989,33.19653748,0,Pana Geer Village Mosque,Ghazni,4,Qara Bagh,4,Pangeer Village,11,Village,11,4,0,TRUE
+1111143,68.09607772,33.09791799,0,Mollah Faqir Mosque,Ghazni,2,Qara Bagh,2,Malang Khel Village,11,Village,11,0,2,FALSE
+1111144,68.11179461,33.12046617,2,Nawrooz Khel Village Mosque,Ghazni,2,Qara Bagh,0,Nawrooz Khel Village,11,Building,11,2,0,TRUE
+1111145,67.97538347,33.31801278,0,Bashi Mosque,Ghazni,2,Qara Bagh,2,Bashi Village,11,Village,11,0,2,FALSE
+1111146,68.04272511,33.11129513,4,Askar Kot Clinic,Ghazni,4,Qara Bagh,0,Askarkot Bazar,11,Building,11,2,2,TRUE
+1111147,68.04240626,33.1118662,0,Askar Kot Bazar Mosque,Ghazni,3,Qara Bagh,3,Askarkot Bazar,11,Building,11,0,3,FALSE
+1111148,68.23609131,33.24719757,4,Qala-E-Baran Upper Mosque,Ghazni,4,Qara Bagh,0,Qala-E-Baran,11,Village,11,0,4,FALSE
+1111149,68.23624835,33.24916539,0,Qala-E-Baran Lower Mosque,Ghazni,2,Qara Bagh,2,Qala-E-Baran,11,Village,11,0,2,FALSE
+1111152,67.95055763,33.12900584,3,Ghatt Village Mosque,Ghazni,3,Qara Bagh,0,Ghatt Jay-E-Agha Sahib Village,11,Village,11,2,1,TRUE
+1111153,67.87402331,33.14872713,0,Ghatt Village Lower Mosque,Ghazni,2,Qara Bagh,2,Ghatt Jay-E-Agha Sahib Village,11,Village,11,2,0,TRUE
+1111154,68.05232283,33.15468357,3,Khonyan Village Mosque,Ghazni,3,Qara Bagh,0,Khonyan Village,11,Village,11,2,1,TRUE
+1111155,68.03910007,33.15083661,0,Khonyan Village Lower Mosque,Ghazni,2,Qara Bagh,2,Khonyan Village,11,Building,11,2,0,TRUE
+1111160,68.05726242,33.1826859,2,Bahadoorgi New Mosque,Ghazni,2,Qara Bagh,0,Bahadoorgi Village,11,Building,11,2,0,TRUE
+1111161,68.05371939,33.18740675,0,Bahadoorgi Old Mosque,Ghazni,2,Qara Bagh,2,Bahadoorgi Village,11,Building,11,2,0,TRUE
+1111162,68.18659111,33.22710134,2,Shaheed Abdul Salam Mosque,Ghazni,2,Qara Bagh,0,Moshaki Village,11,Building,11,2,0,TRUE
+1111163,68.18850943,33.22947475,0,Dawood Khel Mosque,Ghazni,2,Qara Bagh,2,Moshaki Village,11,Building,11,0,2,FALSE
+1111166,68.11531503,33.26615936,2,Sultan Ibrahim School,Ghazni,2,Qara Bagh,0,Aaheen Village,11,Building,11,2,0,TRUE
+1111167,68.11472706,33.26642759,0,Bi Bi Zahra Aaheen School,Ghazni,2,Qara Bagh,2,Aaheen Village,11,Building,11,2,0,TRUE
+1111168,68.06866589,33.29056562,2,Waheed Ali Janlag Mosque,Ghazni,2,Qara Bagh,0,Jangalak Village,11,Building,11,2,0,TRUE
+1111169,68.06747318,33.28722818,0,Balay-E-Bilandi Mosque,Ghazni,2,Qara Bagh,2,Jangalak Village,11,Building,11,2,0,TRUE
+1111170,68.10974649,33.21406067,2,Qarcha Mosque,Ghazni,2,Qara Bagh,0,Qarch Village,11,Building,11,0,2,FALSE
+1111171,68.10007696,33.23780836,0,Meerak Mosque,Ghazni,2,Qara Bagh,2,Meerak Village,11,Village,11,0,2,FALSE
+1111172,67.951,33.311,2,Qolooch Mosque,Ghazni,2,Qara Bagh,0,3 Deh Qolooch Village,11,Building,11,2,0,TRUE
+1111173,67.74263297,33.13720412,0,Toormi Qolooch Bala Mosque,Ghazni,2,Qara Bagh,2,Qolooch Bala Village,11,Village,11,2,0,TRUE
+1111174,68.01549758,33.33178374,3,Godol Mosque,Ghazni,3,Qara Bagh,0,Nekhta Village,11,Building,11,3,0,TRUE
+1111175,68.01816,33.331191,0,Habib Mosque,Ghazni,2,Qara Bagh,2,Nekhta Village,11,Village,11,2,0,TRUE
+1111176,67.98779345,33.38216028,3,Mohammadia Madrassa,Ghazni,3,Qara Bagh,0,Qalia Qul Village,11,Building,11,3,0,TRUE
+1111177,67.98785998,33.38211453,0,Qalia Qul High School,Ghazni,3,Qara Bagh,3,Qalia Qul Village,11,Building,11,3,0,TRUE
+1111178,67.83286581,33.19561334,3,Haseena Zardalo Mosque,Ghazni,3,Qara Bagh,0,Zardalo Village,11,Building,11,3,0,TRUE
+1111179,67.84163602,33.17882811,0,Zardalo Village School,Ghazni,3,Qara Bagh,3,Zardalo Village,11,Village,11,3,0,TRUE
+1111180,67.76997144,33.12055441,5,Taq Cheen Clinic,Ghazni,5,Qara Bagh,0,Taq Cheen Village,11,Village,11,4,1,TRUE
+1111181,67.76718236,33.11832319,0,Taq Cheen School,Ghazni,3,Qara Bagh,3,Taq Cheen Village,11,Village,11,3,0,TRUE
+1111183,67.83326129,33.19589625,2,Husaina Sarkani Mosque,Ghazni,3,Qara Bagh,1,Hussaina Sarkani,11,Village,11,3,0,TRUE
+1111185,67.694608705,33.215469632,3,Abu Raihan School,Ghazni,4,Qara Bagh,1,Hasina Sarkani,11,Village,11,4,0,TRUE
+1111187,68.12250023,33.16093864,3,Deh Rowza Mosque,Ghazni,4,Qara Bagh,1,Deh Rawza,11,Village,11,4,0,TRUE
+1111189,67.78291358,33.27081408,3,Ny Qala School,Ghazni,5,Qara Bagh,2,Ny Qala,11,Building,11,5,0,TRUE
+1111190,67.90849777,33.26497842,3,Malak Ghulam Hussain Mosque,Ghazni,3,Qara Bagh,0,Gulko Village,11,Village,11,3,0,TRUE
+1111191,67.89973167,33.2677825,0,Sang De Mosque,Ghazni,2,Qara Bagh,2,Sang Deh Gulko,11,Building,11,2,0,TRUE
+1111193,68.00904024,33.41848914,2,Bilandghan Village Mosque,Ghazni,3,Qara Bagh,1,Biland Ghan Village,11,Village,11,3,0,TRUE
+1111194,68.10180766,33.20082394,2,Sultan Mahmood Ghaznawi High School,Ghazni,2,Qara Bagh,0,Qalbi Village,11,Building,11,2,0,TRUE
+1111195,67.97676969,33.38577294,0,Sayed Aalam Daftani Godol Mosque,Ghazni,2,Qara Bagh,2,Qodol Bazar Village,11,Village,11,2,0,TRUE
+1111406,68.14171882,33.247075315,2,Qari Abdullah School,Ghazni,3,Qara Bagh,1,Ashlian,11,Building,11,0,3,FALSE
+1112196,68.31159411,33.10063269,3,Shaheed Habibullah Khadim High School,Ghazni,5,Giro,2,"Pune Village, District Center",11,Building,12,1,4,TRUE
+1113376,68.0923816,32.84108005,1,Ghazi Sahib Khan School,Ghazni,2,Ab Band,1,Alam Khel,11,Village,13,2,0,TRUE
+1113378,67.99491518,32.93544384,6,Shamsullah Hotel,Ghazni,6,Ab Band,0,Bazar Jaded,11,Village,13,4,2,TRUE
+1113379,67.96443025,32.98414007,0,Sarferaz Village Mosque,Ghazni,2,Ab Band,2,Sarferaz Village,11,Village,13,1,1,TRUE
+1113380,67.92842805,32.98221643,2,Landa Khel Village Mosque,Ghazni,2,Ab Band,0,Landa Khel Village,11,Village,13,2,0,TRUE
+1113381,67.90795199,32.99380016,1,Sadozai Mosque,Ghazni,2,Ab Band,1,Sadozai,11,Village,13,2,0,TRUE
+1113382,67.94170419,32.9635648,2,Bazgi Mosque,Ghazni,2,Ab Band,0,Bazgi,11,Village,13,1,1,TRUE
+1113383,67.93845503,32.96557663,0,Bacha House,Ghazni,2,Ab Band,2,Bazgi,11,Village,13,1,1,TRUE
+1114321,67.49537682,33.23894295,3,Shabetak Madrassa,Ghazni,4,Jaghuri,1,Ali Sayed Village,11,Building,14,4,1,TRUE
+1114322,67.3633471,33.22802044,4,Almayto Village High School,Ghazni,7,Jaghuri,3,Almetoo Village,11,Building,14,7,0,TRUE
+1114323,67.53100168,32.95461467,3,Angoori High School,Ghazni,5,Jaghuri,2,Angori Village,11,Building,14,7,0,TRUE
+1114324,67.28327576,33.03708753,4,Baba High School,Ghazni,6,Jaghuri,2,Baba Village,11,Building,14,6,0,TRUE
+1114325,67.33387059,33.13740696,2,Pusht-E-Choob High School,Ghazni,3,Jaghuri,1,Chakah Sya Zameen Village,11,Building,14,3,0,TRUE
+1114326,67.28343451,33.14881864,2,Chalbaghto Ooqi Secondary School,Ghazni,3,Jaghuri,1,Chahel Baghto Ooqi Village,11,Building,14,3,0,TRUE
+1114327,67.26873821,33.1103236,3,Pushi School,Ghazni,5,Jaghuri,2,Chahel Baghto Pashi Village,11,Building,14,5,0,TRUE
+1114328,67.53730011,33.16611803,2,Deh Mordah Madrassa,Ghazni,3,Jaghuri,1,Deh Mordah,11,District,14,3,0,TRUE
+1114329,67.57186482,32.9998195,4,Dawood High School,Ghazni,6,Jaghuri,2,Dawood Village,11,Building,14,6,0,TRUE
+1114330,67.4379134,33.06123307,2,Mazar Bi Bi Girls High School,Ghazni,3,Jaghuri,1,Mazar Bi Bi Village,11,Building,14,3,0,TRUE
+1114331,67.18790752,33.03257607,1,Ghawgha Primary School,Ghazni,2,Jaghuri,1,Ghowgha Village,11,Village,14,2,0,TRUE
+1114332,67.53819406,33.15019268,3,Ghajour Teacher Training School,Ghazni,5,Jaghuri,2,Ghajour Village,11,Building,14,5,0,TRUE
+1114333,67.50630831,33.07737869,2,Qaltar Gho Mosque,Ghazni,3,Jaghuri,1,Qaltargho Haider Village,11,Building,14,3,0,TRUE
+1114334,67.51060274,32.93437289,5,Sharifi High School,Ghazni,7,Jaghuri,2,Hatqool Village,11,Building,14,7,0,TRUE
+1114335,67.38370024,33.12625119,1,Jodari Village Mosque,Ghazni,2,Jaghuri,1,Jodari Village,11,Village,14,2,0,TRUE
+1114336,67.38522249,33.07791384,3,Faizia High School,Ghazni,5,Jaghuri,2,Kata Sang Village,11,Building,14,5,0,TRUE
+1114337,67.61063636,33.13313987,2,Loman High School,Ghazni,4,Jaghuri,2,Luman Village,11,Building,14,4,0,TRUE
+1114338,67.5815257,33.06534916,3,Immigrants Primary School,Ghazni,4,Jaghuri,1,Immigrants Village,11,Building,14,4,0,TRUE
+1114339,67.36283804,33.23235646,2,Patoo Village High School,Ghazni,4,Jaghuri,2,Patoo Village,11,Building,14,4,0,TRUE
+1114340,67.21350202,33.03463192,1,Hecha Village Mosque,Ghazni,3,Jaghuri,2,Pusht-E-Hecha Village,11,Building,14,3,0,TRUE
+1114341,67.44177591,33.1394184,9,Ghafor Sultani High School,Ghazni,11,Jaghuri,2,Sang-E-Masha Bazar,11,Building,14,11,0,TRUE
+1114342,67.44720029,33.13887469,6,Shuhada Girls High School,Ghazni,12,Jaghuri,6,Sang-E-Masha Bazar,11,Building,14,12,0,TRUE
+1114343,67.49716749,33.03600166,2,Hedayat High School,Ghazni,4,Jaghuri,2,Sang-E-Shande Village,11,Building,14,4,0,TRUE
+1114344,67.57063702,33.19326195,1,3 Pay-E-Khudaydad Village  High School,Ghazni,2,Jaghuri,1,3 Pay-E-Khudaydad Village,11,Building,14,2,0,TRUE
+1114345,67.67825902,33.19993588,1,Sharzayeda Village Mosque,Ghazni,2,Jaghuri,1,Sharzayeda Village,11,Building,14,2,0,TRUE
+1114346,67.66223816,33.36978429,1,Shahshpar Primary School,Ghazni,2,Jaghuri,1,Shashpar Village,11,Building,14,2,0,TRUE
+1114347,67.64096381,33.33001777,2,Shughla Public School,Ghazni,3,Jaghuri,1,Shughla Village,11,Building,14,3,0,TRUE
+1114348,67.44858496,33.02235071,1,3 Qul Secondary School,Ghazni,2,Jaghuri,1,Suba Gharbeeda Village,11,Building,14,2,0,TRUE
+1114349,67.47122527,33.1985481,1,Tabar Ghanak Secondary School,Ghazni,2,Jaghuri,1,Tabar Ghanak Village,11,Building,14,2,0,TRUE
+1114350,67.32763391,32.99096772,1,Jaka Secondary School,Ghazni,2,Jaghuri,1,Tylum Village,11,Building,14,2,0,TRUE
+1114351,67.61083038,33.29590533,2,Ulyatoo Toormi High School,Ghazni,3,Jaghuri,1,Ulyato Toormi Village,11,Building,14,3,0,TRUE
+1114352,67.63189804,33.05206817,2,Sahili Zirak School,Ghazni,3,Jaghuri,1,Zirak Village,11,Building,14,3,0,TRUE
+1114353,67.34567476,33.07421657,1,Payedgah Public Mosque,Ghazni,2,Jaghuri,1,Payedga Village,11,Building,14,2,0,TRUE
+1114354,67.67119426,33.25608616,1,Barak Public Mosque,Ghazni,2,Jaghuri,1,Barak Village,11,Village,14,2,0,TRUE
+1114355,67.28334131,33.21632545,1,Dahan-E-Dawra Village Mosque,Ghazni,2,Jaghuri,1,Dahan-E-Dawra Village,11,Building,14,2,0,TRUE
+1114408,67.408612831,32.970928707,1,Ayatullah Mudares School,Ghazni,2,Jaghuri,1,Kharbid,11,District,14,2,0,TRUE
+1115356,67.76739292,32.82268973,3,Girls School,Ghazni,5,Muqur,2,Muqur Bazar,11,Building,15,3,2,TRUE
+1115357,67.7687849,32.82245179,4,Abnisena Clinic,Ghazni,5,Muqur,1,Muqur Bazar,11,Building,15,3,2,TRUE
+1115358,67.76659708,32.82407709,3,Naw Abad Khanadar Mosque,Ghazni,4,Muqur,1,Khanadar Village,11,Building,15,3,1,TRUE
+1115359,67.77100509,32.81107287,2,Chahar Qala Mosque,Ghazni,3,Muqur,1,Char Qala,11,Village,15,3,0,TRUE
+1115361,67.85535395,32.8393484,2,Alam Khel Village,Ghazni,3,Muqur,1,Alam Khel Village,11,Building,15,2,1,TRUE
+1115362,67.8368949,32.83573,2,Qala-E-Yarbiq School,Ghazni,3,Muqur,1,Qal-E-Yarbig,11,Village,15,2,1,TRUE
+1115366,67.88120633,32.91769464,3,Laram Village Mosque,Ghazni,4,Muqur,1,Laram Village,11,Building,15,4,0,TRUE
+1115368,67.80011891,32.78173759,2,Abas Qala School,Ghazni,3,Muqur,1,Abas Qala,11,Building,15,1,2,TRUE
+1115369,67.75178983,32.80575596,2,Akhtar Khel Village Mosque,Ghazni,3,Muqur,1,Akhtar Khel Village,11,Building,15,2,1,TRUE
+1115370,67.794906,32.991589,1,Sra Zranda Village School,Ghazni,3,Muqur,2,Sra Zranda Village,11,Village,15,1,2,TRUE
+1115371,67.76793346,32.82120485,1,Disrtict Compound,Ghazni,2,Muqur,1,Muqur District Center,11,Building,15,2,0,TRUE
+1116295,67.44364266,33.43691413,3,Beelagho Village Secondary School,Ghazni,4,Malistan,1,Beelagho Village,11,Building,16,4,0,TRUE
+1116296,67.33223213,33.32223455,3,Qalam Mazar Boghra Village Mosque,Ghazni,4,Malistan,1,Boghra Village,11,Village,16,4,0,TRUE
+1116297,66.96832084,33.01532138,2,Chaktamor Secondary School,Ghazni,3,Malistan,1,Chaktamoor Village,11,Building,16,3,0,TRUE
+1116298,67.00831392,33.07281269,3,Wali Asr Sherdagh Mosque,Ghazni,4,Malistan,1,Payen Village,11,Village,16,4,0,TRUE
+1116299,67.51045712,33.49349575,3,Khar Qol Dala High School,Ghazni,4,Malistan,1,Khar Qol Dala Village,11,Building,16,4,0,TRUE
+1116300,67.07944546,33.0152023,1,Qojangi Mosque,Ghazni,2,Malistan,1,Quchangi Village,11,Building,16,2,0,TRUE
+1116301,67.35895347,33.28879062,2,Mir Ahmad Gheghanto Mosque,Ghazni,3,Malistan,1,Gheghanto Village,11,Building,16,3,0,TRUE
+1116302,67.10463869,33.14307377,2,Jaka Village Clinic,Ghazni,3,Malistan,1,Jaka Village,11,Building,16,3,0,TRUE
+1116303,67.29974634,33.34104562,2,Jambood Girls High School,Ghazni,3,Malistan,1,Jambood Village,11,Building,16,3,0,TRUE
+1116304,66.96595716,33.08357515,1,Shafali Mosque,Ghazni,2,Malistan,1,Jani Shir Dagh Village,11,Building,16,2,0,TRUE
+1116305,67.50539974,33.36363933,3,Kamarak Boys High School,Ghazni,5,Malistan,2,Kamarak Village,11,Building,16,5,0,TRUE
+1116306,67.05508275,32.99519003,2,Khairo Mosque,Ghazni,3,Malistan,1,Khairo Village,11,Building,16,3,0,TRUE
+1116307,67.36450932,33.39291626,2,Khakrezak Primary School,Ghazni,3,Malistan,1,Naw Deh Village,11,Building,16,3,0,TRUE
+1116308,67.53404085,33.40652834,1,Kandali Secondary School,Ghazni,2,Malistan,1,Kandali Village,11,Building,16,2,0,TRUE
+1116309,67.23296906,33.32733908,2,Mir Ahmad Mohabat Mosque,Ghazni,3,Malistan,1,Mohabat Lalchak Village,11,Building,16,3,0,TRUE
+1116310,67.18656003,33.29264488,3,Meradeena High School,Ghazni,5,Malistan,2,Muradeena Bazar,11,Building,16,5,0,TRUE
+1116311,67.143329,33.207773,1,Martaba Ulyat Mosque,Ghazni,2,Malistan,1,Ulyat Village,11,Village,16,2,0,TRUE
+1116312,67.44286757,33.40082963,2,Ulom Balkhsan Village Public Mosque,Ghazni,3,Malistan,1,Ulom Balkhsan Village,11,Building,16,3,0,TRUE
+1116313,67.08441491,33.11725045,3,Pay Jalgah High School,Ghazni,5,Malistan,2,Pay Jalga Village,11,Building,16,5,0,TRUE
+1116314,67.16711568,33.14411552,1,Qabjay Village Primary School,Ghazni,2,Malistan,1,Qabjay Village,11,Building,16,2,0,TRUE
+1116315,67.38389835,33.46706498,1,Petaw Qochanghato Village Mosque,Ghazni,2,Malistan,1,Qochanghato Village,11,Village,16,2,0,TRUE
+1116316,67.41458309,33.40722346,2,Sabzak Village High School,Ghazni,3,Malistan,1,Sabzak Village,11,Building,16,3,0,TRUE
+1116317,67.3468017,33.34884724,2,Sheena Deh Health Clinic,Ghazni,3,Malistan,1,Sheena Deh Bazar,11,Building,16,3,0,TRUE
+1116318,67.31298632,33.40535772,2,Qara Warda Maknak Village Mosque,Ghazni,3,Malistan,1,Warda Maknak Village,11,Building,16,3,0,TRUE
+1116319,67.08233333,33.21430555,2,Kohnda Deh Mosque,Ghazni,3,Malistan,1,Bechi Lal Village,11,Building,16,3,0,TRUE
+1116320,67.042507,33.268994,1,Tokreek Village School,Ghazni,2,Malistan,1,Tokreek Village,11,Village,16,2,0,TRUE
+1116407,67.062950311,33.096468793,1,Nawa Peshi Masque,Ghazni,2,Malestan,1,Nawa Peshi,11,Village,16,2,0,TRUE
+1117384,67.63746952,32.72670785,3,Janda Bazar Mosque,Ghazni,5,Gelan,2,Mosque,11,Building,17,1,4,TRUE
+1117385,67.65827589,32.69726542,3,Lateef Village Mosque,Ghazni,5,Gelan,2,Lateef Village,11,Building,17,1,4,TRUE
+1117386,67.61678171,32.77834437,3,Sheenki Village Mosque,Ghazni,4,Gelan,1,Sheenki Village,11,Building,17,2,2,TRUE
+1117387,67.60690747,32.7444839,4,Agho Jan Village Mosque,Ghazni,5,Gelan,1,Agho Jan Village,11,Building,17,3,2,TRUE
+1117394,67.72024251,32.74810515,2,Azad Village Mosque,Ghazni,3,Gelan,1,Azad Village,11,Building,17,3,0,TRUE
+1117395,67.4694809,32.87890108,1,Bangish Village Mosque,Ghazni,2,Gelan,1,Bangish Village,11,Village,17,1,1,TRUE
+1118291,67.19728825,33.51718001,4,Sangar Village Clinic,Ghazni,9,Ajristan,5,"Sangar Village, Khwaja Khel",11,Building,18,8,1,TRUE
+1201001,68.78734656,33.17558918,7,Ali Baba High School,Paktika,7,Sharan,0,Sharana,12,Building,1,7,0,TRUE
+1201002,68.78773856,33.17621882,0,Sharan Hospital,Paktika,4,Sharan,4,Sharana Bazaar,12,Village,1,4,0,TRUE
+1201003,68.73065491,33.17628283,4,Primary School,Paktika,4,Sharan,0,Mohammad Khel Bazaar,12,Building,1,4,0,TRUE
+1201004,68.72970501,33.17689639,0,Polio Old Center,Paktika,4,Sharan,4,Mohammad Khel Bazaar,12,Village,1,4,0,TRUE
+1201005,68.74701403,33.23069421,4,Primary School,Paktika,4,Sharan,0,Maswas,12,Building,1,4,0,TRUE
+1201006,68.73799628,33.22645866,0,Maswas Mosque,Paktika,4,Sharan,4,Maswas,12,Village,1,3,1,TRUE
+1201007,68.73782697,33.22754306,3,Maswas Primary School,Paktika,4,Sharan,1,Chalai Maswas,12,Village,1,4,0,TRUE
+1201008,68.73937094,33.21694358,0,Maswas Primary School,Paktika,3,Sharan,3,Osman,12,Village,1,3,0,TRUE
+1201009,68.81752065,33.19355742,4,Aljahad Primary School,Paktika,4,Sharan,0,Omer Khel,12,Building,1,5,0,TRUE
+1201010,68.82264376,33.18985915,0,Primary School,Paktika,4,Sharan,4,Sra Qala,12,Village,1,4,0,TRUE
+1201011,68.79638559,33.19301011,4,Dulow Mosque,Paktika,4,Sharan,0,Dulow,12,Village,1,4,0,TRUE
+1201012,68.7943246,33.19310768,0,Malik Ahmad Jan Guest House,Paktika,4,Sharan,4,Dulow,12,Village,1,4,0,TRUE
+1201013,68.78676909,33.1503088,4,Sepvani Mosque,Paktika,4,Sharan,0,Spavani,12,Building,1,4,0,TRUE
+1201014,68.78634792,33.14912383,0,Dagir Guest House,Paktika,4,Sharan,4,Spavani,12,Village,1,4,0,TRUE
+1201015,68.7728248,33.22241883,4,Primary School,Paktika,4,Sharan,0,Kari Khel,12,Village,1,4,0,TRUE
+1201016,68.83869444,33.13935,0,Market Mosque,Paktika,3,Sharan,3,Kari Khel,12,District,1,3,0,TRUE
+1201017,68.76837563,33.13743336,3,Merza Qala Mosque,Paktika,3,Sharan,0,Merza Qala,12,Village,1,3,0,TRUE
+1201018,68.76859979,33.13720056,0,Asghar Guest House,Paktika,3,Sharan,3,Merza Qala,12,Village,1,3,0,TRUE
+1201019,68.75550053,33.14646574,4,School,Paktika,4,Sharan,0,Kotwal,12,Village,1,4,0,TRUE
+1201020,68.75525109,33.14645225,0,Old School,Paktika,4,Sharan,4,Kotwal,12,Village,1,4,0,TRUE
+1201021,68.78182044,33.19304064,4,Jeni School,Paktika,4,Sharan,0,Shah Baddin,12,Village,1,3,1,TRUE
+1201022,68.7822222,33.1936111,0,Shahabuddin Mosque,Paktika,3,Sharan,3,Shahabuddin,12,Village,1,3,0,TRUE
+1201023,68.783879,33.16722,2,Banosi Qala Mosque,Paktika,2,Sharan,0,Benosi Qala,12,District,1,2,0,TRUE
+1201024,68.783879,33.16722,0,Banor Guest House,Paktika,2,Sharan,2,Benosi Qala,12,District,1,2,0,TRUE
+1201026,68.863626,33.086971,2,Abdullah House,Paktika,4,Sharan,2,Tawa Kacha Village,12,Village,1,4,0,TRUE
+1201281,68.83959958,33.13520421,3,Ali Baba Primary School,Paktika,3,Sharan,0,Sharana Bazaar,12,Village,1,3,0,TRUE
+1201282,68.8403967,33.13262011,2,Gharwal Guest House,Paktika,3,Sharan,1,Sharana Bazaar,12,Village,1,3,0,TRUE
+1202027,68.85968702,33.27008779,4,District Centeral Mosque,Paktika,4,Mata Khan,0,Mata Khan Bazaar,12,Village,2,3,1,TRUE
+1202028,68.85914995,33.27073416,0,District Center,Paktika,4,Mata Khan,4,Zarra Qala,12,Building,2,4,0,TRUE
+1202029,68.87169726,33.27717196,2,Koti Khel Mosque,Paktika,2,Mata Khan,0,Koti Khel,12,Village,2,2,0,TRUE
+1202030,68.87247534,33.27806426,0,Koti Khel Clinic,Paktika,2,Mata Khan,2,Koti Khel,12,Village,2,2,0,TRUE
+1202032,68.90686522,33.31745452,3,Qala-E-Saydo Tent,Paktika,5,Mata Khan,2,Qala-E-Saydo,12,Village,2,5,0,TRUE
+1202034,68.81682591,33.25790287,3,Laghar Village Boys & Girls School,Paktika,4,Mata Khan,1,Laghar Village,12,Village,2,4,0,TRUE
+1202035,68.81351964,33.24698232,3,Koti Khel Tent,Paktika,3,Mata Khan,0,Koti Khel,12,Building,2,3,0,TRUE
+1202036,68.82777777,33.22972222,0,Koti Khel Tent,Paktika,3,Mata Khan,3,Kari Khel,12,Building,2,3,0,TRUE
+1202038,68.89277703,33.16840291,2,"Chena Bagh, District Center",Paktika,3,Mata Khan,1,Chena Bagh,12,Building,2,3,0,TRUE
+1202283,68.85793451,33.26802518,2,Mata Khan High School,Paktika,2,Mata Khan,0,Mata Khan Bazaar,12,Building,2,2,0,TRUE
+1203039,68.6748467,33.06675072,4,Bazi Wani Mosque,Paktika,4,Yosuf Khel,0,Yousuf Khel Markaz,12,Building,3,4,0,TRUE
+1203040,68.65260428,33.04851121,0,Haji Pati Guest House,Paktika,3,Yosuf Khel,3,Yousuf Khel,12,Village,3,3,0,TRUE
+1203041,68.68805719,33.08343867,4,"Merza Khel  Bazar, Old School",Paktika,4,Yosuf Khel,0,Mosh Khel,12,Building,3,4,0,TRUE
+1203042,68.56035882,32.96532025,0,Bazi Wani Mosque,Paktika,4,Yosuf Khel,4,Mosh Khel,12,Village,3,4,0,TRUE
+1203043,68.55838077,32.96455173,4,Mest Mosque,Paktika,4,Yosuf Khel,0,Mest Sagi,12,Village,3,4,0,TRUE
+1203044,68.55841814,32.96455489,0,Ramazan Guest House,Paktika,3,Yosuf Khel,3,Mest,12,Village,3,3,0,TRUE
+1203046,68.71529469,33.09132904,3,Malang Guest House,Paktika,5,Yosuf Khel,2,Parak Village,12,Village,3,5,0,TRUE
+1204047,68.64568014,32.93523768,3,Noor Mohammad Guest Houes,Paktika,3,Yahya Khel,0,Yahya Khel,12,Village,4,3,0,TRUE
+1204048,68.64567451,32.93523768,0,Abdul Rahman Guest Hlosue,Paktika,2,Yahya Khel,2,Yahya Khel,12,Village,4,2,0,TRUE
+1204051,68.63553096,32.94492652,4,Nik Mohammad Male & Female Guest House & Mosque,Paktika,4,Yahya Khel,0,Ghayeb Khel,12,Village,4,4,0,TRUE
+1204052,68.631519,32.949728,0,Nik Mohammad Male & Female Guest House,Paktika,4,Yahya Khel,4,Nik Muhammad Khil_Ghaibi Khil,12,Village,4,4,0,TRUE
+1204055,68.67470436,32.98682794,2,Qurbuddin School,Paktika,2,Yahya Khel,0,Qurbuddin Village,12,Village,4,2,0,TRUE
+1204056,68.67545607,32.98645209,0,Bangal Guest House,Paktika,2,Yahya Khel,2,Qurbuddin Village,12,Village,4,2,0,TRUE
+1204058,68.66641101,32.99109906,3,Mohammd Yaqoob Mosque,Paktika,4,Yahya Khel,1,Mohammd Yaqoob Village,12,District,4,4,0,TRUE
+1204060,68.64675955,32.93613983,2,District Compound (Tent),Paktika,3,Yahya Khel,1,District Center,12,Village,4,3,0,TRUE
+1204062,68.63082034,32.91691078,1,Mughol Khel Mosque,Paktika,2,Yahya Khel,1,Mughol Khel,12,Village,4,3,0,TRUE
+1204064,68.60267723,32.87054977,2,Ahmad Khan Guest House,Paktika,4,Yahya Khel,2,Peyawi,12,Village,4,5,0,TRUE
+1205073,69.05202326,33.06538215,4,Edgah Mosque,Paktika,4,Sar Rawza,0,Madaji,12,District,5,5,0,TRUE
+1205074,68.99904464,33.11569245,4,Sar Rawza Primary School,Paktika,4,Sar Rawza,0,Sar Rawza Bazar,12,Building,5,5,0,TRUE
+1205075,69.08466662,33.14770746,3,Marzak Boys School,Paktika,3,Sar Rawza,0,Marzak,12,Village,5,3,0,TRUE
+1205076,69.08469915,33.14770746,0,Marzak Girls School,Paktika,3,Sar Rawza,3,Marzak,12,Village,5,3,0,TRUE
+1205077,68.97065434,33.06422717,3,Big Mosque,Paktika,3,Sar Rawza,0,Sultani,12,Village,5,4,0,TRUE
+1205078,68.97114213,33.0642242,0,Malik Zahir Guest House,Paktika,3,Sar Rawza,3,Sultani,12,Village,5,3,0,TRUE
+1205079,68.97568611,33.10285277,0,District Compound (Tent),Paktika,3,Sar Rawza,3,Sar Rawza District,12,Building,5,3,0,TRUE
+1205080,69.0308124,33.06990193,0,Parraaw Mosque,Paktika,2,Sar Rawza,2,Parraaw,12,Building,5,2,0,TRUE
+1205081,69.07377057,32.9709349,2,Big Mosque,Paktika,2,Sar Rawza,0,Shah Tori,12,Village,5,2,0,TRUE
+1205082,69.07476653,32.97138823,0,Mohammad Hayat Guest House,Paktika,2,Sar Rawza,2,Shah Tori,12,Village,5,2,0,TRUE
+1205083,69.10607776,33.03047437,2,Molla Joma Gul Mosque,Paktika,2,Sar Rawza,0,Gularuddin,12,Building,5,2,0,TRUE
+1205084,69.10696708,33.0256848,0,Gularddin Guest House,Paktika,2,Sar Rawza,2,Gularuddin,12,Village,5,2,0,TRUE
+1205285,69.01820021,33.12033261,3,Sar Rawza Clinic,Paktika,3,Sar Rawza,0,Musto Khan Bagh,12,Village,5,3,0,TRUE
+1205286,69.08468213,33.14770311,0,Marzak Primary School,Paktika,2,Sar Rawza,2,Marzak,12,Village,5,2,0,TRUE
+1206066,68.80992814,32.96887948,3,Raji Khel Mosque,Paktika,4,Omna,1,Zawaka,12,Village,6,4,0,TRUE
+1206068,68.79627598,32.90049003,2,Raji Khel Mosque,Paktika,3,Omna,1,District Center,12,Village,6,3,0,TRUE
+1206070,68.87478606,32.9116038,2,Speena School,Paktika,3,Omna,1,Speena,12,Village,6,3,0,TRUE
+1206071,68.8040129,32.92620992,1,Wakil Ghami Village Guest House,Paktika,2,Omna,1,Wakil Ghami Village,12,District,6,2,0,TRUE
+1206072,68.80558418,32.92568616,1,Wakil Ghami Village Secondary School,Paktika,2,Omna,1,Wakil Ghami Village,12,District,6,2,0,TRUE
+1206284,68.79808801,32.90102305,3,Speena Clinic,Paktika,3,Omna,0,District Center,12,Village,6,3,0,TRUE
+1207085,68.45457881,32.85179986,4,Naiem Shop,Paktika,4,Zarghun Shahr,0,Khair Kot,12,Village,7,4,0,TRUE
+1207086,68.4622826,32.85254807,0,Haji Mir Ahmad Guest House,Paktika,2,Zarghun Shahr,2,Khair Kot,12,Building,7,2,0,TRUE
+1207087,68.50374906,32.92347752,3,Segana Zarghon City,Paktika,3,Zarghun Shahr,0,Segana,12,Village,7,2,1,TRUE
+1207088,68.50371797,32.92350861,0,Abdul Manan House,Paktika,3,Zarghun Shahr,3,Segana,12,Village,7,3,0,TRUE
+1207089,68.53245166,32.86451058,2,Payanda Khel Village School,Paktika,2,Zarghun Shahr,0,Payanda Khil Village,12,Village,7,3,0,TRUE
+1207090,68.5324137,32.86435871,0,Sahib Jan House,Paktika,2,Zarghun Shahr,2,Payanda Khil Village,12,Village,7,3,0,TRUE
+1207092,68.4475,32.85222222,2,District Compound (Tent),Paktika,4,Zarghun Shahr,2,Zarghon Shahr,12,Village,7,4,0,TRUE
+1207093,68.4940928,32.79872115,2,Meli Zai Mosque,Paktika,2,Zarghun Shahr,0,Meli Zai,12,Village,7,3,0,TRUE
+1207094,68.4943129,32.79963724,0,Sharif Guest House,Paktika,2,Zarghun Shahr,2,Meli Zai,12,Village,7,3,0,TRUE
+1207095,68.47124917,32.80979797,2,Mohammad Hassan Mosque,Paktika,2,Zarghun Shahr,0,Mohammad Hassan,12,Building,7,2,0,TRUE
+1207096,68.46969351,32.81231095,0,Ibrahim Guest House,Paktika,2,Zarghun Shahr,2,Mohammad Hassan,12,Village,7,3,0,TRUE
+1207098,68.48861455,32.83058872,2,Mohammad Dost Mosque,Paktika,4,Zarghun Shahr,2,Mohammad Dost Village,12,Building,7,4,0,TRUE
+1207100,68.45255325,32.84806253,2,Fasela Compound,Paktika,4,Zarghun Shahr,2,Zarghon Shahr,12,Village,7,4,0,TRUE
+1207101,68.5613889,32.8188889,3,District Center,Paktika,3,Zarghun Shahr,0,Bak Khel,12,Village,7,3,0,TRUE
+1207102,68.55647619,32.81901883,0,Daoud Jan Guest House,Paktika,3,Zarghun Shahr,3,Bak Khel,12,Village,7,3,0,TRUE
+1207103,68.54603539,32.819416,3,Shah Khel Mosque,Paktika,3,Zarghun Shahr,0,Shah Khel,12,Village,7,3,0,TRUE
+1207104,68.54518563,32.81990027,0,Ajab Khan Guest House,Paktika,2,Zarghun Shahr,2,Shah Khel,12,Village,7,2,0,TRUE
+1207105,68.55446769,32.81814239,3,Haji Pacha Mosque,Paktika,3,Zarghun Shahr,0,Bak Khel,12,Village,7,3,0,TRUE
+1207106,68.56589786,32.81481925,0,Haji Kheyal Guest House,Paktika,2,Zarghun Shahr,2,Bak Khel,12,Village,7,2,0,TRUE
+1207107,68.54279452,32.82000728,2,Haji Kheyal Gul Mosque,Paktika,2,Zarghun Shahr,0,Haji Kheyal Gul,12,Village,7,2,0,TRUE
+1207108,68.54030432,32.82021235,0,Shah Alam Guest House,Paktika,2,Zarghun Shahr,2,Haji Kheyal Gul,12,Village,7,2,0,TRUE
+1207287,68.52293613,32.92674654,2,Segana Primary School,Paktika,2,Zarghun Shahr,0,Segana,12,Village,7,2,0,TRUE
+1207288,68.51848461,32.92220317,2,Bazaar Mosque,Paktika,2,Zarghun Shahr,0,District Center,12,Building,7,2,0,TRUE
+1207289,68.5213048,32.92386648,2,Segana Village Mosque,Paktika,4,Zarghun Shahr,2,Segana,12,Building,7,4,0,TRUE
+1208125,68.99962528,32.30778429,4,Primary School,Paktika,5,Gomal,1,Fatehuddin,12,District,8,5,0,TRUE
+1208126,69.00664213,32.18463805,3,Mawlavi Serajuddin Madressa,Paktika,4,Gomal,1,Payandi Village,12,Building,8,4,0,TRUE
+1208127,68.85172837,32.44728365,3,Shekin Bazaar Mosque,Paktika,3,Gomal,0,Shekin,12,Village,8,3,0,TRUE
+1208128,68.85169469,32.4473061,0,Zarif Khan Guest House,Paktika,3,Gomal,3,Shekin,12,Village,8,3,0,TRUE
+1208129,69.08527955,32.1257959,3,Haji Omar Mosque,Paktika,3,Gomal,0,Amovaz,12,Village,8,3,0,TRUE
+1208130,69.00023064,32.30875505,0,Saroki Guest House,Paktika,3,Gomal,3,Amovaz,12,Village,8,3,0,TRUE
+1208131,68.5656549,32.36482285,3,"Mawlavi Abbas School, Kamky Gomal",Paktika,3,Gomal,0,Shadezai Village,12,Building,8,3,0,TRUE
+1208132,68.903075482,32.739765737,0,Amand Khel Village School,Paktika,2,Gomal,2,Rozi Khel,12,Village,8,2,0,TRUE
+1208133,68.89004139,32.57744321,4,Molla Dawlat Madrassa,Paktika,4,Gomal,0,Zavlo Khel,12,Village,8,4,0,TRUE
+1208134,68.89016583,32.57734532,0,Shaheed Feroz School,Paktika,4,Gomal,4,Zavlo Khel,12,Village,8,4,0,TRUE
+1208135,68.94002266,32.74250146,2,Amir Madar Guest House,Paktika,2,Gomal,0,Tabot,12,Village,8,2,0,TRUE
+1208136,68.94004699,32.74249173,0,Saied Ahmad Madrassa,Paktika,2,Gomal,2,Tabot,12,Village,8,2,0,TRUE
+1208137,69.28591904,31.97384031,0,Apsena Girls Secondary School,Paktika,2,Gomal,2,Apsena,12,District,8,2,0,TRUE
+1208138,69.28568109,31.97348815,4,Gul Mir Mosque,Paktika,4,Gomal,0,Apsena,12,District,8,4,0,TRUE
+1208139,68.92016381,32.77657545,2,Ali Zai Clinic,Paktika,2,Gomal,0,Ali Zai,12,Village,8,2,0,TRUE
+1208140,68.87225293,32.63215188,0,Khair Manzo Girls Primary School,Paktika,2,Gomal,2,Khair Manzi,12,Village,8,2,0,TRUE
+1208141,68.93130714,32.79526119,2,District Center,Paktika,2,Gomal,0,Charhar Baran,12,Village,8,2,0,TRUE
+1208142,68.93133087,32.7952256,0,Chahar Baran Secondary School,Paktika,2,Gomal,2,Charhar Baran,12,Village,8,2,0,TRUE
+1208143,68.90544844,32.74379842,3,Saied Khel Secondary School,Paktika,3,Gomal,0,Saied Khel,12,Village,8,3,0,TRUE
+1208144,68.90432478,32.74551927,0,Saied Khel Mosque,Paktika,3,Gomal,3,Saied Khel,12,Village,8,3,0,TRUE
+1208146,68.78740968,32.62673839,4,Esa Jee School,Paktika,6,Gomal,2,Menzi,12,District,8,6,0,TRUE
+1208291,69.198431,32.487308,3,Shekin Primary School,Paktika,3,Gomal,0,Shekin,12,Village,8,3,0,TRUE
+1208292,69.198268375,32.487366041,0,Shekin Secondary School,Paktika,3,Gomal,3,Shekin,12,Village,8,3,0,TRUE
+1208293,68.87225482,32.63216376,0,Khair Manzy Tent,Paktika,3,Gomal,3,Khair Manzi,12,Village,8,3,0,TRUE
+1209109,68.40139725,32.76456129,6,District Old Compound,Paktika,6,Jani Khel,0,District Center,12,Building,9,6,0,TRUE
+1209110,68.40064473,32.76417635,0,Jani Khel Bazaar Mosque,Paktika,3,Jani Khel,3,District Center,12,Building,9,3,0,TRUE
+1209111,68.39860019,32.74827956,3,Molla Ghani Guest House,Paktika,3,Jani Khel,0,Jalalzo,12,Village,9,3,0,TRUE
+1209112,68.39659947,32.74537542,0,Jalozo Girls School,Paktika,3,Jani Khel,3,Jalalzo,12,Village,9,3,0,TRUE
+1209113,68.39824447,32.77999801,3,Abdullah Guest House,Paktika,3,Jani Khel,0,Shadi Khel,12,Village,9,3,0,TRUE
+1209114,68.51570725,32.58115416,0,Sadi Khel Village Mosque,Paktika,3,Jani Khel,3,Shadi Khel,12,District,9,3,0,TRUE
+1209115,68.34612017,32.69470224,3,Hasi Village Mosque,Paktika,3,Jani Khel,0,Hasti,12,Building,9,3,0,TRUE
+1209116,68.34643699,32.69426854,0,Malik Abdullah Guest House,Paktika,3,Jani Khel,3,Hasti,12,Village,9,3,0,TRUE
+1209117,68.39710272,32.76294915,2,Ahmad Guest House,Paktika,2,Jani Khel,0,Jafar,12,Village,9,2,0,TRUE
+1209118,68.39701093,32.7628,0,Zekria Guest House,Paktika,2,Jani Khel,2,Jafar,12,Village,9,2,0,TRUE
+1209120,68.39802073,32.76447971,1,Jani Khel School,Paktika,2,Jani Khel,1,Jani Khel,12,Building,9,2,0,TRUE
+1209122,68.38532623,32.70816119,3,Shah Khel Abad Village School,Paktika,4,Jani Khel,1,Shah Khel Abad Village,12,Village,9,4,0,TRUE
+1209123,68.52730293,32.53791728,3,Akbar House,Paktika,3,Jani Khel,0,Shahen Shah Haji Hareem Khan Village,12,Village,9,3,0,TRUE
+1209124,68.52317873,32.53739792,0,Haji Hareem Khan House,Paktika,2,Jani Khel,2,Shahen Shah Haji Hareem Khan Village,12,Village,9,2,0,TRUE
+1209290,68.40064473,32.76417635,0,Bazaar Mosque,Paktika,3,Jani Khel,3,Jani Khel Bazar,12,Building,9,3,0,TRUE
+1210147,69.09691675,32.79569668,4,Nawi Hali Mosque,Paktika,4,Surubi,0,Old Lanja Khel,12,Village,10,4,0,TRUE
+1210148,69.10490474,32.65872052,2,Khan Mohammad Mosque,Paktika,3,Surubi,1,Lanja Khel,12,Village,10,3,0,TRUE
+1210149,69.02115543,32.78617696,2,Khani Qala Mosque,Paktika,2,Surubi,0,Khani Kala,12,Village,10,2,0,TRUE
+1210150,69.11102749,32.72241355,0,Payandi Mosque,Paktika,3,Surubi,3,Khani Kala,12,Village,10,3,0,TRUE
+1210151,69.12159946,32.77654616,2,Mado Shop,Paktika,2,Surubi,0,Robat,12,Building,10,2,0,TRUE
+1210152,69.121601,32.776548,0,Mado Guest House,Paktika,3,Surubi,3,Robat,12,Village,10,3,0,TRUE
+1210153,69.093604,32.789109,2,Masti Mosque,Paktika,2,Surubi,0,Masti,12,Village,10,2,0,TRUE
+1210154,69.094346,32.792024,0,Hayat Guest House,Paktika,3,Surubi,3,Masti,12,Village,10,3,0,TRUE
+1210155,69.04856766,32.7958595,1,Central High School,Paktika,2,Surubi,1,Sodan Khel,12,District,10,2,0,TRUE
+1210156,69.09365345,32.80549914,3,Central Clinic,Paktika,3,Surubi,0,New Lanja Khel,12,Village,10,3,0,TRUE
+1210157,69.26181071,32.83212352,2,Abas Khel Mosque,Paktika,2,Surubi,0,Abbas Khel,12,Building,10,2,0,TRUE
+1210158,69.122639,32.827805,2,Abas Khel School,Paktika,3,Surubi,1,Abbas Khel,12,Village,10,3,0,TRUE
+1210159,69.09691623,32.79020315,2,Navi Khel Mosque,Paktika,2,Surubi,0,Navi Khel,12,Village,10,2,0,TRUE
+1210160,69.09716195,32.7902993,0,Molla Samandar Guest House,Paktika,2,Surubi,2,Navi Khel,12,Village,10,2,0,TRUE
+1210294,69.04813265,32.76110004,0,Rebat Asghar Kala Primary School,Paktika,2,Surubi,2,Asghar Kala,12,District,10,2,0,TRUE
+1210295,69.04626702,32.75197732,2,Asghar Kala Mosque,Paktika,2,Surubi,0,Asghar Kala,12,District,10,2,0,TRUE
+1211161,69.17819316,32.9404782,4,Balish School,Paktika,4,Urgoon,0,Balish District Center,12,Building,11,4,0,TRUE
+1211162,69.17948535,32.94026284,0,Barakat Girls School,Paktika,3,Urgoon,3,Balish District Center,12,Building,11,2,1,TRUE
+1211163,69.158374,32.918975,2,Orgon Old School,Paktika,2,Urgoon,0,Qara Khel Village,12,Village,11,2,0,TRUE
+1211164,69.1581,32.9092,0,Qara Khel Girls School,Paktika,2,Urgoon,2,Qara Khel Village,12,Village,11,2,0,TRUE
+1211165,69.18644392,32.99602403,2,Mera Gul Mosque,Paktika,2,Urgoon,0,Mera Gul Village,12,Village,11,2,0,TRUE
+1211166,69.18645279,32.99604177,0,Malik Moyen Guest House,Paktika,2,Urgoon,2,Mera Gul Village,12,Village,11,2,0,TRUE
+1211167,69.21477337,33.04262072,2,Chena Khwa Madrassa,Paktika,2,Urgoon,0,Ambron Village,12,Building,11,2,0,TRUE
+1211168,69.22111025,33.03862316,0,Amiran Guest House,Paktika,2,Urgoon,2,Ambron Village,12,Village,11,2,0,TRUE
+1211169,69.14553711,32.88834036,2,Baba Sahib Shaikhan School,Paktika,2,Urgoon,0,Shaikhia Argon,12,Building,11,2,0,TRUE
+1211170,69.14686456,32.88691698,0,Shaikhia Orgon Mosque,Paktika,3,Urgoon,3,Shaikhia Argon,12,Village,11,3,0,TRUE
+1211171,69.16609587,32.89676784,2,Kalandar Madrassa,Paktika,2,Urgoon,0,Old Argon,12,Building,11,2,0,TRUE
+1211172,69.15105084,32.90187149,0,Old Orgon Girls School,Paktika,2,Urgoon,2,Old Argon,12,Village,11,2,0,TRUE
+1211173,69.15553408,32.87511663,3,Ghouch School,Paktika,3,Urgoon,0,Jani Qala,12,Village,11,3,0,TRUE
+1211174,69.15698727,32.87686592,0,Haji Fazel Guest House,Paktika,2,Urgoon,2,Jani Qala,12,Building,11,0,2,FALSE
+1211175,69.13863483,32.86554254,2,Noorli School,Paktika,2,Urgoon,0,Noorullah Village,12,Village,11,2,0,TRUE
+1211176,69.13596557,32.86387124,0,Haji Guest House,Paktika,2,Urgoon,2,Noorullah Village,12,Village,11,2,0,TRUE
+1211177,69.24188991,32.93893913,2,Bebi Kot Mosque,Paktika,2,Urgoon,0,Bebi Kot Village,12,Village,11,2,0,TRUE
+1211178,69.24189705,32.93893913,0,Nazir Guest House,Paktika,2,Urgoon,2,Bebi Kot Village,12,Village,11,2,0,TRUE
+1211179,69.22203894,32.97821802,3,Pashti Mosque,Paktika,3,Urgoon,0,Pashti Village,12,Building,11,2,1,TRUE
+1211180,69.22030608,32.97824846,0,Ali Baz Guest House,Paktika,2,Urgoon,2,Pashti Village,12,Village,11,2,0,TRUE
+1211181,69.27590907,32.9998294,2,Garbozi Guest House,Paktika,2,Urgoon,0,Garbozi Village,12,Village,11,2,0,TRUE
+1211182,69.27591273,32.99984403,0,Alim Khan Guest House,Paktika,3,Urgoon,3,Garbozi Village,12,Village,11,3,0,TRUE
+1211183,69.2568454,32.92701965,3,Peer Koti,Paktika,3,Urgoon,0,Peer Koti Village,12,Village,11,3,0,TRUE
+1211184,69.25685818,32.92703243,0,Zarif Guest House,Paktika,2,Urgoon,2,Peer Koti Village,12,Village,11,2,0,TRUE
+1211186,69.269766837,32.900984065,3,Zarif Guest House,Paktika,4,Urgoon,1,Shaikhan Village,12,Village,11,4,0,TRUE
+1211296,69.25700206,32.9253963,2,Per Koti Clinic,Paktika,2,Urgoon,0,Peer Koti,12,Village,11,2,0,TRUE
+1211297,69.1792271,32.9537973,0,Balish Girls Primary School,Paktika,2,Urgoon,2,Balishi,12,District,11,2,0,TRUE
+1211298,69.26984298,32.90166935,2,Shaikhan Girls Primary School,Paktika,2,Urgoon,0,Shaikhan,12,Village,11,2,0,TRUE
+1212187,69.32252614,33.15454399,4,Ziruk School,Paktika,4,Ziruk,0,Khodeki,12,Building,12,4,0,TRUE
+1212188,69.31710798,33.1567078,0,Alimi Village Madrassa,Paktika,3,Ziruk,3,Alimi Village,12,Building,12,3,0,TRUE
+1212189,69.31137204,33.15833863,3,Khaima Mosque,Paktika,3,Ziruk,0,District Bazaar,12,Building,12,3,0,TRUE
+1212190,69.30869734,33.15652513,0,Clinic,Paktika,2,Ziruk,2,Bazar,12,Building,12,2,0,TRUE
+1212191,69.32865922,33.16777937,0,Bostan Clinic,Paktika,2,Ziruk,2,Ster Kalai,12,Village,12,2,0,TRUE
+1212192,69.32865922,33.16773056,3,Gulistan Clinic,Paktika,3,Ziruk,0,Ster Kalai,12,Village,12,3,0,TRUE
+1212193,69.26336706,33.12234512,2,Sro Maidan Secondary School,Paktika,2,Ziruk,0,Sro Maidan,12,Building,12,2,0,TRUE
+1212194,69.25383347,33.12545502,0,Jamil Khan Mosque,Paktika,2,Ziruk,2,Sro Maidan,12,Village,12,2,0,TRUE
+1212195,69.24792004,33.12278622,2,War Zana Girls School,Paktika,2,Ziruk,0,Sro Maidan,12,Village,12,2,0,TRUE
+1212196,69.2288816,33.07264797,0,Shah Agha Mosque,Paktika,2,Ziruk,2,Var Zana,12,Village,12,2,0,TRUE
+1213197,69.25769903,33.20120325,0,Nooraki Mosque,Paktika,6,Nika,6,Nora Ki,12,Village,13,6,0,TRUE
+1213198,69.25774202,33.20137383,5,Sharbat Shah Guest House,Paktika,5,Nika,0,Nora Ki,12,Village,13,5,0,TRUE
+1213199,69.27245988,33.18839995,2,Ghazi Khan Mosque,Paktika,2,Nika,0,Janat Khan,12,Village,13,2,0,TRUE
+1213200,69.27199425,33.18935233,0,Haji Sakhi Jan Guest House,Paktika,2,Nika,2,Janat Khan,12,Village,13,2,0,TRUE
+1213201,69.24836985,33.1727249,3,Tori Khel Mosque,Paktika,3,Nika,0,Tori Khel,12,Village,13,3,0,TRUE
+1213202,69.23540362,33.14792194,0,Zafar Jan Guest House,Paktika,3,Nika,3,Tori Khel,12,Village,13,3,0,TRUE
+1213203,69.25471428,33.18795351,3,District Center,Paktika,3,Nika,0,Sadiq Khel,12,Village,13,3,0,TRUE
+1213204,69.25966832,33.18832471,0,Hakim Khan Guest House,Paktika,2,Nika,2,Sadiq Khel,12,Village,13,2,0,TRUE
+1214247,69.24437933,32.62542026,5,Malekeshi Madrassa,Paktika,5,Barmal,0,Malik Shahi,12,Village,14,4,1,TRUE
+1214248,69.24444226,32.62538879,0,Malik Shahi Madrassa,Paktika,2,Barmal,2,Malik Shahi,12,Village,14,2,0,TRUE
+1214249,69.25767484,32.64356452,5,District Mosque,Paktika,5,Barmal,0,District Center,12,Building,14,2,3,TRUE
+1214250,69.27211516,32.51926005,0,Nawab Clinic,Paktika,3,Barmal,3,District Center,12,Village,14,2,1,TRUE
+1214251,69.2559536,32.5404118,4,Faroqia School,Paktika,4,Barmal,0,Faroqia,12,Building,14,3,1,TRUE
+1214252,69.286422,32.740717,0,Molla Aqib Khan Guest House,Paktika,3,Barmal,3,Fakhir Khan Madrassa,12,Village,14,2,1,TRUE
+1214253,69.32288312,32.78607092,4,Morgha Madrassa,Paktika,4,Barmal,0,Margha Village,12,Village,14,4,0,TRUE
+1214256,69.32907039,32.77908444,3,Margha Clinic,Paktika,5,Barmal,2,Margha Village,12,Village,14,0,5,FALSE
+1214258,69.33067343,32.78069219,2,Margha Tent,Paktika,5,Barmal,3,Margha Village,12,Village,14,5,0,TRUE
+1214259,69.33256218,32.79021587,3,Eid Khan Madrassa,Paktika,3,Barmal,0,Sher Aavah,12,Village,14,3,0,TRUE
+1214260,69.33257775,32.79021587,0,Jangir Guest House,Paktika,2,Barmal,2,Sher Aavah,12,Village,14,2,0,TRUE
+1214261,69.20021221,32.55276613,2,Petogay Secondary School,Paktika,2,Barmal,0,Petogay,12,Building,14,2,0,TRUE
+1214262,69.19936929,32.55326023,0,Saifurahman Guest House,Paktika,2,Barmal,2,Petogay,12,Building,14,2,0,TRUE
+1214263,69.31770868,32.77934201,4,Ahmad Gati Shop,Paktika,4,Barmal,0,Gati,12,District,14,4,0,TRUE
+1214264,69.34195848,32.79120847,0,Makhfirollah Guest House,Paktika,2,Barmal,2,Serdag,12,District,14,2,0,TRUE
+1214265,69.25223052,32.52274813,2,Saif-U-Rahman Guest House,Paktika,4,Barmal,2,Aati Village,12,District,14,4,0,TRUE
+1214266,69.33365159,32.78316741,2,Bador Ahmadzai Mosque,Paktika,4,Barmal,2,Ahmadzai Madrassa,12,District,14,4,0,TRUE
+1214303,69.31605548,32.79124568,2,Makhfirollah Guest House,Paktika,2,Barmal,0,Zangi Ada,12,District,14,2,0,TRUE
+1214304,69.31605548,32.79038907,0,Zangi Ada Village Mosque,Paktika,2,Barmal,2,Zangi Ada,12,District,14,2,0,TRUE
+1214305,69.25408167,32.54938381,3,Bahadr Mosque,Paktika,3,Barmal,0,Malik Noorullah,12,District,14,3,0,TRUE
+1214306,69.28771969,32.80657528,3,Adam Khan Village Primary School,Paktika,3,Barmal,0,Adam Khan Village,12,Village,14,3,0,TRUE
+1215267,69.34920559,33.00659399,4,Kamal Village Mosque,Paktika,4,Giyan,0,Kamal Village,12,Building,15,4,0,TRUE
+1215268,69.38400933,32.92811727,0,Shazar Guest House,Paktika,3,Giyan,3,Kamal Village,12,Village,15,3,0,TRUE
+1215269,69.3396876,32.96675301,3,Jangir Mosque,Paktika,3,Giyan,0,Ogo Hast,12,Village,15,3,0,TRUE
+1215270,69.34073935,32.96815535,0,Nazar Gul Guest House,Paktika,3,Giyan,3,Ogo Hast,12,Village,15,3,0,TRUE
+1215272,69.37333341,32.97819948,4,District Compound Tent,Paktika,5,Giyan,1,District Center,12,Village,15,5,0,TRUE
+1215273,69.36835491,33.00876078,3,Saravtah Mosque,Paktika,3,Giyan,0,Saravatah,12,Village,15,3,0,TRUE
+1215274,69.37093676,33.00567656,0,Mir Del Guest House,Paktika,3,Giyan,3,Saravatah,12,Village,15,3,0,TRUE
+1215275,69.36787163,33.01001868,2,Esla Shah Mosque,Paktika,2,Giyan,0,Esla Shah,12,District,15,2,0,TRUE
+1215276,69.36813813,33.00961893,0,Kheraj Guest House,Paktika,2,Giyan,2,Esla Shah,12,District,15,2,0,TRUE
+1215278,69.39140943,32.98026559,3,Latif Guest House,Paktika,4,Giyan,1,Gali,12,District,15,4,0,TRUE
+1215279,69.37276916,32.97686407,3,Geyan District Mosque,Paktika,3,Giyan,0,Geyan District Center,12,Village,15,3,0,TRUE
+1215280,69.37276202,32.97685694,0,Molla Fazel Guest House,Paktika,3,Giyan,3,Geyan District Center,12,Village,15,3,0,TRUE
+1216206,68.20593947,32.54802026,4,Gender Guest House,Paktika,5,Dila Wa Khushamand,1,Gender,12,District,16,5,0,TRUE
+1216208,68.04441791,32.59710482,2,District Compound Tent,Paktika,4,Dila Wa Khushamand,2,District Center,12,Village,16,4,0,TRUE
+1216210,68.04435485,32.5970838,3,Health Clinic,Paktika,4,Dila Wa Khushamand,1,District Center,12,Village,16,4,0,TRUE
+1216212,68.08786797,32.62203767,1,Gul Sadin Guest House,Paktika,2,Dila Wa Khushamand,1,Atargai,12,Village,16,2,0,TRUE
+1216215,68.04058322,32.60041182,3,Akbar Khan Shop,Paktika,5,Dila Wa Khushamand,2,District Center,12,Village,16,5,0,TRUE
+1216216,68.20647853,32.52643354,3,Moonari Village School,Paktika,5,Dila Wa Khushamand,2,Manari,12,Village,16,5,0,TRUE
+1216217,68.1846685,32.63882853,3,Chori Village Mosque,Paktika,3,Dila Wa Khushamand,0,Chori,12,Building,16,3,0,TRUE
+1216218,68.18395871,32.63887842,0,Mera Gul Old House,Paktika,2,Dila Wa Khushamand,2,Chori,12,Building,16,2,0,TRUE
+1217219,68.35680112,32.19613199,6,Bazar Mosque,Paktika,6,Wazakhwah,0,Bazar,12,Building,17,6,0,TRUE
+1217220,68.31497182,31.98411603,0,Mashori Village Mosque,Paktika,4,Wazakhwah,4,Mashori Village,12,Village,17,4,0,TRUE
+1217221,68.259258,32.185088,4,Marjan Mosque,Paktika,4,Wazakhwah,0,Marjan Village,12,Village,17,4,0,TRUE
+1217222,68.26054844,32.18444682,0,Haji Fateh Khan Mosque,Paktika,4,Wazakhwah,4,Marjan Village,12,Village,17,4,0,TRUE
+1217224,68.36228333,32.18206944,3,District Compound Tent,Paktika,4,Wazakhwah,1,District Center,12,Building,17,4,0,TRUE
+1217227,68.43313159,32.15752626,2,Apsar Kot Mosque,Paktika,2,Wazakhwah,0,Apsar Kot,12,Building,17,2,0,TRUE
+1217228,68.43351561,32.17238121,0,Servand Primary School,Paktika,3,Wazakhwah,3,Haji Adam Qala,12,Building,17,3,0,TRUE
+1217229,68.31011716,32.18190214,0,Gulalabi Mosque,Paktika,3,Wazakhwah,3,Gulalabi,12,Village,17,3,0,TRUE
+1217230,68.30884724,32.18077701,5,Hamidullah Guest House,Paktika,5,Wazakhwah,0,Gulalabi,12,Village,17,5,0,TRUE
+1217299,68.25623665,32.18532421,0,Marjan Village Tent,Paktika,3,Wazakhwah,3,Marjan Village,12,Village,17,3,0,TRUE
+1217300,68.36369675,32.19523828,2,District Center Primary School,Paktika,2,Wazakhwah,0,District Center,12,Building,17,2,0,TRUE
+1218237,68.67657091,32.08993908,5,District Compound,Paktika,5,Wor Mamy,0,Wowr,12,Building,18,5,0,TRUE
+1218238,68.67342765,32.09054251,0,Clinic,Paktika,3,Wor Mamy,3,Wowr,12,Building,18,3,0,TRUE
+1218239,68.84451047,32.02648763,3,Haji Balol Guest House,Paktika,4,Wor Mamy,1,Mami,12,Building,18,4,0,TRUE
+1218240,68.84416425,32.02602601,1,Eid Gul Guest House,Paktika,4,Wor Mamy,3,Mami,12,Building,18,4,0,TRUE
+1218241,68.88371646,31.79766383,4,2 Cheena Village Shop,Paktika,4,Wor Mamy,0,Do Cheena Village,12,Building,18,4,0,TRUE
+1218242,68.86986918,31.77636961,4,Old Police Office,Paktika,4,Wor Mamy,0,Do Cheena,12,Village,18,4,0,TRUE
+1218243,68.59189804,31.98372708,3,Sarwazai Mosque,Paktika,3,Wor Mamy,0,Awr,12,District,18,3,0,TRUE
+1218244,68.68454914,32.13031113,0,Wakil Ghami School,Paktika,3,Wor Mamy,3,Awr,12,District,18,3,0,TRUE
+1218245,68.704444,31.974722,2,Haji Nawab Khan Guest House,Paktika,3,Wor Mamy,1,Sangar Khel,12,Village,18,3,0,TRUE
+1218246,68.704444,31.974722,1,Abdul Guest House,Paktika,3,Wor Mamy,2,Sangar Khel,12,Village,18,3,0,TRUE
+1218301,68.67581223,32.0881279,0,District Center Secondary School,Paktika,2,Wor Mamy,2,Cheena,12,Building,18,2,0,TRUE
+1218302,68.86965503,31.77452553,0,2 Cheena Village Mosque,Paktika,2,Wor Mamy,2,Do Cheena Village,12,Village,18,2,0,TRUE
+1219231,68.403386812,31.793000207,4,Turwo District School,Paktika,5,Turwo,1,Turwo District Center,12,Village,19,5,0,TRUE
+1219234,68.40189795,31.79417634,2,District Compound Tent,Paktika,4,Turwo,2,Turwo District Center,12,Village,19,4,0,TRUE
+1219236,68.40506428,31.79422316,2,Dost Mohammad Shop,Paktika,4,Turwo,2,District Center Bazar,12,Village,19,4,0,TRUE
+1301001,69.22128943,33.60158164,12,Abdul Hai High School,Paktya,12,Gardez,0,Gardez City,13,Building,1,13,0,TRUE
+1301002,69.22210157,33.60395393,0,City Girls High School,Paktya,6,Gardez,6,Gardez City,13,Building,1,6,0,TRUE
+1301003,69.30354818,33.60902204,4,Mohlan School,Paktya,7,Gardez,3,Mohlan,13,Building,1,7,0,TRUE
+1301004,69.22731638,33.66193925,5,Tera School,Paktya,6,Gardez,1,Tera,13,Building,1,6,0,TRUE
+1301005,69.228955723,33.655356922,3,Abdula Khel High School,Paktya,5,Gardez,2,Tera,13,Building,1,5,0,TRUE
+1301006,69.16959117,33.55770078,5,Ibrahim Khel School,Paktya,8,Gardez,3,Ibrahim Khel,13,Building,1,8,0,TRUE
+1301007,69.16432346,33.63602654,4,Robaat Boys School,Paktya,4,Gardez,0,Robaat Village,13,Building,1,4,0,TRUE
+1301008,69.17345242,33.63028866,0,Robaat Girls School,Paktya,4,Gardez,4,Robaat Village,13,Building,1,4,0,TRUE
+1301009,69.33665829,33.55841193,4,Zahoo Primary School,Paktya,6,Gardez,2,Zahoo Village,13,Building,1,6,0,TRUE
+1301010,69.33456877,33.52412326,4,Dara High School,Paktya,7,Gardez,3,Dara,13,Building,1,7,0,TRUE
+1301011,69.23321589,33.58350007,3,Khudaidad Khel High School,Paktya,6,Gardez,3,Dawlatzai,13,Building,1,6,0,TRUE
+1301012,69.28732015,33.62450347,4,Bala Deh School,Paktya,6,Gardez,2,Bala Deh,13,Building,1,6,0,TRUE
+1301013,69.26984564,33.53430384,2,Kajeer Tent,Paktya,3,Gardez,1,Banozai,13,Village,1,3,0,TRUE
+1301014,69.26222222,33.5975,2,Ramazan Tent,Paktya,3,Gardez,1,Mamri,13,Building,1,3,0,TRUE
+1301015,69.25265365,33.64244822,2,Marjaan Tent,Paktya,3,Gardez,1,Glowal Tera,13,Village,1,3,0,TRUE
+1301016,69.20194444,33.56027777,3,Mohammad Ajan Tent,Paktya,4,Gardez,1,Kwash Warsak,13,Village,1,4,0,TRUE
+1301017,69.25594714,33.65210776,2,Khan Dawran Tent,Paktya,4,Gardez,2,"Nasti Kot, Golo Khel",13,Village,1,4,0,TRUE
+1301018,69.24217106,33.5675881,3,Maldaari Tent,Paktya,4,Gardez,1,Lakri,13,Village,1,4,0,TRUE
+1301201,69.27330736,33.5522071,3,Banozo Primary School,Paktya,5,Gardez,2,Banozai,13,Building,1,9,0,TRUE
+1301202,68.940376,33.459766,3,Khowazako School,Paktya,4,Gardez,1,Khowazak,13,Village,1,4,0,TRUE
+1301203,69.15372261,33.74881696,2,Tandano School,Paktya,3,Gardez,1,Tandan,13,Building,1,3,0,TRUE
+1301204,69.216245373,33.666502828,3,Serraie School,Paktya,4,Gardez,1,Serraie,13,Building,1,4,0,TRUE
+1302190,69.3045596,33.65338274,5,Rod High School,Paktya,6,Ahmadaba,1,Rod-E-Shali Khel,13,Building,2,9,0,TRUE
+1302191,69.33460404,33.67227459,5,Salam Khel School,Paktya,5,Ahmadaba,0,Salam Khel,13,Village,2,8,0,TRUE
+1302192,69.36035169,33.75820946,0,Sarkay Malang Clinic,Paktya,4,Ahmadaba,4,Salam Khel,13,Building,2,4,0,TRUE
+1302193,69.30202256,33.63376909,3,Khwaja Ali Ziarat,Paktya,3,Ahmadaba,0,Esa Khel,13,Village,2,4,0,TRUE
+1302194,69.29938136,33.63079477,0,Mali Khel School,Paktya,3,Ahmadaba,3,Esa Khel,13,Village,2,3,0,TRUE
+1302195,69.37177225,33.75744943,4,Machalgho High School,Paktya,6,Ahmadaba,2,"Noora Khel, Machalgho",13,Village,2,6,0,TRUE
+1302196,69.38023399,33.75870391,2,Machalgho Clinic,Paktya,4,Ahmadaba,2,Machalgho,13,Village,2,4,0,TRUE
+1302197,69.40928675,33.74447566,4,Mamozo Secondary School,Paktya,5,Ahmadaba,1,Mamozay,13,Building,2,5,0,TRUE
+1302198,69.382415,33.777437,3,Akhond Khel Secondary School,Paktya,5,Ahmadaba,2,Machalgho,13,Village,2,6,1,TRUE
+1302199,69.33690875,33.74895712,4,Gharak High School,Paktya,4,Ahmadaba,0,Gharak,13,Building,2,4,0,TRUE
+1302200,69.3367,33.7489,0,Fazel Khel Mosque,Paktya,4,Ahmadaba,4,Gharak,13,Village,2,4,0,TRUE
+1302218,69.38372216,33.76907314,1,Boragay School,Paktya,2,Ahmadaba,1,Boragieo Village,13,District,2,4,0,TRUE
+1303078,69.03306479,33.43587668,5,Habibullah High School,Paktya,7,Zurmat,2,Tameer,13,Building,3,7,0,TRUE
+1303079,69.07356422,33.47383944,4,Batoor High School,Paktya,4,Zurmat,0,Batoor,13,Village,3,1,3,TRUE
+1303080,69.07188047,33.48240941,0,Maqarab Khel Madrassa,Paktya,2,Zurmat,2,"Maqarab Khel, Batoor",13,Building,3,1,1,TRUE
+1303081,69.02518018,33.52564868,2,Shagom Bala Madrssa,Paktya,2,Zurmat,0,Haibat Khel,13,Village,3,2,0,TRUE
+1303082,69.03327035,33.52519183,0,Haibat Khel Mosque,Paktya,2,Zurmat,2,Haibat Khel,13,Village,3,0,2,FALSE
+1303083,69.04157043,33.4966318,2,Shamul Zai Madrassa,Paktya,2,Zurmat,0,Shamul Zai Sahak,13,Village,3,2,0,TRUE
+1303084,69.05237823,33.5444404,0,Sahak Clinic,Paktya,2,Zurmat,2,Sahak,13,Village,3,0,2,FALSE
+1303085,69.04578799,33.53504126,2,Sahak High School,Paktya,2,Zurmat,0,Sahak,13,Village,3,0,2,FALSE
+1303086,69.04574141,33.53504244,0,Ataa Gul Mosque,Paktya,2,Zurmat,2,Sahak,13,Village,3,2,0,TRUE
+1303087,68.8880439,33.45436018,2,Dawlat Khan Mosque,Paktya,3,Zurmat,1,Kolalgo,13,Village,3,0,3,FALSE
+1303088,68.88883057,33.45288607,5,Kolalgo High School,Paktya,5,Zurmat,0,Kolalgo,13,Building,3,4,1,TRUE
+1303089,68.88188321,33.46777722,0,Ettifaq School,Paktya,2,Zurmat,2,Jaighatian Kolalgo,13,Village,3,1,1,TRUE
+1303090,68.92159197,33.47088388,3,Koti Khel School,Paktya,5,Zurmat,2,Koti Khel,13,Building,3,3,2,TRUE
+1303091,68.94573841,33.4693094,1,Dawlat Zo High School,Paktya,2,Zurmat,1,Makawa Dawlatzai,13,Village,3,2,0,TRUE
+1303092,68.97591714,33.43677864,2,Nawi Kohi Mosque,Paktya,2,Zurmat,0,Guldat Khel,13,Village,3,2,0,TRUE
+1303093,68.97604535,33.43651678,0,Hussain Hojra,Paktya,2,Zurmat,2,Guldat Khel,13,Village,3,2,0,TRUE
+1303094,69.1886632,33.36105506,0,Sorkai School,Paktya,4,Zurmat,4,Sorkai,13,Building,3,4,0,TRUE
+1303095,69.13877371,33.35884095,3,Saleh Khel Shah Mohammad Hojra,Paktya,3,Zurmat,0,Sorkai,13,Village,3,3,0,TRUE
+1303096,69.01278751,33.38272543,4,Alozo School,Paktya,4,Zurmat,0,"Alozo Kala, Sorkai",13,Building,3,4,0,TRUE
+1303097,69.13770586,33.35960077,0,Kam Jamali Hojra,Paktya,2,Zurmat,2,Sorkai,13,Village,3,2,0,TRUE
+1303098,69.10462602,33.41237302,2,Emani Khel Madrassa,Paktya,2,Zurmat,0,Zor Kohi,13,District,3,2,0,TRUE
+1303099,69.017218,33.460139,0,Zor Kohi Madrassa,Paktya,2,Zurmat,2,Zor Kohi,13,Village,3,2,0,TRUE
+1303100,68.95664445,33.46516666,1,Dawlat Zai Hojra,Paktya,2,Zurmat,1,Makawa Dawlat Zai,13,Village,3,2,0,TRUE
+1303101,69.09300288,33.26073461,1,Shahi Kot School,Paktya,2,Zurmat,1,Arma Shahi Kot,13,Village,3,2,0,TRUE
+1303102,69.0952796,33.26437526,1,District Compound,Paktya,2,Zurmat,1,Arma,13,Village,3,2,0,TRUE
+1303103,69.0375,33.3133333,3,New Madrassa,Paktya,6,Zurmat,3,Arma Astogan,13,Village,3,6,0,TRUE
+1303104,69.118559711,33.455527175,6,Nek Naam Mosque,Paktya,6,Zurmat,0,Arma Nek Naam,13,Village,3,6,0,TRUE
+1303105,69.09447311,33.26300501,0,Fazel Rahman Hojra,Paktya,3,Zurmat,3,Arma Nek Naam,13,Village,3,3,0,TRUE
+1303106,69.13852272,33.47813804,0,Mamozo Clinic,Paktya,2,Zurmat,2,Arma Janik Khel,13,Village,3,2,0,TRUE
+1303107,69.12989398,33.48509556,2,Janik Khel Mosque,Paktya,2,Zurmat,0,Arma Janik Khel,13,Village,3,2,0,TRUE
+1303108,69.15402412,33.47858348,2,Khar Mast Khel Mosque,Paktya,2,Zurmat,0,Arma Khar Mast Khel,13,Village,3,2,0,TRUE
+1303109,69.155,33.4780556,0,Mohammad Telaa Hojra,Paktya,2,Zurmat,2,Arma Khar Mast Khel,13,Village,3,2,0,TRUE
+1303110,69.11850766,33.45434488,2,Rahman Khel Madrassa,Paktya,2,Zurmat,0,Arma Rahman Khel,13,Village,3,2,0,TRUE
+1303111,69.11755513,33.45702921,0,Rahman Khel Mosque,Paktya,2,Zurmat,2,Arma Rahman Khel,13,Village,3,2,0,TRUE
+1304112,69.37547536,33.44260351,5,Ibrahim Khel High School,Paktya,7,Shwak,2,Ibrahim Khel,13,Building,4,7,0,TRUE
+1304113,69.38478716,33.39402274,3,Shabak Primary School,Paktya,6,Shwak,3,Shabak,13,Building,4,6,0,TRUE
+1305114,69.43875767,33.36706248,3,Waza Primary School,Paktya,3,Wuza Zadran,0,Waza Village,13,Building,5,3,0,TRUE
+1305115,69.43982326,33.36715205,0,Waza Education Madrassa,Paktya,2,Wuza Zadran,2,Waza Village,13,Village,5,2,0,TRUE
+1305116,69.45263117,33.36959923,2,Lota Mosque,Paktya,2,Wuza Zadran,0,Lotta Village,13,Building,5,2,0,TRUE
+1305117,69.4499672,33.368764,0,Gul Wali Tent,Paktya,2,Wuza Zadran,2,Lotta,13,Village,5,2,0,TRUE
+1305118,69.45950527,33.34315267,2,School Tent,Paktya,3,Wuza Zadran,1,Tanga Berai,13,Village,5,3,0,TRUE
+1305119,69.42787573,33.32025299,3,Moti Mir Khan Jan Shop,Paktya,3,Wuza Zadran,0,Moti,13,Village,5,3,0,TRUE
+1305120,69.42656227,33.32056708,0,Hamidullah Hojra,Paktya,2,Wuza Zadran,2,Moti,13,Village,5,2,0,TRUE
+1305121,69.49287812,33.46087521,2,Shelm Mosque,Paktya,2,Wuza Zadran,0,Shelm,13,Village,5,2,0,TRUE
+1305122,69.49360029,33.46243685,0,Qadir Jan Hojra,Paktya,2,Wuza Zadran,2,Shelm,13,Village,5,2,0,TRUE
+1305123,69.474711,33.4324086,1,Commissioner House,Paktya,2,Wuza Zadran,1,Mita Khel,13,Village,5,2,0,TRUE
+1305124,69.41520755,33.51667215,2,Primary School,Paktya,3,Wuza Zadran,1,Ali Ahmad Khel,13,Village,5,3,0,TRUE
+1305125,69.34265677,33.28679979,3,Nasri Baba School,Paktya,3,Wuza Zadran,0,Klazai Khola,13,Village,5,3,0,TRUE
+1305126,69.34265506,33.28681643,0,Kalazai Khola,Paktya,3,Wuza Zadran,3,Kaliza Khola,13,Village,5,3,0,TRUE
+1305127,69.318005799,33.386060067,3,Ibrahim Shops,Paktya,4,Wuza Zadran,1,"Garda Seri,  Zarghon Ragha",13,Village,5,4,0,TRUE
+1305128,69.39465372,33.37018464,2,Fakhri Shops,Paktya,3,Wuza Zadran,1,"Garda Seri, Fakhri",13,Village,5,3,0,TRUE
+1305129,69.43727059,33.36788294,3,Garda Seri Clinic,Paktya,4,Wuza Zadran,1,District Center,13,Building,5,4,0,TRUE
+1305130,69.43881248,33.36711199,2,District Compound,Paktya,3,Wuza Zadran,1,District Center,13,Building,5,3,0,TRUE
+1305131,69.383943558,33.386063454,3,Garda Seri Mosque,Paktya,4,Wuza Zadran,1,"Khar Khil, Garda Seri",13,Building,5,4,0,TRUE
+1305206,69.47151259,33.36819073,1,Ghorkai Khola Madrassa,Paktya,2,Wuza Zadran,1,"Ghorkai Khola, Garda Seri",13,Village,5,2,0,TRUE
+1306019,69.38164864,33.694558,5,Sayed Karam District Compound,Paktya,5,Sayyid Karam,0,District Center,13,Building,6,6,0,TRUE
+1306020,69.3807786,33.69381393,0,Sayed Karam District Clinic,Paktya,3,Sayyid Karam,3,District Center,13,Building,6,5,0,TRUE
+1306021,69.36792781,33.6909021,3,Kondar Khel Mosque,Paktya,4,Sayyid Karam,1,Kondar Khel,13,Building,6,6,0,TRUE
+1306023,69.41200095,33.71112895,3,Khandh Khel Mosque,Paktya,3,Sayyid Karam,0,Khandh Khel,13,Building,6,4,0,TRUE
+1306024,69.41749588,33.70405809,0,Khandh Khel School,Paktya,3,Sayyid Karam,3,Khandh Khel,13,Village,6,4,0,TRUE
+1306025,69.42953335,33.65318929,2,Usman Khel Mosque,Paktya,2,Sayyid Karam,0,Usman Khel,13,Building,6,2,0,TRUE
+1306026,69.42956993,33.65320694,0,Usman Khel Mosque,Paktya,2,Sayyid Karam,2,Usman Khel,13,Building,6,2,0,TRUE
+1306027,69.44120248,33.67846572,2,Khushal Khel Madrassa,Paktya,2,Sayyid Karam,0,Khushal Khel,13,Building,6,2,0,TRUE
+1306028,69.45731048,33.67466963,0,Khushal Khel Clinic,Paktya,2,Sayyid Karam,2,Khushal Khel,13,Village,6,2,1,TRUE
+1306029,69.4866491,33.72961555,3,Samin Khel Madrassa,Paktya,3,Sayyid Karam,0,Samin Khel,13,Village,6,3,0,TRUE
+1306030,69.49373643,33.72884295,0,Nadir Khan House,Paktya,2,Sayyid Karam,2,Samin Khel,13,Village,6,2,0,TRUE
+1306031,69.45204473,33.75416709,3,Karez Mosque,Paktya,3,Sayyid Karam,0,Karez,13,Building,6,3,0,TRUE
+1306032,69.45010404,33.75343072,0,Karez School,Paktya,2,Sayyid Karam,2,Karez,13,Building,6,2,0,TRUE
+1306034,69.40557362,33.69869044,3,Shekhano Mosque,Paktya,4,Sayyid Karam,1,Shekhan,13,Building,6,4,0,TRUE
+1306035,69.48302024,33.66387495,2,Khan Khel School,Paktya,3,Sayyid Karam,1,Khan Khel Barkalgar,13,Building,6,3,0,TRUE
+1306036,69.48421625,33.60659968,2,Dam Mangal Madrassa,Paktya,2,Sayyid Karam,0,Dam Mangal,13,Village,6,2,0,TRUE
+1306037,69.49169727,33.60418215,0,Nek Mohammad Hojra,Paktya,2,Sayyid Karam,2,Dam Mangal,13,Village,6,2,0,TRUE
+1306038,69.45869145,33.68071057,3,Kalgar Madrassa,Paktya,3,Sayyid Karam,0,Kalgar,13,Building,6,3,0,TRUE
+1306039,69.4583012,33.68108725,0,Kalgar School,Paktya,2,Sayyid Karam,2,Kalgar,13,Building,6,2,0,TRUE
+1306040,69.40080131,33.65871404,2,Moch Mossque,Paktya,3,Sayyid Karam,1,Moch,13,Building,6,3,0,TRUE
+1307053,69.71583451,33.9424781,5,Hashim Shop,Paktya,5,Jaji Aryob,0,Ali Khel,13,Building,7,5,0,TRUE
+1307054,69.71400923,33.94464683,0,Miseri Khel Mosque,Paktya,4,Jaji Aryob,4,Ali Khel,13,Building,7,4,0,TRUE
+1307055,69.67197019,33.96721958,4,Maari Khel School,Paktya,4,Jaji Aryob,0,Mari Khel,13,Building,7,0,4,FALSE
+1307056,69.68426164,33.95199563,0,Shah Mohammad Mosque,Paktya,4,Jaji Aryob,4,Mari Khel,13,Building,7,4,0,TRUE
+1307057,69.65383528,33.98685983,3,Rokiano Madrassa,Paktya,4,Jaji Aryob,1,Rokian,13,Village,7,0,4,FALSE
+1307058,69.618564353,34.027907324,3,Kharlooti Hospital,Paktya,4,Jaji Aryob,1,Kharlooti,13,Village,7,0,4,FALSE
+1307059,69.70286212,33.93850706,4,Mohammad Anwer Shop,Paktya,4,Jaji Aryob,0,Shishta Village,13,Building,7,4,0,TRUE
+1307060,69.69924316,33.930931,0,Kotkai Sheshti Mosque,Paktya,4,Jaji Aryob,4,Shishta,13,Building,7,4,0,TRUE
+1307061,69.73831673,33.9751106,3,Speri School,Paktya,4,Jaji Aryob,1,Shishta Village,13,District,7,4,0,TRUE
+1307062,69.74879891,33.9300556,3,Speri School,Paktya,4,Jaji Aryob,1,Speri Village,13,District,7,0,4,FALSE
+1307063,69.63011356,34.01168281,4,Rahmatullah Shop,Paktya,4,Jaji Aryob,0,Hassan Lagada,13,Village,7,0,4,FALSE
+1307064,69.63357743,34.01143882,0,Hassan Algadi Mosque,Paktya,3,Jaji Aryob,3,Hassan Lagada,13,Village,7,0,3,FALSE
+1307065,69.81600124,33.98798269,4,Mohammadullah School,Paktya,6,Jaji Aryob,2,Belawott,13,Building,7,6,0,TRUE
+1307067,69.74540331,33.95256067,3,Mir Mohammad Shop,Paktya,3,Jaji Aryob,0,Khawazi Khel,13,Building,7,3,0,TRUE
+1307068,69.72059457,33.94002671,0,Kana Khel School,Paktya,4,Jaji Aryob,4,Kana Khel,13,Village,7,4,0,TRUE
+1307070,69.79679552,33.96517629,3,Faqir Baba School,Paktya,5,Jaji Aryob,2,Lar Lewani/Sharif Village,13,Building,7,5,0,TRUE
+1307071,69.77850402,33.98287045,3,Imam-E-Azam School,Paktya,4,Jaji Aryob,1,Ali Sangi,13,Building,7,4,0,TRUE
+1307073,69.76770339,33.9591857,4,Sabil House,Paktya,5,Jaji Aryob,1,Ghonzai Ahmad Khel,13,Building,7,5,0,TRUE
+1307074,69.75780682,33.95930766,4,Ahmad Khel School,Paktya,5,Jaji Aryob,1,Ghonzai Ahmad Khel,13,Building,7,5,0,TRUE
+1307076,69.85175567,33.99065173,4,Gul Ghundi School,Paktya,5,Jaji Aryob,1,Gul Ghundi,13,Building,7,5,0,TRUE
+1307077,69.83788608,33.97793247,3,Kotkai Mosque,Paktya,4,Jaji Aryob,1,Kotkai,13,Village,7,4,0,TRUE
+1307211,69.6771271,33.95265269,1,Sarwan Khel School,Paktya,2,Jaji Aryob,1,Sarwan Khel,13,Village,7,2,0,TRUE
+1307212,69.69204438,33.90403496,1,Khair Meni School,Paktya,2,Jaji Aryob,1,Khair Mena,13,Building,7,2,0,TRUE
+1307213,69.83622834,33.99439503,1,Sor Gul School,Paktya,3,Jaji Aryob,2,Sor Gul,13,Building,7,3,0,TRUE
+1307214,69.69201477,33.94174409,1,Shagay School,Paktya,3,Jaji Aryob,2,Shaga,13,Building,7,3,0,TRUE
+1307215,69.77395082,33.96883587,2,Ali Sangayo Cilnic,Paktya,3,Jaji Aryob,1,Ali Sangi,13,Village,7,3,0,TRUE
+1307216,69.60133942,33.99549064,2,Muhram Astea School,Paktya,3,Jaji Aryob,1,Muhram Astea,13,District,7,3,0,TRUE
+1307217,69.70832092,33.95831691,1,Badali School,Paktya,2,Jaji Aryob,1,Badala,13,Village,7,2,0,TRUE
+1308132,69.59113356,33.83714234,5,Showat School,Paktya,5,Laja Ahmad Khel,0,"Showat, Ahmad Khel",13,Village,8,5,0,TRUE
+1308133,69.59113882,33.83514252,0,Showat Clinic,Paktya,2,Laja Ahmad Khel,2,"Showat, Ahmad Khel",13,Village,8,2,0,TRUE
+1308134,69.6408694,33.83621402,3,Mirzai School,Paktya,3,Laja Ahmad Khel,0,"Mirzai Village, Ahmad Khel",13,Village,8,3,0,TRUE
+1308135,69.64696915,33.84094305,0,Mirzai High School,Paktya,2,Laja Ahmad Khel,2,"Mirzai Village, Ahmad Khel",13,Village,8,2,0,TRUE
+1308136,69.6408519,33.82225021,2,Moshaki Mosque,Paktya,2,Laja Ahmad Khel,0,"Moshaka, Ahmad Khel",13,Village,8,2,0,TRUE
+1308137,69.64165182,33.82142606,0,Moshaka Clinic,Paktya,2,Laja Ahmad Khel,2,"Moshaka, Ahmad Khel",13,Village,8,2,0,TRUE
+1308138,69.6333802,33.87580948,3,Venus Khel Mosque,Paktya,3,Laja Ahmad Khel,0,Kwandi Hassan Khel Village,13,District,8,3,0,TRUE
+1308139,69.63409761,33.87544069,0,Sulaiman Khel Mosque,Paktya,2,Laja Ahmad Khel,2,Kwandi Hassan Khel Village,13,District,8,2,0,TRUE
+1308140,69.6322472,33.86539851,3,Janaz Bagh Clinic,Paktya,3,Laja Ahmad Khel,0,Sabt Khel Village,13,District,8,3,0,TRUE
+1308141,69.63340548,33.83997434,0,Dawlat Khel Mosque,Paktya,2,Laja Ahmad Khel,2,"Sabt Khel Village, Ahmad Khel",13,Village,8,2,0,TRUE
+1308142,69.68143352,33.89109818,3,Sakandar Khel High School,Paktya,3,Laja Ahmad Khel,0,Woersak Village,13,Building,8,3,0,TRUE
+1308143,69.68121907,33.89187725,0,Sakandar Khel Clinic,Paktya,2,Laja Ahmad Khel,2,"Worsak Village, Ahmad Khel",13,Building,8,2,0,TRUE
+1308207,69.67766876,33.885779689,1,Moti School,Paktya,2,Laja Ahmad Khel,1,"Moti Village, Sakander Khel",13,Village,8,2,0,TRUE
+1308219,69.639397735,33.836450892,2,Transport Station,Paktya,3,Ahmadaba,1,Mama Khil Village,13,Building,8,3,0,TRUE
+1308220,69.561522022,33.817246923,2,Makh Ki Mosque,Paktya,3,Ahmadaba,1,Makhi Village,13,Building,8,3,0,TRUE
+1309170,69.7848217,33.66666217,3,Kotkai Mosque,Paktya,3,Jani Khel,0,"Kotkai, Setar Kalai",13,Village,9,3,0,TRUE
+1309171,69.87417344,33.64299175,0,Ajab Khan Hojra,Paktya,2,Jani Khel,2,"Kotkai, Setar Kalai",13,Building,9,2,0,TRUE
+1309172,69.77894233,33.65458926,6,Jani Khel High School,Paktya,6,Jani Khel,0,Maidan Khola,13,Building,9,6,0,TRUE
+1309173,69.78089163,33.65219131,0,Jani Khel Clinic,Paktya,6,Jani Khel,6,Maidan Khola,13,Building,9,6,0,TRUE
+1309174,69.74503456,33.70519582,3,Asadullah Shop,Paktya,3,Jani Khel,0,Orgur,13,Village,9,3,0,TRUE
+1309175,69.81237712,33.54393721,0,Tent,Paktya,2,Jani Khel,2,Orgur,13,Village,9,2,0,TRUE
+1309176,69.80873783,33.54691136,0,Manz Algadi Mosque,Paktya,2,Jani Khel,2,Bal Khel,13,Village,9,2,0,TRUE
+1309177,69.819924786,33.56488866,3,Mowla Gul Mosque,Paktya,3,Jani Khel,0,Bal Khel,13,Village,9,3,0,TRUE
+1309178,69.79177561,33.55834751,3,Chenari Madrassa,Paktya,4,Jani Khel,1,Tanga Paaro Khel,13,Village,9,4,0,TRUE
+1309208,69.80770505,33.68361468,1,Chalam School,Paktya,2,Jani Khel,1,Chalam Village,13,Building,9,2,0,TRUE
+1309209,69.81929035,33.63034813,1,Darandy Mosque,Paktya,2,Jani Khel,1,"Darandi, Bal Khel",13,Building,9,2,0,TRUE
+1310156,69.81469719,33.80420755,5,District Clinic,Paktya,5,Samkani,0,"Chamkani District Center, Shahr-E-Naw",13,Building,10,5,0,TRUE
+1310157,69.81470407,33.80422075,0,District Central Hospital,Paktya,4,Samkani,4,"Chamkani, Shahr-E-Naw",13,Building,10,4,0,TRUE
+1310158,69.74815892,33.80626394,4,Bagyaar School,Paktya,4,Samkani,0,Bagyaar,13,Building,10,4,0,TRUE
+1310159,69.74202191,33.79689135,0,Sultan House,Paktya,4,Samkani,4,"Tanni, Bagyaar",13,Building,10,4,0,TRUE
+1310160,69.76232377,33.71254472,4,Eid Gul Mosque,Paktya,4,Samkani,0,Mangyaar Village,13,Village,10,4,0,TRUE
+1310161,69.78733092,33.802023,0,Ahmad Jan Shops,Paktya,4,Samkani,4,Mangyaar Village,13,Village,10,4,0,TRUE
+1310162,69.79795435,33.75059842,4,Sulaiman Khel Mosque,Paktya,4,Samkani,0,Sulaiman Khel,13,Building,10,4,0,TRUE
+1310163,69.80013229,33.76896251,0,Manda Khel High School,Paktya,4,Samkani,4,"Sulaiman Khel, Manda Khel",13,Village,10,4,0,TRUE
+1310165,69.78734687,33.80203565,3,Nargisi School,Paktya,4,Samkani,1,Nargisi,13,Village,10,4,0,TRUE
+1310166,69.78652214,33.72159014,4,Lowarry Madrassa,Paktya,4,Samkani,0,Lowarry,13,Village,10,4,0,TRUE
+1310167,69.7825631,33.72077247,0,Chinar Mosque,Paktya,4,Samkani,4,"Lowarry, Peeran",13,Village,10,4,0,TRUE
+1310168,69.88163531,33.80034298,4,Bablo Khel School,Paktya,4,Samkani,0,Toshi Village,13,Building,10,4,0,TRUE
+1310169,69.85454978,33.79666616,0,Babo Khel School,Paktya,4,Samkani,4,Babo Khel,13,Village,10,4,0,TRUE
+1311179,69.9230339,33.82337358,4,District Compound,Paktya,4,Dand Patan,0,"Dand Patan District Center, Sperai",13,Building,11,4,0,TRUE
+1311180,69.92275653,33.82432523,0,Spera Clinic,Paktya,3,Dand Patan,3,"Dand Patan District Center, Sperai",13,Building,11,3,0,TRUE
+1311181,69.90434141,33.87501094,3,Darang Secondary School,Paktya,4,Dand Patan,1,Ghundai Jangal,13,Village,11,4,0,TRUE
+1311182,69.88852043,33.8734439,3,Mir Hassan Mosque,Paktya,4,Dand Patan,1,Mir Hassan Village,13,Village,11,4,0,TRUE
+1311183,69.90831854,33.78451944,2,Shirwana Algada School,Paktya,2,Dand Patan,0,Hassan Lagada,13,Building,11,2,0,TRUE
+1311184,69.89427559,33.78639894,0,Speen Mosque,Paktya,2,Dand Patan,2,Sherwana Alagada,13,Village,11,2,0,TRUE
+1311185,69.9022222,33.8319444,2,Secondary School,Paktya,2,Dand Patan,0,Narai Zawar,13,Village,11,2,0,TRUE
+1311186,69.9022222,33.8319444,0,Sorgai Mosque,Paktya,2,Dand Patan,2,Narai Zawar,13,Village,11,2,0,TRUE
+1311187,69.90866464,33.73367967,3,Saltak Maqbol Secondary School,Paktya,3,Dand Patan,0,Saltak Moqbol,13,Village,11,3,0,TRUE
+1311188,69.90835161,33.73420542,0,Saltak Maqbol Health Clinic,Paktya,2,Dand Patan,2,Saltak Moqbol,13,Village,11,2,0,TRUE
+1311189,69.93841518,33.80743908,3,Shpoli Khola Mosque,Paktya,4,Dand Patan,1,"Shpoli Khola, Danda",13,Village,11,4,0,TRUE
+1311210,69.89208126,33.80046753,1,Matorokh Mosque,Paktya,2,Dand Patan,1,Matorokh Village,13,Building,11,2,0,TRUE
+1311221,69.924232936,33.822753944,2,Femal Secondary School,Paktya,3,Dand Patan,1,Patan Village,13,Building,11,3,0,TRUE
+1312144,69.6887489,33.79553893,3,District Compound,Paktya,3,Laja Mangal,0,"Laja Khola, Laja Mangal",13,Village,12,3,0,TRUE
+1312145,69.637422113,33.701945466,0,Araam Mosque,Paktya,2,Laja Mangal,2,"Araam Village, Laja Mangal",13,Village,12,2,0,TRUE
+1312146,69.62981956,33.81125735,2,Laja Mangal School,Paktya,2,Laja Mangal,0,"Chargo Village, Laja Mangal",13,Village,12,2,0,TRUE
+1312147,69.62819815,33.80925555,0,Chargo Village Mosque,Paktya,2,Laja Mangal,2,"Chargo Village, Laja Mangal",13,Village,12,2,0,TRUE
+1312148,69.66695998,33.7846718,3,Laja Primary School,Paktya,3,Laja Mangal,0,Laja Mangal Patka,13,Village,12,3,0,TRUE
+1312149,69.66689881,33.78512347,0,Patka Mosque,Paktya,2,Laja Mangal,2,Laja Mangal Patka,13,Village,12,2,0,TRUE
+1312150,69.64725224,33.76242586,3,Khairani School,Paktya,3,Laja Mangal,0,"Khairani, Laja Mangal",13,Village,12,3,0,TRUE
+1312151,69.70560328,33.75481145,0,Khairani Mosque,Paktya,2,Laja Mangal,2,"Khairani, Laja Mangal",13,Village,12,2,0,TRUE
+1312152,69.63033818,33.71560826,4,Toshnak School,Paktya,5,Laja Mangal,1,"Toshnak, Laja Mangal",13,Village,12,5,0,TRUE
+1312153,69.62718135,33.71482123,3,Toshnak Mosque,Paktya,4,Laja Mangal,1,"Toshnak, Laja Mangal",13,Village,12,4,0,TRUE
+1312154,69.62318382,33.70240797,2,Sharabak Primary School,Paktya,2,Laja Mangal,0,"Sharabak, Laja Mangal",13,Village,12,2,0,TRUE
+1312155,69.6228758,33.70302402,0,Sharabak Mosque,Paktya,2,Laja Mangal,2,"Sharabak, Laja Mangal",13,Village,12,2,0,TRUE
+1312222,69.629267355,33.734688266,2,Lalak Kahol Madrasa,Paktya,3,Laja Mangal,1,Lalak Village,13,Building,12,3,0,TRUE
+1312223,69.674158025,33.804050103,2,Dodai Mosque,Paktya,3,Laja Mangal,1,Koza Doda,13,Building,12,3,0,TRUE
+1313044,69.475957794,33.811046065,4,Naibuddin Mosque,Paktya,5,Meerzaka,1,Shamazali Khwar,13,District,13,7,0,TRUE
+1313046,69.4871915,33.76829497,3,Khalilan High School,Paktya,4,Meerzaka,1,"Khalilan, Merzaka",13,Village,13,6,0,TRUE
+1313047,69.53871169,33.79926444,3,Andwam Secondary School,Paktya,3,Meerzaka,0,"Andwam, Merzaka",13,Village,13,4,2,TRUE
+1313048,69.54447104,33.80262022,0,Andwam Madrassa,Paktya,2,Meerzaka,2,"Maenz Andwam, Merzaka",13,Village,13,2,2,TRUE
+1313049,69.51321941,33.82949444,2,Wacha Alagadi School,Paktya,2,Meerzaka,0,"Karkeen, Merzaka",13,Village,13,3,0,TRUE
+1313050,69.51319421,33.82950074,0,Wacha Alagadi School,Paktya,2,Meerzaka,2,"Karkeen, Merzaka",13,Village,13,2,0,TRUE
+1313051,69.52988008,33.76971539,3,Chorrkay Mosque,Paktya,3,Meerzaka,0,"Chorrkay, Merzaka",13,Village,13,4,0,TRUE
+1313052,69.53137438,33.77034833,0,Chorrkay School,Paktya,2,Meerzaka,2,"Chorrkay, Merzaka",13,Village,13,2,2,TRUE
+1313205,69.51524327,33.80012651,2,Ghonzai Mosque,Paktya,3,Meerzaka,1,"Ghonzai, Merzaka",13,Village,13,4,0,TRUE
+1401001,69.98252872,33.32002795,4,Shamul Old Village Mosque (Noorzai),Khost,6,Khost,2,Shamal Old Village,14,Building,1,6,0,TRUE
+1401002,69.98251682,33.32000178,3,Sharbat Khan Hojra,Khost,5,Khost,2,Shamal Old Village,14,Building,1,5,0,TRUE
+1401003,69.9427947,33.32614995,4,Omer Village Dermand,Khost,5,Khost,1,Omar Village,14,Village,1,5,0,TRUE
+1401004,69.94409176,33.3276505,2,Mohammad Vally Shah Hojra,Khost,4,Khost,2,Shamal Omar Village,14,Village,1,4,0,TRUE
+1401005,70.02635392,33.3284625,2,Malzayo Mosque,Khost,3,Khost,1,Shamal Malyzi,14,Building,1,3,0,TRUE
+1401006,70.02550998,33.32822751,2,Sayedullah Hojra,Khost,3,Khost,1,Shamal Malyzi,14,Building,1,3,0,TRUE
+1401007,70.01947279,33.34397029,2,Sarkai Jan Village Mosque,Khost,4,Khost,2,Shamal Serkai Jaan Village,14,Building,1,4,0,TRUE
+1401008,70.01448472,33.34363455,2,Akber Jan Hojra,Khost,4,Khost,2,Shamal Serkai Jaan Village,14,Village,1,4,0,TRUE
+1401009,69.89894358,33.3118118,2,Boda Khan Mosque,Khost,4,Khost,2,Shamal Mardi Khel,14,Building,1,4,0,TRUE
+1401010,69.89792041,33.31245426,2,Old Mosque,Khost,4,Khost,2,Shamal Mardi Khel,14,Building,1,4,0,TRUE
+1401011,70.05463299,33.28996611,2,Pasti Pali Mosque,Khost,3,Khost,1,Shamal Khar Seen,14,Building,1,3,0,TRUE
+1401012,70.05279767,33.28758572,2,Zahir Khan Hojra,Khost,3,Khost,1,Shamal Khar Seen,14,Village,1,3,0,TRUE
+1401013,69.90377529,33.36501336,3,Taza Village Mosque,Khost,5,Khost,2,Maton Shakari Village,14,Village,1,6,0,TRUE
+1401014,69.91814926,33.34637966,2,Maton Mandikhel Mosque,Khost,4,Khost,2,Maton Mandikhel,14,Village,1,5,0,TRUE
+1401015,69.92308238,33.34041792,3,Yaqoobi Adi Mosque,Khost,5,Khost,2,"Khost City, Maton",14,Building,1,7,0,TRUE
+1401016,69.91284201,33.33782236,3,Shaheed Mohammad Dawood School,Khost,5,Khost,2,Khost City,14,Building,1,6,0,TRUE
+1401017,69.92359683,33.34142655,3,Central Mosque,Khost,6,Khost,3,Khost City,14,Building,1,8,0,TRUE
+1401018,69.91762629,33.33419087,4,Women'S Affairs Department,Khost,6,Khost,2,Khost City,14,Building,1,7,0,TRUE
+1401019,69.92307813,33.34254225,3,Askari Hospital,Khost,5,Khost,2,Khost City,14,Building,1,6,0,TRUE
+1401020,69.90055555,33.34194444,4,Disabled Department,Khost,6,Khost,2,Azadi Mena,14,Building,1,7,0,TRUE
+1401021,69.90925164,33.34230395,4,Former Civil Hospital,Khost,6,Khost,2,"Khost City, Maton Tapa",14,Building,1,6,0,TRUE
+1401022,69.91795799,33.33725553,2,Ghazi Babrak Zadran Park,Khost,3,Khost,1,Khost City,14,Building,1,5,0,TRUE
+1401023,69.87812766,33.3321151,3,Customs House Mosque,Khost,5,Khost,2,Mata Cheena,14,Village,1,7,0,TRUE
+1401024,69.881096,33.334015,2,Mohammad Anwer Mosque And Hojra,Khost,3,Khost,1,Maton Chinay Village,14,Village,1,3,0,TRUE
+1401025,70.01488961,33.36848214,3,Mangaso Village Mosque,Khost,4,Khost,1,Mangas,14,Village,1,4,0,TRUE
+1401026,69.893554004,33.300170702,2,Mosque And Senator Hojra,Khost,3,Khost,1,"Maton, Warda Khel",14,Building,1,3,0,TRUE
+1401027,69.95236716,33.32809022,2,Landy Village Madrassa,Khost,4,Khost,2,"Maton, Landi Village",14,Building,1,4,0,TRUE
+1401028,70.06927586,33.38288656,3,Sroki Village Mosque,Khost,5,Khost,2,Lakan Babro Village,14,Building,1,5,0,TRUE
+1401029,70.03388888,33.375,2,Madikhel Village Madrassa,Khost,4,Khost,2,Madikhel Village,14,Village,1,4,0,TRUE
+1401030,70.08591661,33.38751826,3,Mosque And Hanif Hojra,Khost,5,Khost,2,Lakan Tang  Tang Village,14,Village,1,5,0,TRUE
+1401031,70.08123397,33.34052875,2,Sarbaz Mosque,Khost,3,Khost,1,Lakan Zokhi Khel,14,Building,1,3,0,TRUE
+1401032,70.06846301,33.38143071,3,Ayoub Khel Village Mosque,Khost,4,Khost,1,Ayoub Village,14,Building,1,4,0,TRUE
+1401033,70.0599016,33.35286045,3,Madrassa,Khost,4,Khost,1,Lakan Chinar Village,14,Village,1,4,0,TRUE
+1401034,69.91091303,33.38603973,3,Mosque,Khost,4,Khost,1,Lakan Khoni Khwar,14,Village,1,4,0,TRUE
+1401035,70.0324094,33.29477399,3,Loy Market,Khost,4,Khost,1,Ghazi Abad,14,Village,1,4,0,TRUE
+1401036,69.92040881,33.353551,2,Khalil House,Khost,4,Khost,2,Mani Village,14,Village,1,4,0,TRUE
+1401037,69.88702391,33.44041938,3,Mosque,Khost,4,Khost,1,Mazghora Village,14,Village,1,4,0,TRUE
+1401038,69.99332462,33.36391944,3,Badsha Wali Hojra,Khost,4,Khost,1,Kandio Village,14,Building,1,4,0,TRUE
+1401039,69.8367,33.39329,2,Mosque,Khost,3,Khost,1,Asarr,14,Village,1,3,0,TRUE
+1401040,69.91356751,33.36897969,3,Rahmat Gul Hojra,Khost,4,Khost,1,Habash Khel,14,Building,1,4,0,TRUE
+1401041,69.97405249,33.34481173,3,Mosque,Khost,4,Khost,1,Karwan Sarai,14,Village,1,4,0,TRUE
+1401042,69.98161609,33.33624786,3,Gul Badsha Hojra,Khost,4,Khost,1,Latak Haji Gul Badsha Village,14,Village,1,4,0,TRUE
+1401043,69.97111111,33.33777777,3,Gul Mar Jan Hojra,Khost,4,Khost,1,Latak Haji Omer Khan Village,14,Building,1,4,0,TRUE
+1401044,69.96190565,33.35606542,3,Amin Rahman House,Khost,4,Khost,1,Kajery Village,14,Building,1,5,0,TRUE
+1401045,69.94086493,33.35422509,3,Mosque,Khost,4,Khost,1,Kotoli Village,14,Building,1,4,0,TRUE
+1401046,69.90429967,33.30510505,3,Toor Ghondy School,Khost,4,Khost,1,Tori Ghonday Wazian Village,14,Building,1,4,0,TRUE
+1401047,69.95692123,33.31388832,3,Rasool House,Khost,4,Khost,1,Bangi Bagh,14,Building,1,4,0,TRUE
+1401161,70.02169062,33.35022909,3,Dere Madrassa,Khost,5,Khost,2,Deri,14,Building,1,7,0,TRUE
+1401162,69.91089704,33.386028,6,Khani Khwar Mosque,Khost,11,Khost,5,Deri,14,Village,1,11,0,TRUE
+1401176,70.03892225,33.320307402,2,Hasan Kot School,Khost,3,Khost,1,Center,14,Building,1,3,0,TRUE
+1402079,69.811321741,33.313208352,2,Bay Village School,Khost,3,Manduzay,1,Bay Village,14,Building,2,5,0,TRUE
+1402080,69.79922198,33.30968295,1,Dadwalow Nice Mosque,Khost,2,Manduzay,1,Dadwalow Village,14,Village,2,2,0,TRUE
+1402081,69.83104228,33.30833308,1,Burhani Khelo Mosque,Khost,2,Manduzay,1,Burhani Khel Village,14,Building,2,3,0,TRUE
+1402082,69.84322803,33.3245318,4,Mohammad Sedeq Highschool,Khost,5,Manduzay,1,Haider Khel,14,Building,2,8,0,TRUE
+1402083,69.79998572,33.32350248,1,Hassan Mohammad Mosque,Khost,2,Manduzay,1,Hassan Mohammad Mandozai,14,Village,2,3,0,TRUE
+1402084,69.76656403,33.30186096,1,Meta Khan High School,Khost,2,Manduzay,1,Meta Khan Village,14,Building,2,3,0,TRUE
+1402085,69.86801995,33.29951064,1,Tora Wari High School Degan,Khost,2,Manduzay,1,Tora Worrai,14,Building,2,2,0,TRUE
+1402086,69.8617206,33.32307098,1,Sayda Jan Mosque,Khost,2,Manduzay,1,Deganano Village,14,Building,2,2,0,TRUE
+1402087,69.76924939,33.31520926,1,Zhawari Village Khano Khel Mosque,Khost,2,Manduzay,1,Zhawari Village Khano Khel,14,Village,2,2,0,TRUE
+1402088,69.72152956,33.30978053,1,Shadal Village Mosque,Khost,2,Manduzay,1,Shadal,14,Building,2,2,0,TRUE
+1402089,69.75078601,33.31364663,2,Ajab Khan Village Mosque,Khost,3,Manduzay,1,Darnami,14,Building,2,3,0,TRUE
+1402090,69.78787052,33.31689854,2,Chandarr Village Mosque,Khost,3,Manduzay,1,Chandarr Village Mandozay,14,Village,2,3,0,TRUE
+1402091,69.74043096,33.31099848,2,Hassanzayo Girls High School,Khost,3,Manduzay,1,Hassanzai -Mandozi Village,14,Village,2,3,0,TRUE
+1402092,69.8128396,33.30992396,1,Dadwalo Village Mosque,Khost,2,Manduzay,1,Dadwaal Shamal Khel,14,Building,2,2,0,TRUE
+1402093,69.73960271,33.30153164,1,Dalpowrio Secondary School,Khost,2,Manduzay,1,Dalporayo Village,14,Village,2,3,0,TRUE
+1402094,69.79611111,33.36277777,1,Warza Village Mosque,Khost,2,Manduzay,1,Warza Village,14,Village,2,2,0,TRUE
+1402095,69.83101622,33.3079098,2,Bahram Khel Mosque,Khost,3,Manduzay,1,Bahram Khel,14,Village,2,3,0,TRUE
+1402096,69.85453647,33.32386107,1,Haider Khel Samawat School,Khost,2,Manduzay,1,Haider Khel,14,Village,2,2,0,TRUE
+1402177,69.864384958,33.316118869,2,Mosque,Khost,3,Manduzay,1,Dikano Village,14,Building,2,3,0,TRUE
+1402178,69.819562787,33.318805464,2,Shiraz Ali Mosque,Khost,3,Manduzay,1,Kram Village,14,Building,2,3,0,TRUE
+1402179,69.796455514,33.363467202,2,Noor Sha House,Khost,3,Manduzay,1,Warza Village,14,Building,2,3,0,TRUE
+1403147,69.96477239,33.28349679,5,Shaheed Mohammad Qadir High School,Khost,5,Gurbuz,0,Shaheed Village,14,Building,3,5,0,TRUE
+1403148,69.98061946,33.29590301,4,Mohammad Yaqoob Khan Mosque,Khost,5,Gurbuz,1,Marmandi Village,14,Village,3,5,0,TRUE
+1403149,69.91153846,33.28693206,3,Zakim Shah Mosque,Khost,4,Gurbuz,1,Sheikh Amir,14,Building,3,4,0,TRUE
+1403150,69.92825245,33.29854781,5,Jan Baz Mosque,Khost,5,Gurbuz,0,Wara Village,14,Village,3,5,0,TRUE
+1403151,69.88562661,33.24470486,1,Zolddin High School,Khost,2,Gurbuz,1,Fatlan Village,14,Village,3,2,0,TRUE
+1403152,69.92039304,33.28731763,2,Shaikh Amer High School,Khost,3,Gurbuz,1,"District Center, Shaikh Amir",14,Building,3,3,0,TRUE
+1403153,69.92525556,33.23579392,1,Bori Khelo Mosque,Khost,3,Gurbuz,2,Boro Khel,14,Building,3,3,0,TRUE
+1403154,69.92449108,33.23263571,2,Bozhi Khel Village Mosque,Khost,4,Gurbuz,2,Bogi Khel,14,Building,3,4,0,TRUE
+1403174,70.011179793,33.236315083,2,Mister Bill Ghazi Abad Mosque,Khost,4,Gurbuz,2,Ghazi Abad Village,14,Village,3,7,0,TRUE
+1403175,70.009535018,33.286705917,1,Lewa Zhawy Khola Mosque,Khost,2,Gurbuz,1,Lewa Zhawar Khola Village,14,Village,3,2,0,TRUE
+1404133,69.85189271,33.22142933,3,Faqeeran Haji Badshah Waldod Hojra,Khost,5,Tanay,2,Lezha,14,Village,4,5,0,TRUE
+1404134,69.70985263,33.23557535,2,Sawat Khan Hojra,Khost,3,Tanay,1,Hisarak,14,Village,4,3,0,TRUE
+1404135,69.86367371,33.24301392,2,Dr. Badshah Khan House,Khost,4,Tanay,2,Khabi Khail,14,District,4,4,0,TRUE
+1404136,69.86785733,33.28250968,2,Salam Khan House,Khost,4,Tanay,2,Peeran Village,14,Village,4,4,0,TRUE
+1404137,69.77424357,33.1765014,4,Awal Jan School,Khost,5,Tanay,1,Sanaki Village,14,Village,4,5,0,TRUE
+1404138,69.6222356,33.15368467,2,Malik Khona Gul Mosque,Khost,4,Tanay,2,Kochan,14,Village,4,4,0,TRUE
+1404139,69.66031164,33.14553387,3,Warzhali Madrassa,Khost,4,Tanay,1,Warzhala Tandai,14,Building,4,4,0,TRUE
+1404140,69.64715706,33.17578098,2,Banda Khel Mosque,Khost,3,Tanay,1,Banda Khel,14,Village,4,3,0,TRUE
+1404141,69.70281772,33.15300976,3,Narzaye Mosque,Khost,4,Tanay,1,Narezi,14,Building,4,4,0,TRUE
+1404142,69.77792093,33.17484773,4,Esa Khel Mosque,Khost,5,Tanay,1,Sinaki,14,Village,4,5,0,TRUE
+1404143,69.82024677,33.28027619,3,Daragi Madrassa,Khost,4,Tanay,1,Dara Gai,14,Village,4,6,0,TRUE
+1404144,69.70651737,33.19915476,3,Toor Khel Village Mosque,Khost,4,Tanay,1,Tora Khel,14,Building,4,4,0,TRUE
+1404145,69.704603661,33.306690323,3,Dakhi Village Mosque,Khost,4,Tanay,1,Dakhi Village,14,Building,4,4,0,TRUE
+1404146,69.87866286,33.26934807,3,Sahra Village Madrassa,Khost,4,Tanay,1,Sahra Village,14,Village,4,4,0,TRUE
+1404180,69.820944264,33.264825991,2,Haji Pir Padsh Village Mosque,Khost,3,Tanay,1,Pir Padsha Village,14,Building,4,3,0,TRUE
+1404181,69.786591024,33.254104547,2,Haji Nik Muhammad Village School,Khost,3,Tanay,1,Nik Muhammad Village,14,Building,4,3,0,TRUE
+1404182,69.867197476,33.288715133,2,Shahr Kli Mosque,Khost,3,Tanay,1,Shaher Village,14,District,4,3,0,TRUE
+1405067,69.82638514,33.46274217,3,Haji Mir Afghan Hojra,Khost,4,Musa Khel,1,Murgha,14,Village,5,4,0,TRUE
+1405068,69.69626934,33.55043238,1,Haji Qaseem Hojra,Khost,2,Musa Khel,1,Pori Khel,14,Village,5,2,0,TRUE
+1405069,69.73675212,33.58816744,1,Mamor Hojra,Khost,3,Musa Khel,2,Khoshmand Village,14,Village,5,3,0,TRUE
+1405070,69.60556943,33.57637786,2,Badak Hojra,Khost,3,Musa Khel,1,Wachkri Village,14,Village,5,3,0,TRUE
+1405071,69.85532151,33.44334137,1,Gharani Tapa Mosque,Khost,2,Musa Khel,1,Gharani Tapa,14,Village,5,2,0,TRUE
+1405072,69.73450282,33.54132235,2,Musa Khel District Central Mosque,Khost,3,Musa Khel,1,Dwa Manda,14,Village,5,3,0,TRUE
+1405073,69.73668238,33.51836361,2,Mandai Mosque,Khost,3,Musa Khel,1,Mandai,14,Village,5,3,0,TRUE
+1405074,69.7284373,33.5473858,3,Zoor Kot Mosque,Khost,5,Musa Khel,2,Zor Kot,14,Village,5,5,0,TRUE
+1405075,69.71007964,33.59367545,2,Open Space,Khost,3,Musa Khel,1,Owzak Village,14,Village,5,3,0,TRUE
+1405076,69.64850208,33.59772353,2,Ajab Khan Mosque,Khost,3,Musa Khel,1,Kosin Khola,14,Village,5,3,0,TRUE
+1405077,69.62773426,33.67792705,3,Hasan Gul Hojra,Khost,5,Musa Khel,2,Dabaki Village,14,Village,5,5,0,TRUE
+1405078,69.72191715,33.55206853,4,Sardar Khan Turky Mosque,Khost,5,Musa Khel,1,Turky Village,14,Village,5,5,0,TRUE
+1406113,69.73881664,33.36892541,2,Maslat Qala Mosque,Khost,3,Nadirshah Kot,1,Maslat Qala,14,Village,6,3,0,TRUE
+1406114,69.73571985,33.363516,1,Dr. Abdul Badsha House,Khost,2,Nadirshah Kot,1,Latkai,14,Village,6,2,0,TRUE
+1406115,69.67079954,33.29950642,1,Makosh Mosque,Khost,2,Nadirshah Kot,1,Lera,14,Village,6,2,0,TRUE
+1406116,69.62402601,33.29262135,1,Kekha Village Mosque,Khost,2,Nadirshah Kot,1,Kekha Village,14,Building,6,2,0,TRUE
+1406117,69.73892281,33.37255172,1,Shambowat Clinic,Khost,2,Nadirshah Kot,1,Shambowat,14,Building,6,2,0,TRUE
+1406118,69.66277777,33.3025,1,Juma Noor Hojra,Khost,2,Nadirshah Kot,1,Pakai Village,14,Building,6,2,0,TRUE
+1406119,69.6515316,33.29951489,1,Sarkary Hojra,Khost,2,Nadirshah Kot,1,Ghorashti,14,Village,6,2,0,TRUE
+1406120,69.76676493,33.36930471,1,Shaz Ghar Village Mosque,Khost,2,Nadirshah Kot,1,Aim Toy,14,Building,6,2,0,TRUE
+1406121,69.69762685,33.39350439,1,Kani Mosque,Khost,2,Nadirshah Kot,1,Kani,14,Village,6,2,0,TRUE
+1406122,69.65408038,33.30390551,1,Almara School,Khost,2,Nadirshah Kot,1,Almara,14,Building,6,4,0,TRUE
+1406123,69.698842475,33.307808631,2,Jahanmer Mosque,Khost,3,Nadirshah Kot,1,Nawi Kot,14,Building,6,3,0,TRUE
+1406124,69.64127995,33.40762691,2,Haraspan Village School,Khost,3,Nadirshah Kot,1,Haraspan Village,14,Building,6,3,0,TRUE
+1406125,69.74133537,33.37153555,2,Shambowat Village School,Khost,3,Nadirshah Kot,1,Shambwat,14,Village,6,3,0,TRUE
+1406126,69.77340203,33.3836076,1,Owm Village Madrassa,Khost,2,Nadirshah Kot,1,Owm Village,14,Building,6,2,0,TRUE
+1407064,69.9157439,33.49614565,6,Mochi Village School,Khost,9,Sabari,3,Mochi Village,14,Village,7,9,0,TRUE
+1407065,69.87863295,33.56708909,5,Zambar Mosque,Khost,8,Sabari,3,Zambar,14,Village,7,8,0,TRUE
+1407066,69.95513079,33.50978454,4,Kariz Village Mosque,Khost,7,Sabari,3,Kariz Village,14,Village,7,7,0,TRUE
+1407166,70.0511325,33.48108103,2,Korro Village Mosque,Khost,3,Sabari,1,Korro Village,14,Village,7,3,0,TRUE
+1407167,69.88666657,33.57066309,5,District Center,Khost,5,Sabari,0,Halbasat,14,Village,7,5,0,TRUE
+1408048,70.20770938,33.32274335,3,Nizamuddin Hojra,Khost,4,Ali Sher,1,Sedeeq,14,Village,8,4,0,TRUE
+1408049,70.0622985,33.43427141,3,Mandena Mosque,Khost,4,Ali Sher,1,Mandenah,14,District,8,4,0,TRUE
+1408050,70.08891638,33.463686858,5,Chingai Mosque,Khost,6,Ali Sher,1,Chingai,14,Village,8,6,0,TRUE
+1408051,70.18670241,33.34772634,3,Qadam Mosque,Khost,5,Ali Sher,2,Qadam,14,Village,8,6,0,TRUE
+1408052,70.07922709,33.46484632,3,Kabul Village Big Mosque,Khost,5,Ali Sher,2,Kabul Village,14,Building,8,5,0,TRUE
+1408053,70.21185613,33.34438324,2,Tori Awbo Mosque,Khost,4,Ali Sher,2,Tori Awba,14,District,8,5,0,TRUE
+1408054,70.14611137,33.42017402,4,Balawat Markarzi Bagh,Khost,6,Ali Sher,2,Balawat Mot Khel Village,14,District,8,6,0,TRUE
+1408055,70.21944023,33.45988143,1,Babrak Tana Village Tent,Khost,2,Ali Sher,1,Babrak Tana Village,14,Village,8,2,0,TRUE
+1408056,70.20099714,33.44256825,1,Miram Gul Mosque,Khost,2,Ali Sher,1,Zaman Khel,14,District,8,2,0,TRUE
+1408163,70.20069647,33.45497389,5,Adam Khan Central Mosque,Khost,8,Ali Sher,3,Babrak Tana Village,14,Village,8,6,2,TRUE
+1408164,70.20953815,33.45613196,2,Bati Tana,Khost,4,Ali Sher,2,Babrak Tana Village,14,Village,8,4,0,TRUE
+1408165,70.10891584,33.44252044,4,Chargoti Mosque,Khost,7,Ali Sher,3,Chargoti,14,District,8,7,0,TRUE
+1408183,70.0614456,33.427554982,2,Mosque,Khost,3,Ali Sher,1,Mata Khil,14,Building,8,3,0,TRUE
+1408184,70.074683277,33.420218205,2,Shakari Mosque,Khost,3,Ali Sher,1,Shakari Village,14,Building,8,3,0,TRUE
+1409057,70.00638712,33.53891714,5,Manzai Mosque,Khost,8,Baak,3,Shamal Khel Village,14,Village,9,8,0,TRUE
+1409058,70.018357466,33.542785398,2,Spearkai Mosque,Khost,3,Baak,1,Shaga Village,14,Building,9,3,0,TRUE
+1409059,70.05942706,33.5027438,2,School,Khost,3,Baak,1,Kotaki Awazi Village,14,Village,9,3,0,TRUE
+1409060,70.0221005,33.58525487,2,Totak Village School,Khost,3,Baak,1,Totak,14,Village,9,3,0,TRUE
+1409061,70.02509032,33.53738078,2,Noor Afzal Hojra,Khost,3,Baak,1,Mana Kahol,14,Village,9,3,0,TRUE
+1409062,70.02189116,33.53778018,2,Rahim Jamal Hojra,Khost,3,Baak,1,Mana Kahol,14,Village,9,3,0,TRUE
+1409063,70.02359909,33.52281104,3,District Compound,Khost,6,Baak,3,Yaqobayo District Center,14,Building,9,6,0,TRUE
+1410105,69.6320205,33.53676834,3,Haji Gulstan House,Khost,4,Qalandar,1,Mal Village,14,Building,10,4,0,TRUE
+1410106,69.6739628,33.51273341,1,Haji Dawood Hojra,Khost,2,Qalandar,1,Landari Village,14,Village,10,2,0,TRUE
+1410107,69.59348396,33.52636926,2,Haji Qader House,Khost,3,Qalandar,1,Begali,14,Village,10,3,0,TRUE
+1410108,69.69019773,33.50445732,2,Mela Village Mosque,Khost,3,Qalandar,1,Khost Mela Village,14,Building,10,3,0,TRUE
+1410109,69.69679808,33.46875329,3,Ghafar House,Khost,4,Qalandar,1,Landi Village,14,Building,10,4,0,TRUE
+1410110,69.67639206,33.51425629,2,Tor Shara Village Tent,Khost,4,Qalandar,2,Torshara,14,Building,10,4,0,TRUE
+1410111,69.67257835,33.46577417,2,Ster Kot Mana Mosque,Khost,3,Qalandar,1,Ster Kot Mana,14,Building,10,3,0,TRUE
+1410112,69.64176867,33.4916781,1,Shenkai Village Mosque,Khost,2,Qalandar,1,Shenkai,14,Village,10,2,0,TRUE
+1411127,69.5138609,33.20123787,7,Spera Village School,Khost,7,Spera,0,Spera Village,14,Village,11,7,0,TRUE
+1411128,69.51640408,33.20271752,0,Spera Village Mosque,Khost,6,Spera,6,Spera Village,14,Village,11,6,0,TRUE
+1411129,69.47150287,33.19535937,2,Open Space,Khost,4,Spera,2,Ghorma,14,Village,11,4,0,TRUE
+1411130,69.48963482,33.13520708,2,Tormanda Village Tent,Khost,3,Spera,1,Tormanda Village,14,Village,11,3,0,TRUE
+1411131,69.53453461,33.17924277,2,Shinshobi Kaski,Khost,3,Spera,1,Jahangeer Village,14,Village,11,3,0,TRUE
+1411132,69.43276804,33.11507588,2,Kali Da Lamani Khaima,Khost,3,Spera,1,Mandata Village,14,Village,11,3,0,TRUE
+1411168,69.53889996,33.22248703,0,Dandaki Village Mosque,Khost,2,Spera,2,Dandoki Big Village,14,Village,11,2,0,TRUE
+1411169,69.50109287,33.17476972,2,Zarbi Shops,Khost,2,Spera,0,Zarbi Village,14,District,11,2,0,TRUE
+1411170,69.52137073,33.24177776,1,Ghulam Jan Shop,Khost,2,Spera,1,Tarwai Village,14,Village,11,2,0,TRUE
+1411171,69.50468792,33.13864082,1,Parwand Asar Khel Village Mosque,Khost,2,Spera,1,Asar Khel,14,Village,11,2,0,TRUE
+1411172,69.49354734,33.1703809,1,Bar Khel Mandaye,Khost,2,Spera,1,Bar Khel,14,District,11,2,0,TRUE
+1411173,69.42129627,33.18030492,1,Khost Khel Village Shops,Khost,2,Spera,1,Khost Khel Village,14,Village,11,2,0,TRUE
+1412155,69.59740798,33.27778468,4,Dwa Manda Village School,Khost,6,Shamul,2,Dowa Manda,14,Building,12,6,0,TRUE
+1412156,69.50374728,33.35003744,3,Sayed Khel Clinic,Khost,5,Shamul,2,Sayed Khail Village,14,Building,12,5,0,TRUE
+1412157,69.50579498,33.29706356,1,Kamal Khel Taza Village Mosque,Khost,2,Shamul,1,Kamal Khail Taza Village,14,Village,12,2,0,TRUE
+1412158,69.54369225,33.3133852,1,Amir Gulistan Mosque,Khost,2,Shamul,1,Alauddin Village,14,Building,12,2,0,TRUE
+1412159,69.5571435,33.30231401,2,Open Space,Khost,4,Shamul,2,Borgie Village,14,Building,12,4,0,TRUE
+1412160,69.58406694,33.2828551,1,Khaloti Village Mosque,Khost,2,Shamul,1,Khalotai,14,Building,12,2,0,TRUE
+1413097,70.08061833,33.62512273,3,Aka Kahol School,Khost,5,Jaji Maidan,2,Aka Kahol,14,Building,13,5,0,TRUE
+1413098,70.11300382,33.6718927,3,City One School,Khost,5,Jaji Maidan,2,City One,14,Village,13,5,0,TRUE
+1413099,70.13522388,33.62866133,3,Zana Khel Madrassa,Khost,5,Jaji Maidan,2,Zana Khel Village,14,Building,13,5,0,TRUE
+1413100,70.007681,33.677208,4,Askandary School,Khost,5,Jaji Maidan,1,Askandary,14,Building,13,5,0,TRUE
+1413101,70.00662017,33.64565925,3,Algada High School,Khost,5,Jaji Maidan,2,Algada,14,Building,13,5,0,TRUE
+1413102,70.08891002,33.60022662,2,Dani School,Khost,4,Jaji Maidan,2,Dani Khel,14,Village,13,4,0,TRUE
+1413103,70.12090203,33.62315905,2,Moghul Khel Mosque,Khost,3,Jaji Maidan,1,Moghul Khel,14,Building,13,3,0,TRUE
+1413104,70.04700613,33.64897085,2,Open Space,Khost,5,Jaji Maidan,3,Kuchi Khel,14,Village,13,5,0,TRUE
+1413185,70.0865715,33.584588859,2,Sari Pili School,Khost,3,Jaji Maidan,1,Sara Pila,14,Building,13,3,0,TRUE
+1413186,69.987352211,33.652700139,2,Shaikhano Mosque,Khost,3,Jaji Maidan,1,Shaikhan,14,Building,13,3,0,TRUE
+1501001,71.15052777,34.87200277,7,Omera Khan High School,Kunar,7,Asad Abad,0,Dam Village,15,Village,1,8,0,TRUE
+1501002,71.1491301,34.87301816,4,Imam-E-Abu Hanifa Mosque,Kunar,6,Asad Abad,2,Dam Village,15,Building,1,6,0,TRUE
+1501003,71.14865144,34.87587592,5,Women Affairs Department,Kunar,9,Asad Abad,4,Asad Abad,15,Building,1,9,0,TRUE
+1501004,71.15548205,34.87523396,6,Kirhala Secondary School,Kunar,9,Asad Abad,3,Kirhala,15,Building,1,11,0,TRUE
+1501005,71.11893928,34.81893994,5,Naw Abad Madrassa,Kunar,7,Asad Abad,2,Naw Abad,15,Village,1,7,0,TRUE
+1501006,71.1191423,34.83291533,4,Tesha Primary School,Kunar,7,Asad Abad,3,Tesha,15,Building,1,7,0,TRUE
+1501007,71.15337491,34.87028536,3,Kirhala Girls High School,Kunar,4,Asad Abad,1,Kirhala,15,Village,1,5,0,TRUE
+1501008,71.14257998,34.86092576,3,Shaheed Minaa Primary School,Kunar,4,Asad Abad,1,Yar Gul,15,Village,1,5,0,TRUE
+1501009,71.15119724,34.87309752,4,Communications Department,Kunar,6,Asad Abad,2,Dam Village,15,Village,1,7,0,TRUE
+1501010,71.18520898,34.90182354,4,Primary School,Kunar,6,Asad Abad,2,Sagai,15,Building,1,6,0,TRUE
+1502043,71.17674083,34.88583071,4,Khan Ghondy Primary School,Kunar,5,Mara Wara,1,Khan Ghondy,15,Building,2,5,0,TRUE
+1502046,71.18561949,34.89955606,3,Adam Khel Clinic,Kunar,4,Mara Wara,1,Adam Khel,15,Building,2,4,0,TRUE
+1502048,71.21525347,34.92118878,3,Village Mosque,Kunar,4,Mara Wara,1,Baacha,15,Village,2,4,0,TRUE
+1502049,71.22767899,34.9261723,3,Daag Primary School,Kunar,4,Mara Wara,1,Daag,15,Village,2,4,0,TRUE
+1503011,71.09515726,34.92128364,3,Watapoor Village Religious Madrassa,Kunar,5,Watapoor,2,Watapoor,15,Village,3,5,0,TRUE
+1503012,71.0863397,34.9343291,3,Shenigam Primary School,Kunar,4,Watapoor,1,Shenigam,15,Building,3,4,0,TRUE
+1503013,71.11071811,34.92230458,3,Qamchi High School,Kunar,4,Watapoor,1,Qamchi,15,Building,3,4,0,TRUE
+1503016,71.09246,34.92530164,2,Shamirkot Village Mosque,Kunar,4,Watapoor,2,Shamirkot,15,Village,3,4,0,TRUE
+1504031,71.02242309,34.75012066,3,Narang High School,Kunar,5,Narang,2,Narang,15,Building,4,5,0,TRUE
+1504032,71.05200263,34.76072893,2,Lamtak Primary School,Kunar,3,Narang,1,Lamtak,15,Building,4,3,0,TRUE
+1504033,70.99966294,34.73864555,2,Primary School,Kunar,3,Narang,1,Kotakai,15,Building,4,3,0,TRUE
+1504034,71.06760834,34.76076873,2,Girls School,Kunar,3,Narang,1,Bar Narang,15,Building,4,3,0,TRUE
+1504035,71.00861111,34.73944444,2,Kotki Village Mosque,Kunar,3,Narang,1,Kotakai,15,Building,4,4,0,TRUE
+1504036,71.00274093,34.76138386,2,Qalawona Village Mosque,Kunar,3,Narang,1,Qalawona,15,Village,4,4,0,TRUE
+1504037,71.06761697,34.77140715,3,Bar Narang High School,Kunar,4,Narang,1,Bar Narang,15,Building,4,4,0,TRUE
+1505038,71.10719183,34.78696827,5,Sarkany Central High School,Kunar,8,Sar Kani,3,Sarkany,15,Building,5,8,0,TRUE
+1505039,71.10785927,34.78804804,3,Girls School,Kunar,4,Sar Kani,1,Sarkany,15,Building,5,4,0,TRUE
+1505040,71.0921994,34.7589579,3,Donaye Village Madrassa,Kunar,4,Sar Kani,1,Donaye,15,Building,5,4,0,TRUE
+1505041,71.01444444,34.72611111,2,Pashad Primary School,Kunar,4,Sar Kani,2,Pashad,15,Building,5,4,0,TRUE
+1506063,71.22808631,34.94980635,4,Primary School,Kunar,6,Shigal Wa Shiltan,2,Shenkorak,15,Building,6,6,0,TRUE
+1506064,71.27483787,34.96645553,3,District Compound,Kunar,5,Shigal Wa Shiltan,2,Shegal Washilton,15,Building,6,5,0,TRUE
+1506065,71.25799806,34.9775346,3,Mony Primary School,Kunar,6,Shigal Wa Shiltan,3,Mony,15,Building,6,7,0,TRUE
+1506066,71.25644811,34.9587431,3,Shegal Washilton High School,Kunar,5,Shigal Wa Shiltan,2,Shangar Shah,15,Building,6,5,0,TRUE
+1506067,71.26377821,34.98910294,3,Shilton Primary School,Kunar,5,Shigal Wa Shiltan,2,Shilton,15,Village,6,5,0,TRUE
+1506120,71.239144852,35.03881658,2,Clinic,Kunar,3,Shigal Wa Shiltan,1,Dirai,15,Building,6,3,0,TRUE
+1507018,70.97760033,34.94401693,3,Barkandy High School,Kunar,4,Dara-E-Pech,1,Barkandi,15,Village,7,4,0,TRUE
+1507019,70.95419358,34.9396781,2,Kandagal Village Mosque,Kunar,3,Dara-E-Pech,1,Kandagal,15,Village,7,3,0,TRUE
+1507020,70.90720584,34.98145526,2,Nanglam Village Madrassa,Kunar,3,Dara-E-Pech,1,Nanglam,15,Village,7,3,0,TRUE
+1507021,70.9192291,35.01351589,2,Shahilam Primary School,Kunar,3,Dara-E-Pech,1,Shahilam,15,Village,7,3,0,TRUE
+1507022,70.95970067,34.94094469,2,Kolak Village Mosque,Kunar,3,Dara-E-Pech,1,Kolak,15,Village,7,3,0,TRUE
+1507023,70.894975206,34.984196628,2,Manogi High School,Kunar,3,Dara-E-Pech,1,Manogai,15,Village,7,3,0,TRUE
+1507024,70.84717178,34.96219518,1,Lacha Lam High School,Kunar,3,Dara-E-Pech,2,Lacha Lam,15,Village,7,3,0,TRUE
+1507025,70.99795758,34.87347765,2,Waradesh Village Mosque,Kunar,3,Dara-E-Pech,1,Waradesh,15,Village,7,3,0,TRUE
+1507026,70.9535577,34.93952933,2,Kandagal Village Madrassa,Kunar,3,Dara-E-Pech,1,Kandagal,15,Village,7,3,0,TRUE
+1507027,70.9208863,34.96724033,1,Sondoray Village Mosque,Kunar,3,Dara-E-Pech,2,Sondoray,15,Village,7,3,0,TRUE
+1507028,70.9960703,34.93909805,1,Khara Village Mosque,Kunar,3,Dara-E-Pech,2,Khara,15,Village,7,3,0,TRUE
+1507029,71.022783926,34.942776004,2,Tarra Village Madrassa,Kunar,3,Dara-E-Pech,1,Tarra,15,Village,7,3,0,TRUE
+1507030,70.87692997,34.97048411,1,Kandro Village Madrassa,Kunar,4,Dara-E-Pech,3,Kandro,15,Village,7,4,0,TRUE
+1508056,71.35132351,35.02658351,3,Jaji High School,Kunar,4,Bar Kunar,1,Jaji Village,15,Building,8,4,0,TRUE
+1508057,71.36836017,35.06724394,2,Shangar Boys High School,Kunar,3,Bar Kunar,1,Shangar,15,Building,8,3,0,TRUE
+1508058,71.35751426,35.03303466,2,Zor Asmar Girls School,Kunar,3,Bar Kunar,1,Zor Asmar,15,Building,8,3,0,TRUE
+1508059,71.344254798,35.025148367,2,Sher Kasi Village Mosque,Kunar,3,Bar Kunar,1,Sher Kasi Village,15,Village,8,3,0,TRUE
+1508060,71.32527777,35.00833333,2,Dambaro Village Mosque,Kunar,3,Bar Kunar,1,Dambaro Village,15,Building,8,3,0,TRUE
+1508061,71.34881044,35.03307028,2,District Mosque,Kunar,3,Bar Kunar,1,Asmar Bazar,15,Building,8,3,0,TRUE
+1508062,71.30726439,34.98956403,2,Palosonaw School,Kunar,4,Bar Kunar,2,Palasonaw,15,Building,8,4,0,TRUE
+1509089,70.95579976,34.71574115,3,Babaro Primary School,Kunar,4,Sawkai,1,Babaro,15,Village,9,4,0,TRUE
+1509090,70.9275,34.69972222,2,Jamiat High School,Kunar,3,Sawkai,1,Shaloti,15,Building,9,3,0,TRUE
+1509091,70.91888888,34.68527777,3,Kalmani Village Mosque,Kunar,5,Sawkai,2,Kalmani,15,Village,9,5,0,TRUE
+1509092,70.90388888,34.68527777,3,Faizullah School,Kunar,5,Sawkai,2,Kandaharo Village,15,Building,9,7,0,TRUE
+1509093,70.90350575,34.70483329,3,Tarnab Village School,Kunar,4,Sawkai,1,Tarnab,15,Village,9,4,0,TRUE
+1509094,70.91272429,34.69274037,3,Wali Qala Mosque,Kunar,5,Sawkai,2,Wali Qala,15,Building,9,7,0,TRUE
+1509095,70.88194444,34.67138888,2,Gato Qala High School,Kunar,3,Sawkai,1,Gato Qala,15,Building,9,5,0,TRUE
+1510096,70.89763711,34.64637609,3,Khas Kunar Bararazi High School,Kunar,6,Khas Kunar,3,Bar Arazi,15,Building,10,6,0,TRUE
+1510097,70.84944458,34.61758712,3,Chindraway Village Mosque,Kunar,4,Khas Kunar,1,Chindraway,15,Building,10,4,0,TRUE
+1510098,70.92842028,34.67061059,2,Hakim Abad High School,Kunar,3,Khas Kunar,1,Hakim Abad Daag,15,Building,10,3,0,TRUE
+1510099,70.92227686,34.66834463,2,Hakim Abad Village Mosque,Kunar,3,Khas Kunar,1,Hakim Abad,15,Building,10,3,0,TRUE
+1510100,70.83666666,34.60944444,2,Mangwal High School,Kunar,3,Khas Kunar,1,Mangwal,15,Building,10,3,0,TRUE
+1510101,70.82797608,34.60392423,1,Mangwal Village Mosque,Kunar,2,Khas Kunar,1,Mangwal,15,Building,10,2,0,TRUE
+1510102,70.86722056,34.63702499,2,Khas Kunar Primary School,Kunar,4,Khas Kunar,2,Khas Kunar,15,Village,10,4,0,TRUE
+1510103,70.88811224,34.65225362,4,Koza Arazi Village Mosque,Kunar,6,Khas Kunar,2,Koza Arazi,15,Village,10,10,0,TRUE
+1510121,70.953486041,34.689223833,2,Mosque,Kunar,3,Khas Kunar,1,Shamkar,15,Building,10,3,0,TRUE
+1510122,70.815566263,34.61375031,2,Mosque,Kunar,3,Khas Kunar,1,Chambari,15,Building,10,3,0,TRUE
+1511117,71.39304853,35.14684157,3,Sokai Girls School,Kunar,5,Ghazi Abad,2,Nishagam,15,Village,11,5,0,TRUE
+1511118,71.37974599,35.12722494,3,Ami Clinic,Kunar,5,Ghazi Abad,2,Bargam,15,Village,11,5,0,TRUE
+1511119,71.40382339,35.1542066,3,Kachagul Village Mosque,Kunar,5,Ghazi Abad,2,Kachagul,15,Village,11,5,0,TRUE
+1512050,71.41925594,34.99197122,4,Lar Dangam Village Mosque,Kunar,6,Dangam,2,Lar Dangam Village,15,Village,12,6,0,TRUE
+1512052,71.44649329,34.97420779,2,Dairy Primary School,Kunar,4,Dangam,2,Dairy,15,Village,12,4,0,TRUE
+1512054,71.39875741,35.01560098,2,Byadad Primary School,Kunar,4,Dangam,2,Byadad,15,Village,12,4,0,TRUE
+1513070,70.78606607,34.94595136,4,Senzi Primary School,Kunar,5,Chapa Dara,1,Senzi,15,Village,13,5,0,TRUE
+1513071,70.77883229,34.95108904,4,Kandai High School,Kunar,5,Chapa Dara,1,Kandai,15,Village,13,5,0,TRUE
+1513073,70.73391777,34.98575422,2,Gul Salak Village Mosque,Kunar,4,Chapa Dara,2,Gul Salak,15,Village,13,4,0,TRUE
+1513082,70.7366576,34.99739611,3,Morchal Village Primary School,Kunar,4,Chapa Dara,1,Morchal Village,15,Village,13,4,0,TRUE
+1514083,70.76200808,34.61408006,1,Bar Noor Gul Boys High School,Kunar,4,Noor Gal,3,Bar Noor Gul,15,Building,14,4,0,TRUE
+1514084,70.76182524,34.604321,3,Sarkari Qala Mosque,Kunar,5,Noor Gal,2,Sarkari Qala,15,Village,14,5,0,TRUE
+1514085,70.79182971,34.62912308,3,Patan Secondary School,Kunar,5,Noor Gal,2,Patan,15,Building,14,5,0,TRUE
+1514086,70.73873694,34.6389665,3,Sirawar Village School,Kunar,4,Noor Gal,1,Sirawar,15,Building,14,4,0,TRUE
+1514087,70.77078583,34.61822619,3,Mia Qala Dar-Ul-Ulom,Kunar,4,Noor Gal,1,Mia Qala,15,Village,14,5,0,TRUE
+1514088,70.74947696,34.63208334,2,Senzo Village Mosque,Kunar,4,Noor Gal,2,Senzo,15,Building,14,4,0,TRUE
+1515104,71.52285596,35.21056229,3,Primary School,Kunar,5,Nari,2,Zarokas,15,Village,15,5,0,TRUE
+1515105,71.54000337,35.29752309,3,Barikot High School,Kunar,5,Nari,2,Barikot,15,Village,15,5,0,TRUE
+1515106,71.52605763,35.22258125,3,Naray High School,Kunar,4,Nari,1,Naray,15,Village,15,4,0,TRUE
+1515107,71.52608734,35.22437725,3,Naray Clinic,Kunar,4,Nari,1,Naray,15,Village,15,4,0,TRUE
+1515108,71.53062068,35.27069007,3,Police Station,Kunar,4,Nari,1,Khanano Kas,15,Village,15,4,0,TRUE
+1515110,71.55660874,35.22069932,3,Machmana Primary School,Kunar,4,Nari,1,Machmana,15,Village,15,4,0,TRUE
+1601001,70.931810988,35.448330314,3,Shatawi Girls Old School,Nooristan,4,Paroon,1,Shatawi,16,Building,1,4,0,TRUE
+1601003,70.77347196,35.30144654,2,Kantwa Sufla Village Mosque,Nooristan,3,Paroon,1,Kantwa Sufla Village,16,Village,1,3,0,TRUE
+1601005,70.93161536,35.36596937,2,Kashtaki Boys Primary School,Nooristan,4,Paroon,2,Kashtaki,16,Village,1,4,0,TRUE
+1601006,70.92382834,35.42038781,2,Pronz Boys Secondary School,Nooristan,3,Paroon,1,Pronz,16,Building,1,4,0,TRUE
+1601007,70.89700273,35.33002561,2,Pashki Dar-Ul-Ulom,Nooristan,3,Paroon,1,Pashki,16,Building,1,5,0,TRUE
+1601009,70.84379328,35.2084262,2,Kosht Primary School,Nooristan,3,Paroon,1,Kosht,16,Village,1,3,0,TRUE
+1601010,70.82173996,35.25820669,2,Moom Village Mosque,Nooristan,3,Paroon,1,Moom Village,16,Village,1,3,0,TRUE
+1602031,70.90794708,35.05391945,5,Want Secondary School,Nooristan,7,Waygal,2,Want,16,Building,2,7,0,TRUE
+1602032,70.84875664,35.09248401,3,Nashi Gram School,Nooristan,5,Waygal,2,Nashi Gram,16,Building,2,5,0,TRUE
+1602076,71.135524014,35.278636672,2,Shingal Masque,Nuristan,3,Waygal,1,Shingul,16,Village,2,3,0,TRUE
+1602077,70.966364959,35.246119477,1,Zelikan Masque,Nuristan,2,Waygal,1,Zelikan,16,District,2,2,0,TRUE
+1602078,71.093226514,35.203161615,1,Sarigul Masque,Nuristan,2,Waygal,1,Sarigul,16,District,2,0,2,FALSE
+1603040,70.73333333,35.0875,3,Archano Village Mosque,Nooristan,5,Wama,2,Archno Village,16,Building,3,5,0,TRUE
+1603041,70.65674586,35.00396873,4,Kordar Village School,Nooristan,7,Wama,3,Kordar Village,16,Village,3,7,0,TRUE
+1603042,70.744449,35.11919,2,Wama Qadeem School,Nooristan,3,Wama,1,Wama Wadeem,16,Village,3,3,0,TRUE
+1603043,70.78061401,35.13841644,2,Kam Gul Mosque,Nooristan,4,Wama,2,Kam Gul,16,Village,3,4,0,TRUE
+1603044,70.74357813,35.11313656,2,Ponz Primary School,Nooristan,4,Wama,2,Ponz,16,Village,3,4,0,TRUE
+1603045,70.75071179,35.11965781,3,Sar-E-Pul Mosque,Nooristan,6,Wama,3,Sar-E-Pul Paso Cham,16,Village,3,6,0,TRUE
+1603075,70.838760387,35.193642947,2,Boni Mosque,Nooristan,3,Wama,1,Boni,16,Village,3,3,0,TRUE
+1604011,70.38142343,34.9424855,3,Nangraj High School,Nooristan,4,Noor Gram,1,Nangraj,16,Building,4,3,1,TRUE
+1604012,70.35247597,34.95404699,2,Wadaho Secondary School,Nooristan,3,Noor Gram,1,Wadaho,16,Building,4,3,0,TRUE
+1604013,70.45767337,34.95692357,3,Maleel Wa Mashqa Secondary School,Nooristan,5,Noor Gram,2,Maleel,16,Village,4,5,0,TRUE
+1604016,70.4925,35.00361111,2,Teteen Secondary School,Nooristan,3,Noor Gram,1,Tarwat,16,Village,4,3,0,TRUE
+1604017,70.46583333,35.05166666,2,Malak Mashoq Mosque,Nooristan,3,Noor Gram,1,Malak Village,16,Village,4,3,0,TRUE
+1604018,70.53165978,35.09875276,2,Koltan School,Nooristan,3,Noor Gram,1,Koltan,16,Building,4,3,0,TRUE
+1605020,70.31924534,35.11096211,2,Du Aab High School,Nooristan,3,Duab,1,District Center,16,Village,5,3,0,TRUE
+1605025,70.30625855,35.07432989,1,Kor Gul Secondary School,Nooristan,2,Duab,1,Kor Gul,16,Village,5,2,0,TRUE
+1606055,71.33808505,35.40935951,3,Paparistan Village Mosque,Nooristan,5,Kamdesh,2,Paparistan Village,16,Village,6,4,1,TRUE
+1606073,71.32875133,35.40918903,2,Kamdesh Village School,Nooristan,4,Kamdesh,2,Kamdesh Village,16,Village,6,4,0,TRUE
+1606074,71.362593143,35.521144938,3,Kamez Abad School,Nooristan,6,Kamdesh,3,Kamez Abad,16,District,6,6,0,TRUE
+1608065,71.33886822,35.70563901,4,Shod Gul Village Malak House,Nooristan,6,Barg-E-Matal,2,Shod Gul Village,16,Village,8,6,0,TRUE
+1608066,71.3449583,35.68006833,5,Barg-E-Matal Gharb Village School,Nooristan,8,Barg-E-Matal,3,Barg-E-Matal Gharb Village,16,Village,8,6,2,TRUE
+1608068,71.32996199,35.87398023,3,Anati Village Mosque,Nooristan,5,Barg-E-Matal,2,Anati Village,16,Village,8,5,0,TRUE
+1608069,71.19673235,35.7531751,1,Pasigram Village Mosque,Nooristan,2,Barg-E-Matal,1,Pasigram Village,16,Village,8,2,0,TRUE
+1608070,71.24670768,35.79249954,2,Ganjolok Shal,Nooristan,3,Barg-E-Matal,1,Ganjolok Shal,16,Village,8,3,0,TRUE
+1608071,71.35454961,35.76984329,2,Afsi Village Malak House,Nooristan,3,Barg-E-Matal,1,Afsi Village,16,Village,8,3,0,TRUE
+1608072,71.36312625,35.84180786,2,Peshawarak Village School,Nooristan,4,Barg-E-Matal,2,Peshawarak Village,16,Village,8,4,0,TRUE
+1701001,70.60078224,37.26114579,3,Faizi Shaheed School,Badakhshan,4,Faiz Abad,1,Faiz Abad,17,Building,1,4,0,TRUE
+1701002,70.55237406,37.26719061,3,Do-Aba School,Badakhshan,4,Faiz Abad,1,Dobayee Yaftal Ulya,17,Building,1,4,0,TRUE
+1701003,70.54958472,37.21258559,3,Talabzang High School,Badakhshan,4,Faiz Abad,1,Talabzang,17,Building,1,4,0,TRUE
+1701004,70.5864958,37.19559125,2,Sar Qol School,Badakhshan,3,Faiz Abad,1,Sar Qol Yaftal Ulya,17,Building,1,3,0,TRUE
+1701005,70.51252386,37.22469428,2,Deh Kalan School,Badakhshan,3,Faiz Abad,1,Deh Kalan Yaftal Ulya,17,Building,1,3,0,TRUE
+1701006,70.6790449,37.19819511,2,Kol Gahi School,Badakhshan,3,Faiz Abad,1,Kol Gahi Yaftal Ulya,17,Building,1,3,0,TRUE
+1701007,70.63283979,37.15275799,2,Gezan School,Badakhshan,4,Faiz Abad,2,Gezan Yaftal Ulya,17,Building,1,4,0,TRUE
+1701008,70.5771989,37.11921975,4,Itifaq Mosque,Badakhshan,6,Faiz Abad,2,D01 - Zone One,17,Building,1,6,0,TRUE
+1701009,70.52952398,37.15679029,3,Ziauddin Shaheed School,Badakhshan,4,Faiz Abad,1,Aas Village,17,Building,1,4,0,TRUE
+1701010,70.54378042,37.1006422,4,Aljehad Girls High School,Badakhshan,5,Faiz Abad,1,Dasht Qorogh,17,Building,1,5,0,TRUE
+1701011,70.56338527,37.11221274,4,Sayef Shaheed High School,Badakhshan,6,Faiz Abad,2,Nahia Shahr Jadid,17,Building,1,6,0,TRUE
+1701012,70.55412254,37.10414599,3,Medical Faculty,Badakhshan,4,Faiz Abad,1,Nahia Shahr Jadid,17,Building,1,4,0,TRUE
+1701013,70.55426528,37.10430516,3,Imam Bukhari Mosque,Badakhshan,6,Faiz Abad,3,Hisa 3 Shahr Jadid,17,Building,1,7,0,TRUE
+1701014,70.58912589,37.09842912,3,Najibullah Shaheed School,Badakhshan,5,Faiz Abad,2,Chata Nahia 4,17,Building,1,5,0,TRUE
+1701015,70.58237254,37.11142539,3,Kokcha High School,Badakhshan,4,Faiz Abad,1,Kokcha,17,Building,1,4,0,TRUE
+1701016,70.57736604,37.12363918,3,Girls Number 2 High School,Badakhshan,5,Faiz Abad,2,Nahia 2 Shahr Kuhna,17,Building,1,5,0,TRUE
+1701017,70.6462802,37.25960869,2,Naghz Dara School,Badakhshan,3,Faiz Abad,1,Naghz Dara,17,Building,1,3,0,TRUE
+1701019,70.58084193,37.11750057,3,Makhfi High School Old Building,Badakhshan,5,Faiz Abad,2,Nahia 1 Shahr Kuhna,17,Building,1,5,0,TRUE
+1701020,70.60093056,37.07285662,1,Shorabak School,Badakhshan,2,Faiz Abad,1,Shorabak,17,Building,1,2,0,TRUE
+1701021,70.62660839,37.23569262,1,Dega School,Badakhshan,2,Faiz Abad,1,Dega,17,Building,1,2,0,TRUE
+1701022,70.69623054,37.2609404,1,Palang Dara School,Badakhshan,2,Faiz Abad,1,Palang Dara,17,Building,1,2,0,TRUE
+1701023,70.59534982,37.21816557,1,Dara-E-Kolan School,Badakhshan,2,Faiz Abad,1,Dara-E-Kolan,17,Building,1,2,0,TRUE
+1701283,70.524157149,37.173763397,2,Laiaba Femal High School,Badakhshan,3,Faiz Abad,1,Laiaba,17,Building,1,3,0,TRUE
+1701284,70.536641035,37.105604606,2,Al Jahad High School,Badakhshan,3,Faiz Abad,1,Dasht Shhada,17,Building,1,3,0,TRUE
+1701285,70.585417967,37.124716072,2,Makhfi High School,Badakhshan,3,Faiz Abad,1,Gozar Mahkama,17,Building,1,3,0,TRUE
+1702038,70.41697838,37.05219231,2,Khiradmand Shaheed Boys High School,Badakhshan,4,Argo,2,Shahr-E-Wahdat,17,Building,2,4,0,TRUE
+1702039,70.32602365,37.03290851,3,Barlaas Shamar School,Badakhshan,4,Argo,1,Naswan Shamar,17,Building,2,4,0,TRUE
+1702040,70.35761086,37.12311428,1,Boyeni Qara School,Badakhshan,3,Argo,2,Boyeni Qara Village,17,Building,2,3,0,TRUE
+1702041,70.51632842,37.10851164,3,Sayed Abdul Kareem Husaini Girls High School,Badakhshan,5,Argo,2,Karee,17,Building,2,5,0,TRUE
+1702042,70.49457018,37.181102776,2,Etarchi High School,Badakhshan,4,Argo,2,Qaraqozi Clinic,17,Building,2,4,0,TRUE
+1702043,70.46698271,37.10845875,2,Khwaja Eshtal School,Badakhshan,4,Argo,2,Khwaja Eshtal,17,Building,2,4,0,TRUE
+1702044,70.46132888,37.00189206,2,Deh Dahi Girls School,Badakhshan,4,Argo,2,Deh Dahi,17,Building,2,4,0,TRUE
+1702045,70.50454605,37.05531924,2,Yarnasha School,Badakhshan,3,Argo,1,Yarnasha,17,Building,2,3,0,TRUE
+1702046,70.52311958,36.98214356,2,Barlaas-O-Khyan School,Badakhshan,3,Argo,1,Barlaas-O-Khyan,17,Building,2,3,0,TRUE
+1702047,70.22768708,37.08551663,2,Qadam School,Badakhshan,3,Argo,1,Qadam,17,Building,2,3,0,TRUE
+1702048,70.30823774,37.08353235,2,Khosh Dara Secondary School,Badakhshan,3,Argo,1,Khosh Dara,17,Building,2,3,0,TRUE
+1702049,70.16599515,37.07526866,2,Abdul Qader Hanif Shaheed High School,Badakhshan,3,Argo,1,Ateen Jalo,17,Building,2,3,0,TRUE
+1702050,70.27013095,37.19815208,2,Qara Kamar School,Badakhshan,3,Argo,1,Qara Kamar,17,Building,2,3,0,TRUE
+1702051,70.20824913,37.15629557,2,Qachi High School,Badakhshan,3,Argo,1,Qachi,17,Building,2,3,0,TRUE
+1702052,70.58480449,37.05698305,2,Chatraaq High School,Badakhshan,3,Argo,1,Chatraaq,17,Building,2,3,0,TRUE
+1702054,70.63250517,36.98623977,2,Gazan Mosque,Badakhshan,3,Argo,1,Gazan,17,Building,2,0,3,FALSE
+1702055,70.65470123,37.05528508,2,Bagh Mubarak School,Badakhshan,3,Argo,1,Bagh Mubarak,17,Building,2,3,0,TRUE
+1702056,70.42126568,37.05186245,3,Shahr-E-Wahdat Girls High School,Badakhshan,4,Argo,1,Shahr-E-Wahdat,17,Building,2,4,0,TRUE
+1702057,70.32949994,37.0478517,2,Barlaas Chenar School,Badakhshan,3,Argo,1,Barlaas Chenar,17,Building,2,3,0,TRUE
+1702059,70.36106574,37.11210881,5,Arghand Secondary School,Badakhshan,9,Argo,4,Arghand Village,17,Building,2,9,0,TRUE
+1702060,70.3424174,37.01794208,2,Aab Bareek Secondary School,Badakhshan,3,Argo,1,Aab Bareek,17,Building,2,3,0,TRUE
+1702061,70.46057335,37.12487946,2,Toroq,Badakhshan,3,Argo,1,Toroq,17,Building,2,3,0,TRUE
+1702286,70.449294951,37.049150545,2,Gnda Chasma Secondary High School,Badakhshan,3,Argo,1,Ganda Cheshma,17,Building,2,3,0,TRUE
+1702287,70.107234913,37.008310634,2,Qala Zafar Mosque,Badakhshan,3,Argo,1,Now Abad Qala Zafar,17,Building,2,3,0,TRUE
+1702288,70.466595666,36.976742996,2,Ali Mosque,Badakhshan,3,Argo,1,Ali Mango,17,Building,2,3,0,TRUE
+1702289,70.516047563,37.147701142,2,Shahbaz Khan Shaheed High School,Badakhshan,3,Argo,1,Juta,17,Building,2,3,0,TRUE
+1702290,70.458967962,36.999119419,2,Dehdhi Femal School,Badakhshan,3,Argo,1,Dur Khan,17,Building,2,3,0,TRUE
+1703222,70.76185724,37.17629095,2,Khanqah Mosque,Badakhshan,3,Arghanj Khwah,1,Khanqah,17,Building,3,3,0,TRUE
+1703223,70.71478327,37.10771749,2,Samdarah School,Badakhshan,3,Arghanj Khwah,1,Samdarah,17,Building,3,3,0,TRUE
+1703224,70.77111786,37.16790131,4,Tagabak School,Badakhshan,5,Arghanj Khwah,1,Tagabak,17,Building,3,4,1,TRUE
+1703225,71.01880087,37.31887798,1,Pul Zarewan School,Badakhshan,2,Arghanj Khwah,1,Pul Zarewan,17,Building,3,2,0,TRUE
+1703226,70.90219588,37.36685091,1,Qala-E-Mirza Shah  School,Badakhshan,2,Arghanj Khwah,1,Qala-E-Mirza Shah,17,Building,3,2,0,TRUE
+1703227,70.98677919,37.54389186,2,Khenj Mosque,Badakhshan,3,Arghanj Khwah,1,Khenj,17,Building,3,0,3,FALSE
+1704024,70.49993798,37.24643716,3,Arweesha Mosque,Badakhshan,5,Yaftal-E-Sufla,2,Arweesha,17,Building,4,5,0,TRUE
+1704025,70.41409324,37.28183873,2,Naland Clinic - District Office,Badakhshan,4,Yaftal-E-Sufla,2,Naland,17,Building,4,4,0,TRUE
+1704026,70.27127866,37.21973997,3,Anar Dara School,Badakhshan,4,Yaftal-E-Sufla,1,Anar Dara,17,Building,4,4,0,TRUE
+1704027,70.35736534,37.23202504,2,Farghambol School,Badakhshan,3,Yaftal-E-Sufla,1,Farghambol,17,Building,4,3,0,TRUE
+1704028,70.51831601,37.28336581,2,Gazanak High School,Badakhshan,3,Yaftal-E-Sufla,1,Gazanak,17,Building,4,3,0,TRUE
+1704029,70.32379981,37.29800074,1,Kasheen Dara School,Badakhshan,3,Yaftal-E-Sufla,2,Kasheen Dara,17,Building,4,3,0,TRUE
+1704030,70.39193445,37.36163383,1,Waalak Mosque,Badakhshan,2,Yaftal-E-Sufla,1,Waalak,17,Building,4,2,0,TRUE
+1704031,70.33566635,37.33960511,1,Keshtgaah School,Badakhshan,3,Yaftal-E-Sufla,2,Dasht Shebar,17,Building,4,3,0,TRUE
+1704032,70.34956235,37.39818137,2,Shalakhzar School,Badakhshan,3,Yaftal-E-Sufla,1,Shalakhzar,17,Building,4,3,0,TRUE
+1704033,70.43672001,37.32743526,3,Shakarlab Girls High School,Badakhshan,4,Yaftal-E-Sufla,1,Shakarlab,17,Building,4,4,1,TRUE
+1704034,70.39222222,37.3275,2,Speen Girls School,Badakhshan,3,Yaftal-E-Sufla,1,Speen Village,17,Building,4,3,0,TRUE
+1704035,70.4388394,37.23021745,2,Lab Darya Kokcha School,Badakhshan,3,Yaftal-E-Sufla,1,Dahan Sabat,17,Building,4,3,0,TRUE
+1704036,70.48144556,37.2893353,2,Saran School,Badakhshan,3,Yaftal-E-Sufla,1,Saran,17,Building,4,3,0,TRUE
+1704037,70.24810752,37.27305882,2,Zemestanak School,Badakhshan,3,Yaftal-E-Sufla,1,Zemestanak,17,Building,4,3,0,TRUE
+1704291,70.311260469,37.344768612,2,Bid Kalan High School,Badakhshan,3,Yaftal-E-Sufla,1,Bid Kalan,17,Building,4,3,0,TRUE
+1704292,70.455790503,37.298549245,2,Warig High School,Badakhshan,3,Yaftal-E-Sufla,1,Warang,17,Building,4,3,0,TRUE
+1704293,70.426839277,37.364836385,2,Pahn Dara Secondary School,Badakhshan,3,Yaftal-E-Sufla,1,Pahn Dara,17,Building,4,3,0,TRUE
+1705073,70.77768147,36.88770442,2,Sar Lola High School,Badakhshan,4,Khash,2,Zulm Abad,17,Building,5,4,0,TRUE
+1705074,70.74795619,36.90621981,2,Ghulam Mohammad High School,Badakhshan,4,Khash,2,Deh Para,17,Building,5,4,0,TRUE
+1705075,70.76404588,36.92660037,2,Esmati Girls High School,Badakhshan,4,Khash,2,Deh Naw,17,Building,5,4,0,TRUE
+1705076,70.7371027,36.98252272,3,Shahaan Shahraan Girls School,Badakhshan,5,Khash,2,Shahran Khash,17,Building,5,5,0,TRUE
+1705077,70.71704087,36.99123999,2,Tajekan Girls High School,Badakhshan,4,Khash,2,Tajekan,17,Building,5,4,0,TRUE
+1705078,70.7494541,37.02623219,2,Durkhaan Secondary School,Badakhshan,4,Khash,2,Durkhaan,17,Building,5,4,0,TRUE
+1706102,70.90225996,37.00191069,3,Baharestan High School,Badakhshan,4,Baharak,1,Baharestan,17,Building,6,4,0,TRUE
+1706103,70.94128452,37.00580413,2,Malang Aab School,Badakhshan,3,Baharak,1,Malang Aab,17,Building,6,3,0,TRUE
+1706104,70.88040212,36.98296825,1,Chabchi Yardar School,Badakhshan,2,Baharak,1,Chabchi Yardar,17,Building,6,2,0,TRUE
+1706105,70.85321054,36.97268577,1,Dasht Faraakh School,Badakhshan,2,Baharak,1,Dasht Faraakh,17,Building,6,2,0,TRUE
+1706106,70.9189589,36.97155524,1,Yardar School,Badakhshan,2,Baharak,1,Yardar,17,Building,6,2,0,TRUE
+1706107,70.88256937,37.01608836,1,Khair Abad Girls High School,Badakhshan,2,Baharak,1,Khair Abad,17,Building,6,2,0,TRUE
+1706108,70.78305925,37.05415183,1,Payan Shahr School,Badakhshan,2,Baharak,1,Payan Shahr,17,Building,6,2,0,TRUE
+1706109,70.84870062,37.03368342,1,Farmoragh School,Badakhshan,2,Baharak,1,Farmoragh,17,Building,6,2,0,TRUE
+1706110,70.80382464,37.13070181,1,Aaryaan School,Badakhshan,2,Baharak,1,Aaryaan,17,Building,6,2,0,TRUE
+1706111,70.89660791,36.99905687,1,Do-Aab Mosque,Badakhshan,2,Baharak,1,Do-Aab,17,Building,6,2,0,TRUE
+1707062,70.368824762,36.910877099,3,Zamanuddin & Haji Habibullah House,Badakhshan,4,Darayim,1,Deh Bazar,17,Building,7,4,0,TRUE
+1707063,70.3481802,36.93047356,3,Madina High School,Badakhshan,4,Darayim,1,Fazlan Village,17,Building,7,4,0,TRUE
+1707064,70.30123011,36.97018977,3,Shahr-E-Saadat Girls High School,Badakhshan,5,Darayim,2,Langar,17,Building,7,5,0,TRUE
+1707065,70.27474907,36.99967657,2,Pangani High School,Badakhshan,3,Darayim,1,Pangani,17,Building,7,3,0,TRUE
+1707066,70.41840967,36.92646916,1,Neem Tala Mosque,Badakhshan,2,Darayim,1,Neem Tala,17,Building,7,2,0,TRUE
+1707067,70.45696292,36.91809972,1,Quraishi Mosque,Badakhshan,2,Darayim,1,Quraishi,17,Building,7,2,0,TRUE
+1707068,70.37225426,36.9031265,2,Naw Abaad Roy Dasht Mosque,Badakhshan,3,Darayim,1,Sahibuddin House,17,Building,7,3,0,TRUE
+1707069,70.40940653,36.85326284,2,Do-Aab Mughal Tai High School,Badakhshan,4,Darayim,2,Khum Mir Harzar,17,Building,7,4,0,TRUE
+1707070,70.45063641,36.83643674,3,Yamchiyan School,Badakhshan,4,Darayim,1,Yamchiyan,17,Building,7,4,0,TRUE
+1707071,70.47925158,36.85902402,2,Aarifan High School,Badakhshan,3,Darayim,1,Bagh Sufi,17,Building,7,3,0,TRUE
+1707072,70.52943455,36.84420123,2,Do-Aab Manji High School,Badakhshan,3,Darayim,1,Do-Aab,17,Building,7,3,0,TRUE
+1707294,70.437277503,36.864329893,2,Targani Payan Madrasa,Badakhshan,3,Darayim,1,Trangai Paian,17,Building,7,3,0,TRUE
+1707295,70.339929196,36.96926175,2,Chapa Village Mosque,Badakhshan,3,Darayim,1,Chapa,17,Building,7,3,0,TRUE
+1708120,70.61972725,37.47284747,2,Pas Pul High School,Badakhshan,3,Kohistan,1,Pas Pul,17,Building,8,3,0,TRUE
+1708121,70.66701452,37.43655469,1,Lakhsh School,Badakhshan,2,Kohistan,1,Lakhsh,17,Building,8,2,0,TRUE
+1708122,70.67620578,37.41817761,1,Muragh High School,Badakhshan,2,Kohistan,1,Maidan Payan,17,Building,8,2,0,TRUE
+1708123,70.58869312,37.48656861,1,Shpoy Bala Mosque,Badakhshan,2,Kohistan,1,Shpoy Bala,17,Building,8,2,0,TRUE
+1708124,70.5441331,37.45929136,2,Wakhti Deh School,Badakhshan,3,Kohistan,1,Wakhti Deh,17,Building,8,0,3,FALSE
+1708125,70.66708471,37.37551704,1,March Mosque,Badakhshan,2,Kohistan,1,March,17,Building,8,2,0,TRUE
+1708126,70.71385054,37.37596672,1,Hujra Gardan Mosque,Badakhshan,2,Kohistan,1,Hujra Gardan,17,Building,8,2,0,TRUE
+1708296,70.567483963,37.453043658,2,Zard Noor Mosque,Badakhshan,3,Kohistan,1,Zarnod Bala,17,Building,8,3,0,TRUE
+1709127,70.44559466,37.54061746,2,Yawan School,Badakhshan,3,Yawan,1,Yawan,17,Building,9,3,0,TRUE
+1709128,70.38960563,37.51305835,1,Saari School,Badakhshan,2,Yawan,1,Saari,17,Building,9,2,0,TRUE
+1709129,70.33547037,37.49373239,2,Manzal Dasht School,Badakhshan,3,Yawan,1,Manzal Dasht,17,Building,9,3,0,TRUE
+1709130,70.3217182,37.56325911,2,Shingan Payan School,Badakhshan,3,Yawan,1,Shingan Payan,17,Building,9,3,0,TRUE
+1709131,70.25577143,37.55332351,1,Roy Raza Mosque,Badakhshan,2,Yawan,1,Roy Raza,17,Building,9,2,0,TRUE
+1709132,70.44621744,37.48621425,1,Sang Payan,Badakhshan,2,Yawan,1,Darang Payan,17,Building,9,2,0,TRUE
+1709133,70.46428399,37.47758473,1,Qataar Bed Payan School,Badakhshan,2,Yawan,1,Bed Payan,17,Building,9,2,0,TRUE
+1709134,70.48580701,37.50666117,2,Zo School,Badakhshan,3,Yawan,1,Zo,17,Building,9,3,0,TRUE
+1709135,70.50989858,37.52152262,1,Petaaw School,Badakhshan,2,Yawan,1,Petaaw,17,Building,9,2,0,TRUE
+1709136,70.53806614,37.5377979,1,Aab Zamach Mosque,Badakhshan,2,Yawan,1,Aab Zamach,17,Building,9,2,0,TRUE
+1709297,70.219070637,37.544104683,2,Riman School,Badakhshan,3,Yawan,1,Riman,17,Building,9,3,0,TRUE
+1709298,70.301763518,37.591035181,2,Afch Mosque,Badakhshan,3,Yawan,1,Afch,17,Building,9,3,0,TRUE
+1709299,70.418248562,37.575958799,2,Madrasa,Badakhshan,3,Yawan,1,Tir Garan,17,Building,9,3,0,TRUE
+1710079,70.83182975,36.86654023,2,Ghiyasi High School,Badakhshan,4,Jurm,2,Markaz Jorm,17,Building,10,4,0,TRUE
+1710080,70.83546322,36.74623538,2,Fergha Meero High School,Badakhshan,3,Jurm,1,Fergha Meero,17,Building,10,0,3,FALSE
+1710081,70.88804096,36.9079441,2,Ferghamenj High School,Badakhshan,3,Jurm,1,Ferghamenj,17,Building,10,0,3,FALSE
+1710082,70.83266529,36.89650346,2,Naw Jaram O Chang-Ha High School,Badakhshan,3,Jurm,1,Naw Jaram,17,Building,10,3,0,TRUE
+1710084,70.8390593,36.85327794,2,Ghulam Mohammad Khar Andab High School,Badakhshan,4,Jurm,2,Khar Andab,17,Building,10,4,0,TRUE
+1710088,70.82576025,36.85522936,1,Khanqah Mosque,Badakhshan,2,Jurm,1,Khanqah,17,Building,10,2,0,TRUE
+1710089,70.82109658,36.95260464,1,Sar Hawz High School,Badakhshan,2,Jurm,1,Sar Hawz,17,Building,10,2,0,TRUE
+1710300,70.843157053,36.839787979,2,Kharandab Female School,Badakhshan,3,Jurm,1,Kharandab,17,Building,10,0,3,FALSE
+1711178,70.46431314,36.7078289,2,Ghori Sang School,Badakhshan,3,Tashkan,1,Ghori Sang,17,Building,11,3,0,TRUE
+1711179,70.36386492,36.72150366,1,Deh Aastayan School,Badakhshan,2,Tashkan,1,Deh Aastayan,17,Building,11,2,0,TRUE
+1711180,70.37397743,36.81066667,1,Deh Sayedan School,Badakhshan,2,Tashkan,1,Deh Sayedan,17,Building,11,2,0,TRUE
+1711181,70.30657257,36.84746352,1,Arghandkan School,Badakhshan,2,Tashkan,1,Arghandkan,17,Building,11,2,0,TRUE
+1711182,70.28302985,36.81236318,1,Yawli Bala School,Badakhshan,2,Tashkan,1,Yawli Bala,17,Building,11,2,0,TRUE
+1711183,70.26799292,36.89013519,1,Bazar Teshkan School,Badakhshan,2,Tashkan,1,Bazar Teshkan,17,Building,11,2,1,TRUE
+1711184,70.21631632,36.92660773,1,Sayedan School,Badakhshan,2,Tashkan,1,Sayedan,17,Building,11,2,0,TRUE
+1711185,70.13771086,36.97424992,1,Muzaffari School,Badakhshan,2,Tashkan,1,Muzaffari,17,Building,11,2,0,TRUE
+1711186,70.38130981,36.76328256,1,Dasht Laryang School,Badakhshan,2,Tashkan,1,Dasht Laryang,17,Building,11,2,0,TRUE
+1711187,70.23316592,36.82569649,1,Dasht Aagha School,Badakhshan,2,Tashkan,1,Dasht Aagha,17,Building,11,2,0,TRUE
+1711303,70.179560896,36.970783704,2,Pista Khor School,Badakhshan,3,Tashkan,1,Pista Khor,17,Building,11,3,0,TRUE
+1711304,70.258990402,36.92515974,2,Hazrat Abas School,Badakhshan,3,Tashkan,1,Totak,17,Village,11,3,0,TRUE
+1712113,71.00262055,37.03440108,3,Mahmoodan School,Badakhshan,4,Shuhada,1,Mahmoodan,17,Building,12,4,0,TRUE
+1712114,71.03055906,37.03076195,2,Abu Talha School,Badakhshan,3,Shuhada,1,Joybar Village,17,Building,12,3,0,TRUE
+1712115,71.09213531,37.05509232,1,Shams-Ul-Haq School,Badakhshan,2,Shuhada,1,Abaab,17,Building,12,2,0,TRUE
+1712116,71.10149044,37.05815086,1,Maidan District Office,Badakhshan,2,Shuhada,1,Maidan,17,Building,12,2,0,TRUE
+1712117,71.13440915,37.0719061,1,Hamedi School,Badakhshan,2,Shuhada,1,Shakran,17,Building,12,2,0,TRUE
+1712118,71.21823047,37.05122981,1,Ezro School,Badakhshan,2,Shuhada,1,Ezro,17,Building,12,2,0,TRUE
+1712119,71.26585562,37.05006366,1,Mohammad Raheem Secondary School,Badakhshan,2,Shuhada,1,Maktab,17,Building,12,2,0,TRUE
+1712305,71.175247317,37.057933355,2,Wakil Abdul Jabar School,Badakhshan,3,Shuhada,1,Dargab,17,Building,12,3,0,TRUE
+1713137,70.16815296,37.31107211,2,Khordakan High School,Badakhshan,4,Shahr-E-Buzurg,2,Khordakan,17,Building,13,4,0,TRUE
+1713138,70.17411809,37.38181749,2,Kura Been School,Badakhshan,3,Shahr-E-Buzurg,1,Kura Been,17,Building,13,3,0,TRUE
+1713139,70.22538926,37.44078284,2,Wandyan School,Badakhshan,3,Shahr-E-Buzurg,1,Wandyan,17,Building,13,3,0,TRUE
+1713140,70.18969426,37.24788738,1,Dasht Farang Secondary School,Badakhshan,2,Shahr-E-Buzurg,1,Dasht Farang,17,Building,13,2,0,TRUE
+1713141,70.08715928,37.29936183,1,Shekhan School,Badakhshan,2,Shahr-E-Buzurg,1,Shekhan,17,Building,13,2,0,TRUE
+1713142,70.09060545,37.18262345,2,Koal High School,Badakhshan,3,Shahr-E-Buzurg,1,Koal,17,Building,13,3,0,TRUE
+1713143,70.04925382,37.35579982,1,Baari Kham,Badakhshan,2,Shahr-E-Buzurg,1,Baari Kham,17,Building,13,2,0,TRUE
+1713144,70.13734916,37.41058833,2,Chawgani High School,Badakhshan,3,Shahr-E-Buzurg,1,Chawgani,17,Building,13,3,0,TRUE
+1713145,70.03096488,37.40701819,1,Sangi Khwah School,Badakhshan,2,Shahr-E-Buzurg,1,Sangi Khwah,17,Building,13,2,0,TRUE
+1713146,70.23823711,37.48952769,1,Aab Gandah Secondary School,Badakhshan,2,Shahr-E-Buzurg,1,Aab Gandah,17,Building,13,2,0,TRUE
+1713147,70.05734737,37.24339781,1,Malwan School,Badakhshan,2,Shahr-E-Buzurg,1,Malwan,17,Building,13,2,0,TRUE
+1713148,70.16887691,37.11478705,1,Barlaas High School,Badakhshan,2,Shahr-E-Buzurg,1,Barlaas,17,Building,13,2,0,TRUE
+1713149,70.0413222,37.43146737,1,Kalati Dara School,Badakhshan,2,Shahr-E-Buzurg,1,Gardang,17,Building,13,2,0,TRUE
+1713306,70.036224542,37.476131366,2,School,Badakhshan,3,Shahr-E-Buzurg,1,Aspa Khwa,17,Building,13,3,0,TRUE
+1713307,70.124401614,37.350399749,2,Bul Bul Dara Mowque,Badakhshan,3,Shahr-E-Buzurg,1,Bul Bul Dara!,17,Building,13,3,0,TRUE
+1713308,70.253924678,37.419336228,2,Ghazanfar Paien Mosque,Badakhshan,3,Shahr-E-Buzurg,1,Ghanghar Paian,17,Building,13,3,0,TRUE
+1714229,70.55376294,37.59336632,3,Zerakai Mosque,Badakhshan,4,Raghistan,1,Zerakai,17,Building,14,4,0,TRUE
+1714230,70.55857814,37.56066501,1,Naqsh Deh Secondary School,Badakhshan,4,Raghistan,3,Naqsh Deh,17,Building,14,4,0,TRUE
+1714231,70.60119994,37.62163923,2,Kaalar Secondary School,Badakhshan,4,Raghistan,2,Kaalar,17,Building,14,4,0,TRUE
+1714232,70.6780058,37.69277094,1,Khonelar School,Badakhshan,2,Raghistan,1,Khonelar,17,Building,14,2,0,TRUE
+1714233,70.64775095,37.58984788,3,Siyaab Shahr,Badakhshan,4,Raghistan,1,Siyaab Shahr,17,Building,14,4,0,TRUE
+1714234,70.59842609,37.55791209,2,Aajresh School,Badakhshan,4,Raghistan,2,Aajresh,17,Building,14,4,0,TRUE
+1714235,70.40010979,37.70048457,2,Salam Deh Mosque,Badakhshan,4,Raghistan,2,Salam Deh,17,Village,14,4,0,TRUE
+1714236,70.47030525,37.60490991,2,Ulya Khum School,Badakhshan,4,Raghistan,2,Ulya Khum,17,Building,14,4,0,TRUE
+1714237,70.48313914,37.70023313,2,Pateer School,Badakhshan,3,Raghistan,1,Pateer,17,Building,14,3,0,TRUE
+1715150,70.10085181,36.81804877,4,Mashhad Girls School,Badakhshan,6,Kishm,2,Hawz Shahr,17,Building,15,8,0,TRUE
+1715151,70.20565731,36.80759003,4,Charmagh School,Badakhshan,6,Kishm,2,Charmagh Dara,17,Building,15,6,0,TRUE
+1715152,70.16970042,36.72259271,2,Jar Shah Baba Girls School,Badakhshan,4,Kishm,2,Jar Shah Baba,17,Building,15,4,0,TRUE
+1715153,70.1353359,36.72612142,2,Dara-E-Jeem School,Badakhshan,4,Kishm,2,Dara-E-Jeem,17,Building,15,4,0,TRUE
+1715154,70.20612401,36.8641956,3,Gandum Qol School,Badakhshan,5,Kishm,2,Gandum Qol,17,Building,15,5,0,TRUE
+1715155,70.10981435,36.91954935,2,Nochi School,Badakhshan,3,Kishm,1,Nochi,17,Building,15,3,0,TRUE
+1715156,70.09242033,36.84704957,2,Mahzoon Baloch High School,Badakhshan,3,Kishm,1,Baloch,17,Building,15,4,0,TRUE
+1715157,70.08185905,36.84113937,2,Takya High School,Badakhshan,3,Kishm,1,Takya,17,Building,15,3,0,TRUE
+1715158,70.14609529,36.76795245,2,Namazgah School,Badakhshan,3,Kishm,1,Namazgah,17,Building,15,4,0,TRUE
+1715159,70.1220563,36.76791247,1,Khushka Dara School,Badakhshan,2,Kishm,1,Khushka Dara,17,Building,15,2,0,TRUE
+1715160,70.17893825,36.66171824,2,Dasht Khawrak School,Badakhshan,4,Kishm,2,Dasht Khawrak,17,Building,15,4,0,TRUE
+1715161,70.0229343,36.79340121,2,Qara Bala School,Badakhshan,4,Kishm,2,Madana,17,Building,15,4,0,TRUE
+1715162,70.17859775,36.82647285,1,Wakhshi School,Badakhshan,2,Kishm,1,Wakhshi,17,Building,15,2,0,TRUE
+1715163,70.17093583,36.83144968,1,Khumbak School,Badakhshan,2,Kishm,1,Khumbak,17,Building,15,2,0,TRUE
+1715164,70.11956703,36.72001792,1,Mohammad Hassan Mosque,Badakhshan,2,Kishm,1,Dara-E-Jeem,17,Building,15,2,0,TRUE
+1715165,70.12425343,36.8046103,1,Nawabad Gandom Qol School,Badakhshan,2,Kishm,1,Nawabad Gandum Qol,17,Building,15,3,0,TRUE
+1715166,70.05252514,36.74479169,1,Pasha Dara Mosque,Badakhshan,2,Kishm,1,Pasha Dara,17,Building,15,2,0,TRUE
+1715309,70.211612177,36.882426342,2,Wahdat Abad Madrasa,Badakhshan,3,Khash,1,Wahdat Abad,17,Building,15,3,0,TRUE
+1715310,70.141046216,36.709025324,2,Hazrat Sarwar Kainat Mosque,Badakhshan,3,Khash,1,Gangor Chi,17,District,15,3,0,TRUE
+1716094,71.06597625,36.9067746,3,Shahgaan School,Badakhshan,4,Wardooj,1,Shahgaan,17,Building,16,4,0,TRUE
+1716095,71.0534224,36.87250678,2,Shakeran School,Badakhshan,3,Wardooj,1,Shakeran,17,Building,16,3,0,TRUE
+1716096,71.07721373,36.79185223,3,Khashbeen School,Badakhshan,6,Wardooj,3,Khashbeen,17,Building,16,2,4,TRUE
+1716097,71.06392596,36.83478738,2,Bashand High School,Badakhshan,3,Wardooj,1,Bashand,17,Building,16,3,0,TRUE
+1716098,71.140130126,36.688865244,1,Teer Garan Girls High School,Badakhshan,2,Wardooj,1,Teer Garan,17,Building,16,0,2,FALSE
+1716099,71.14496753,36.63529529,1,Kazdah High School,Badakhshan,2,Wardooj,1,Kazdah,17,Building,16,0,2,FALSE
+1716100,71.05805335,36.87625112,1,Sarqalat School/Hamidullah House,Badakhshan,2,Wardooj,1,Sarqalat,17,Village,16,2,0,TRUE
+1716101,71.07994181,36.87582832,1,Ghanyo School,Badakhshan,2,Wardooj,1,Ghanyo,17,Building,16,2,0,TRUE
+1716311,71.058029287,36.87623437,2,Sar Qalat Mosque,Badakhshan,3,Wardooj,1,Qalat,17,Building,16,3,0,TRUE
+1717167,70.24722965,36.58275121,2,Farman Qoli School,Badakhshan,3,Tagab,1,Farman Qoli,17,Building,17,3,0,TRUE
+1717168,70.24443,36.6314,1,Karsada School,Badakhshan,2,Tagab,1,Karsada Village,17,Building,17,2,0,TRUE
+1718253,70.91945368,36.55626356,3,Chahar Maghzistan School,Badakhshan,4,Yamgan,1,Chahar Maghzistan,17,Building,18,0,4,FALSE
+1718254,70.7955424,36.51762722,2,Gharmai School,Badakhshan,4,Yamgan,2,District Office,17,Building,18,4,0,TRUE
+1718255,70.78550207,36.52717399,1,Mula Qurban Mosque,Badakhshan,2,Yamgan,1,Aawreesh,17,Building,18,2,0,TRUE
+1718256,70.79541674,36.60121065,2,Ashnaam School,Badakhshan,3,Yamgan,1,Mazar,17,Building,18,0,3,FALSE
+1718257,70.77987584,36.47854426,2,Naser Khisraw High School,Badakhshan,3,Yamgan,1,Hazrat Sayeed,17,Building,18,3,0,TRUE
+1718258,70.76059961,36.4045104,2,Gawhar School,Badakhshan,3,Yamgan,1,Gawhar,17,Building,18,3,0,TRUE
+1718259,70.66865335,36.31685373,2,Larkai School,Badakhshan,4,Yamgan,2,Larkai,17,Building,18,4,0,TRUE
+1718260,70.72841121,36.53368033,2,Aab Ashnam School,Badakhshan,3,Yamgan,1,Sanawari,17,Building,18,0,3,FALSE
+1718313,70.948278249,36.566111801,2,Ogh Female Secondary School,Badakhshan,3,Yamgan,1,Awrugh,17,Building,18,0,3,FALSE
+1718314,70.837992583,36.523328995,2,Primary School,Badakhshan,3,Yamgan,1,Ta Lolich,17,Building,18,0,3,FALSE
+1719213,71.46047961,37.55671511,3,Rahmat High School,Badakhshan,4,Shighnan,1,Bahshaar,17,Building,19,4,0,TRUE
+1719214,71.49853,37.57843,3,Sar Chashma High School,Badakhshan,4,Shighnan,1,Sar Chashma,17,Building,19,4,0,TRUE
+1719215,71.53892902,37.69744653,2,Shadoj High School,Badakhshan,3,Shighnan,1,Shadoj,17,Building,19,3,0,TRUE
+1719216,71.44419903,37.91210733,2,Pajor Jawed School,Badakhshan,3,Shighnan,1,Pajor,17,Building,19,3,0,TRUE
+1719217,71.31237958,37.9038614,2,Yaarakh Mosque,Badakhshan,3,Shighnan,1,Yaarakh,17,Building,19,3,0,TRUE
+1719218,71.49868295,37.47136696,2,Weer Boys School,Badakhshan,4,Shighnan,2,Weer,17,Building,19,4,0,TRUE
+1719219,71.46577,37.33809,2,Darmarakht School,Badakhshan,3,Shighnan,1,Darmarakht,17,Building,19,3,0,TRUE
+1719220,71.45116718,37.48825257,2,Pastyo Ghaar Jaween School,Badakhshan,3,Shighnan,1,Pastyo,17,Building,19,3,0,TRUE
+1719221,71.54261771,37.77451852,1,Chansoor Ulya High School,Badakhshan,2,Shighnan,1,Chansor Ulya,17,Building,19,2,0,TRUE
+1720238,70.22138848,37.884655,2,Sang Aab Mosque,Badakhshan,3,Khwahan,1,Sang Aab,17,Building,20,3,0,TRUE
+1720239,70.21828945,37.89285132,2,Chashma Toot Boys High School,Badakhshan,3,Khwahan,1,Chashma Toot,17,Building,20,3,0,TRUE
+1720240,70.20246748,37.92349017,1,Teh Kamar School,Badakhshan,2,Khwahan,1,Teh Kamar,17,Building,20,2,0,TRUE
+1720241,70.42384284,37.83465431,2,Raween Zaar School,Badakhshan,3,Khwahan,1,Raween Zaar,17,Building,20,3,0,TRUE
+1720242,70.38594237,37.75013166,2,Sel Daan School,Badakhshan,4,Khwahan,2,Sel Daan,17,Building,20,4,0,TRUE
+1720243,70.45536145,37.7583498,2,Hawz Shah School,Badakhshan,3,Khwahan,1,Zarhej,17,Building,20,3,0,TRUE
+1720244,70.40822424,37.83920475,1,Jar Payan Mosque,Badakhshan,2,Khwahan,1,Jar Payan,17,Building,20,2,0,TRUE
+1720245,70.48498488,37.76586176,1,Hawza Shah School,Badakhshan,2,Khwahan,1,Kajaga,17,Building,20,2,0,TRUE
+1721246,70.47714391,38.0400871,3,Qala School,Badakhshan,5,Kufab,2,Qala,17,Building,21,5,0,TRUE
+1721247,70.49883746,38.00006869,2,Nashahr School,Badakhshan,4,Kufab,2,Nashahr Village,17,Building,21,4,0,TRUE
+1721248,70.57553329,37.96723531,2,Karniyo School,Badakhshan,3,Kufab,1,Karniyo,17,Building,21,3,0,TRUE
+1721249,70.72012345,37.93142603,2,Daraaj High School,Badakhshan,3,Kufab,1,Daraaj Payan Village,17,Building,21,3,0,TRUE
+1721250,70.65064958,37.93109493,2,Shakhro School,Badakhshan,3,Kufab,1,Shakhro,17,Building,21,3,0,TRUE
+1721251,70.73586388,37.94298771,2,Pay Mazar School,Badakhshan,3,Kufab,1,Pay Mazar,17,Building,21,3,0,TRUE
+1721252,70.5082956,37.96634535,1,Padyo School,Badakhshan,2,Kufab,1,Padyo,17,Building,21,2,0,TRUE
+1722261,71.050758,38.404311,1,Charbagh Madrassa,Badakhshan,4,Darwaz-E-Payin,3,Madrassa,17,Village,22,4,0,TRUE
+1722262,71.20375,38.314598,2,Chashtak School,Badakhshan,3,Darwaz-E-Payin,1,Chashtak Village,17,Village,22,3,0,TRUE
+1722263,71.12020043,38.38027266,2,Warfad School,Badakhshan,3,Darwaz-E-Payin,1,Warfad Village,17,Village,22,3,0,TRUE
+1722264,71.32182583,38.27906626,1,Jamarch School,Badakhshan,2,Darwaz-E-Payin,1,Jamarch Village,17,Village,22,2,0,TRUE
+1722265,71.28057184,38.14570959,1,Ghamai School,Badakhshan,2,Darwaz-E-Payin,1,Ghamai Village,17,Village,22,2,0,TRUE
+1722266,71.038086,38.402153,1,Warwah School,Badakhshan,2,Darwaz-E-Payin,1,Warwah Village,17,Village,22,2,0,TRUE
+1722267,70.946269749,38.291380745,1,Tang Shew School,Badakhshan,2,Darwaz-E-Payin,1,Tang Shew,17,District,22,2,0,TRUE
+1723196,71.45932592,36.64283513,2,Bazgir High School,Badakhshan,3,Eshkashim,1,Bazgir,17,Building,23,3,0,TRUE
+1723197,71.57419754,36.70879772,2,Ashkasham High School,Badakhshan,3,Eshkashim,1,Ashkashm,17,Building,23,3,0,TRUE
+1723198,71.57970045,36.70026816,2,Torbat Mosque,Badakhshan,3,Eshkashim,1,Torbat,17,Building,23,3,0,TRUE
+1723199,71.52269,36.85506,1,Yakhdaro School,Badakhshan,2,Eshkashim,1,Yakhdaro,17,Building,23,2,0,TRUE
+1723200,71.4294805,37.06001627,1,Zeech School,Badakhshan,2,Eshkashim,1,Zeech,17,Building,23,2,0,TRUE
+1723201,71.45727838,37.21731318,1,Gul Bagh School,Badakhshan,2,Eshkashim,1,Gul Bagh,17,Building,23,2,0,TRUE
+1723202,71.48312239,36.66391222,1,Khosh Paak Schook,Badakhshan,2,Eshkashim,1,Khosh Paak,17,Building,23,2,0,TRUE
+1723315,71.439398524,37.219533004,2,Gharan Bala High School,Badakhshan,3,Eshkashim,1,Qaz Deh,17,Village,23,3,0,TRUE
+1724276,70.60760033,38.28694776,3,Ghamai School,Badakhshan,4,Shiki,1,Ghamai Payan,17,Village,24,4,0,TRUE
+1724277,70.69329713,38.3994979,1,Maah Naw,Badakhshan,3,Shiki,2,Manaaw,17,Village,24,3,0,TRUE
+1724278,70.50753614,38.12897222,2,Shahr Sabz High School,Badakhshan,3,Shiki,1,Shahr Sabz,17,Village,24,3,0,TRUE
+1724279,70.54699632,38.24280064,1,Zharaf High School,Badakhshan,2,Shiki,1,Zharaf,17,Village,24,2,0,TRUE
+1724280,70.57268665,38.18781503,1,Sar Naazem School,Badakhshan,2,Shiki,1,Sar Naazem,17,Village,24,2,0,TRUE
+1724281,70.72484923,38.32389392,1,Khan Dara School,Badakhshan,2,Shiki,1,Khan Dara,17,Village,24,2,0,TRUE
+1724282,70.64060715,38.23828703,1,Sang Lech Primary School,Badakhshan,2,Shiki,1,Sang Lech,17,Village,24,2,0,TRUE
+1725192,71.34304435,36.5312549,2,Zebaak Girls High School,Badakhshan,3,Zebak,1,Zebaak,17,Building,25,3,0,TRUE
+1725193,71.3891728,36.60264288,1,Aashor Bek School,Badakhshan,2,Zebak,1,Zarkhan,17,Building,25,2,0,TRUE
+1725194,71.3918012,36.5730477,1,Dand School,Badakhshan,2,Zebak,1,Dand Village,17,Building,25,2,0,TRUE
+1725195,71.30312389,36.43520674,1,Farooq High School,Badakhshan,2,Zebak,1,Farooq,17,Building,25,2,0,TRUE
+1726188,70.41313742,35.89564797,3,Dahan Aab Yamak School,Badakhshan,5,Kiran Wa Menjan,2,Dahan Aab Yamak,17,Building,26,4,1,TRUE
+1726189,70.68109453,36.02196545,1,Askazar Clinic,Badakhshan,2,Kiran Wa Menjan,1,Askazar,17,Building,26,2,0,TRUE
+1726190,70.89235001,35.90664816,1,Shah Pari School,Badakhshan,2,Kiran Wa Menjan,1,Shah Pari,17,Building,26,2,0,TRUE
+1726191,70.90075681,35.98193043,1,Shahran Clinic,Badakhshan,2,Kiran Wa Menjan,1,Shahran,17,Building,26,2,0,TRUE
+1726316,70.780727362,36.172689129,2,Lahjor Sho School,Badakhshan,3,Kiran Wa Menjan,1,Lahjor Sho,17,Building,26,3,0,TRUE
+1727268,70.92810794,38.2738718,3,Khurkad Madrassa,Badakhshan,4,Darwaz-E-Bala,1,Khurkad,17,Village,27,4,0,TRUE
+1727269,70.82660215,38.28303765,3,Sar-E-Pul School,Badakhshan,4,Darwaz-E-Bala,1,Sare-E-Pul,17,Village,27,4,0,TRUE
+1727270,70.84127368,38.3890605,2,Zoghar School,Badakhshan,3,Darwaz-E-Bala,1,Zoghar,17,Village,27,3,0,TRUE
+1727271,70.8028726,38.44329256,2,District Building,Badakhshan,3,Darwaz-E-Bala,1,Darwaza Payeen District Office,17,Village,27,3,0,TRUE
+1727272,70.92066357,38.43034766,2,Awbaghoon School,Badakhshan,3,Darwaz-E-Bala,1,Awbaghoon,17,Village,27,3,0,TRUE
+1727273,70.84019721,38.30588094,2,Aaroon School,Badakhshan,3,Darwaz-E-Bala,1,Aaroon,17,Village,27,3,0,TRUE
+1727274,70.914612,38.23949436,1,Magai School,Badakhshan,2,Darwaz-E-Bala,1,Magai,17,Village,27,2,0,TRUE
+1727275,70.81035051,38.31223609,2,Magai Jawai School,Badakhshan,3,Darwaz-E-Bala,1,Magai Jawai,17,Village,27,3,0,TRUE
+1728203,71.74878999,36.67028,2,Qazi Deh School,Badakhshan,3,Wakhan,1,Qazi Deh,17,Building,28,2,1,TRUE
+1728204,71.91722,36.72867,1,Shakhor School,Badakhshan,2,Wakhan,1,Shakhor,17,Building,28,2,0,TRUE
+1728205,72.31382954,36.94877172,2,Khandod School,Badakhshan,3,Wakhan,1,Khandod,17,Building,28,3,0,TRUE
+1728206,72.57826,36.99903,1,Panja High School,Badakhshan,2,Wakhan,1,Panja,17,Building,28,2,0,TRUE
+1728207,72.89725343,36.96841889,1,Kep Kot Secondary School,Badakhshan,2,Wakhan,1,Kep Kot,17,Building,28,2,0,TRUE
+1728208,74.00513374,37.13775207,1,Bozay Gombaad,Badakhshan,2,Wakhan,1,Pamir,17,Village,28,2,0,TRUE
+1728209,71.94190902,36.74306058,1,Langar,Badakhshan,2,Wakhan,1,Pamir,17,Village,28,2,0,TRUE
+1728210,73.26487435,37.00014319,1,Nesht Khor Secondary School,Badakhshan,2,Wakhan,1,Nesht Khor,17,Building,28,2,0,TRUE
+1728211,72.794213572,36.976909753,1,Khana Qala Panja Mosque,Badakhshan,2,Wakhan,1,Sast,17,Building,28,2,0,TRUE
+1728212,73.40719502,37.00989972,1,Sarhad Pamir_Patokh High School,Badakhshan,2,Wakhan,1,Patokh,17,Building,28,2,0,TRUE
+1801001,69.76534434,36.75067967,3,Lataband High School,Takhar,4,Taluqan,1,Lataband,18,Building,1,4,0,TRUE
+1801002,69.64891581,36.67202229,4,Khatayan High School,Takhar,6,Taluqan,2,Khatayan,18,Building,1,6,0,TRUE
+1801003,69.6140482,36.71013466,5,Alfarooq School,Takhar,7,Taluqan,2,Alfarooq,18,Building,1,8,0,TRUE
+1801004,69.57973339,36.67824075,3,Engineer Nek Mohammad School,Takhar,4,Taluqan,1,Qarmala,18,Building,1,4,0,TRUE
+1801005,69.6698006,36.7960468,3,Khwaja Khalil School,Takhar,4,Taluqan,1,Khwaja Khalil,18,Building,1,4,1,TRUE
+1801006,69.53944421,36.73917365,5,Sayed Abdullah Boys High School,Takhar,7,Taluqan,2,D03 - Nahia 3,18,Building,1,7,0,TRUE
+1801007,69.53683753,36.74108165,3,Bibi Hajera Girls High School,Takhar,5,Taluqan,2,D03 - Nahia 3,18,Building,1,5,0,TRUE
+1801008,69.48043536,36.7636252,3,Qari Sediq High School,Takhar,4,Taluqan,1,Parchaw Village,18,Building,1,5,0,TRUE
+1801009,69.51405172,36.77087343,3,Sray Sang High School,Takhar,6,Taluqan,3,Gunbad Village,18,Building,1,6,0,TRUE
+1801010,69.53416046,36.73622772,5,Doctar Sayed Hussain High School,Takhar,7,Taluqan,2,D03 - Nahia 3,18,Building,1,7,0,TRUE
+1801011,69.5491905,36.73069365,6,Abu Usman Boys High School,Takhar,9,Taluqan,3,D01 - Nahia 1,18,Building,1,9,0,TRUE
+1801012,69.51691312,36.73041659,8,Mullah Abdul Wodood High School,Takhar,13,Taluqan,5,Golayee Bagh,18,Building,1,13,0,TRUE
+1801013,69.52914638,36.73105472,4,Bibi Maryam High School,Takhar,7,Taluqan,3,D04 - Nahia 4,18,Building,1,7,0,TRUE
+1801014,69.54389828,36.73497181,5,Agriculture Department,Takhar,7,Taluqan,2,D02 - Nahia 2,18,Building,1,7,0,TRUE
+1801015,69.54007146,36.73032898,3,Women Affairs Department,Takhar,5,Taluqan,2,D01 - Nahia 1,18,Building,1,5,0,TRUE
+1801016,69.53749732,36.73007354,3,Culture & Information Department,Takhar,5,Taluqan,2,D02 - Nahia 2,18,Building,1,5,0,TRUE
+1801017,69.5562466,36.74563482,3,Bolak Orta Baz Primary School,Takhar,5,Taluqan,2,Bolak Orta Baz,18,Building,1,5,0,TRUE
+1801018,69.567811505,36.727230269,5,Malaria Clinic,Takhar,7,Taluqan,2,D01 - Nahia 1,18,Village,1,8,0,TRUE
+1801019,69.55875756,36.70620703,3,Fayaz Shaheed High School,Takhar,6,Taluqan,3,Nahr Chaman,18,Building,1,6,0,TRUE
+1801020,69.45864119,36.75082186,3,Sayed Naser High School,Takhar,4,Taluqan,1,Abdaal,18,Building,1,4,0,TRUE
+1801021,69.3639122,36.74086425,4,Gul Nazar High School,Takhar,6,Taluqan,2,Shuhada Qalbaras,18,Building,1,6,0,TRUE
+1801022,69.42963423,36.72563101,5,Aaq Masjid High School,Takhar,8,Taluqan,3,Aaq Masjid,18,Building,1,8,0,TRUE
+1801023,69.49304213,36.71916609,3,Chashma Shir High School,Takhar,5,Taluqan,2,Chashma Shir,18,Building,1,5,0,TRUE
+1801024,69.54785822,36.72921527,4,Girls Number 1 High School,Takhar,7,Taluqan,3,D01 - Nahia 1,18,Building,1,7,0,TRUE
+1801025,69.70313293,36.70325421,2,Todan High School,Takhar,3,Taluqan,1,Todan Village,18,Building,1,3,0,TRUE
+1801026,69.71214251,36.77410259,1,Shorcha 1 School,Takhar,2,Taluqan,1,Shorja 1,18,Building,1,2,0,TRUE
+1801027,69.63641772,36.66595739,1,Joy Shekh School,Takhar,2,Taluqan,1,Joy Shekh,18,Building,1,2,0,TRUE
+1801028,69.30362858,36.72665417,2,Chenza Yee School,Takhar,4,Taluqan,2,Chenza Yee,18,Building,1,4,0,TRUE
+1801029,69.49737326,36.79743769,2,Tarma Baay School,Takhar,3,Taluqan,1,Tarma Baay,18,Building,1,3,0,TRUE
+1801030,69.53443773,36.76146277,2,Abdul Rahman Taloqani High School,Takhar,3,Taluqan,1,Qazaq,18,Building,1,4,0,TRUE
+1801031,69.42816105,36.7597084,2,Takhta Koparak Madrassa,Takhar,3,Taluqan,1,Takhta Koparak,18,Building,1,3,0,TRUE
+1801032,69.59076978,36.7430891,2,Ganj Ali Beg High School,Takhar,4,Taluqan,2,Ganj Ali Beg,18,Building,1,4,0,TRUE
+1801033,69.62556305,36.78475052,2,Ochqadaq,Takhar,3,Taluqan,1,Ochqadaq,18,Building,1,3,0,TRUE
+1801034,69.47716457,36.61363653,1,Shorcha 2 School,Takhar,2,Taluqan,1,Shorcha 2 Village,18,Building,1,2,0,TRUE
+1801183,69.57588723,36.72788699,2,Abdul Bari Shaheed School,Takhar,4,Taluqan,2,Zargari Bala,18,Building,1,6,0,TRUE
+1801184,69.59694929,36.72223212,2,Ahan Dara High School,Takhar,3,Taluqan,1,Kolabi,18,Building,1,4,0,TRUE
+1801185,69.34415259,36.75715626,1,Abdul Lateef Shaheed High School,Takhar,2,Taluqan,1,Khwaja Sabz Posh,18,Building,1,2,0,TRUE
+1801186,69.51922923,36.74578604,2,Baghak Primary School,Takhar,3,Taluqan,1,Baghak Village,18,Building,1,4,0,TRUE
+1802035,69.56290379,36.86518186,3,Hazar Smooch Secondary School,Takhar,4,Hazar Sumuch,1,Hazar Smooch,18,Building,2,4,0,TRUE
+1802036,69.55080728,36.95035103,2,Aacha Primary School,Takhar,3,Hazar Sumuch,1,Aacha,18,Building,2,3,0,TRUE
+1802037,69.61726415,36.822615163,1,Aaq Masjid Secondary School,Takhar,2,Hazar Sumuch,1,Aaq Masjid,18,Building,2,2,0,TRUE
+1802038,69.68538256,36.90286679,1,Khwaja Lamtoo Mosque,Takhar,2,Hazar Sumuch,1,Khwaja Lamtoo,18,Building,2,2,0,TRUE
+1802039,69.61232873,36.98979419,1,Qala Mama Ye School,Takhar,2,Hazar Sumuch,1,Qala Mama Ye,18,Building,2,2,0,TRUE
+1802187,69.589614018,36.897043378,1,Bibi Khadija Secondary School,Takhar,2,Hazar Sumuch,1,Shololok,18,Building,2,2,0,TRUE
+1803040,69.43275911,36.79328397,4,Chapla Primary Schoo,Takhar,7,Baharak,3,Chayla,18,Building,3,7,0,TRUE
+1803041,69.39219943,36.77773548,4,Hazrat Omar Primary School,Takhar,7,Baharak,3,Do Rahi,18,Building,3,7,0,TRUE
+1803042,69.40101271,36.84398578,3,Ghulam Sarwar Shaheed Primary School,Takhar,5,Baharak,2,Zard Kamar,18,Building,3,5,0,TRUE
+1803043,69.37710413,36.83676447,2,Haji Pahlawan High School,Takhar,4,Baharak,2,Haji Pahlawan,18,Building,3,4,0,TRUE
+1803044,69.41319307,36.82136528,3,Alhaj Abdul Qayum Bek High School,Takhar,6,Baharak,3,Markaz Shahr,18,Building,3,7,0,TRUE
+1803045,69.5053147,36.88514543,1,Shor Qadoq School,Takhar,2,Baharak,1,Shor Qadoq,18,Building,3,2,0,TRUE
+1803188,69.45599105,36.93430277,1,Qazal Say School,Takhar,2,Baharak,1,Qazal Say,18,Building,3,2,0,TRUE
+1803189,69.335815341,36.766733769,2,Raketi Mosque,Takhar,3,Baharak,1,Hassan Noor Ali,18,Building,3,3,0,TRUE
+1803204,69.438101716,36.780387924,2,Qazi Enayaht Ullah High School,Takhar,3,Baharak,1,Shash Band,18,Village,3,3,0,TRUE
+1804059,69.25501896,36.71706323,5,Dahana Bangi School,Takhar,7,Bangi,2,Saqaba,18,Building,4,7,0,TRUE
+1804060,69.36576055,36.52873468,3,Mawlawi Ezzatullah Shaheed High School,Takhar,5,Bangi,2,Mirza Bacha,18,Building,4,5,0,TRUE
+1804061,69.41521746,36.561612,2,Chaar Chenar High School,Takhar,4,Bangi,2,Chaar Chenar,18,Building,4,4,0,TRUE
+1804062,69.3418959,36.66492815,5,Etihad High School,Takhar,8,Bangi,3,Afaqi,18,Building,4,8,0,TRUE
+1804063,69.3587132,36.58588341,2,Mansoor Shaheed High School,Takhar,4,Bangi,2,Chala Tash,18,Building,4,4,0,TRUE
+1805076,69.53831205,36.44762537,3,Abdul Wahid Shaheed High School,Takhar,5,Chal,2,Mandara,18,Building,5,5,0,TRUE
+1805077,69.55054091,36.5305712,4,Sayed Nimatullah High School,Takhar,6,Chal,2,Khanqa Markaz Chal,18,Building,5,6,0,TRUE
+1805078,69.62256086,36.51483296,2,Sang Lashem School,Takhar,4,Chal,2,Sang Lashem,18,Building,5,4,0,TRUE
+1805079,69.45188572,36.45645827,2,Samandab High School,Takhar,4,Chal,2,Samandab,18,Building,5,4,0,TRUE
+1805080,69.61301701,36.44823563,1,Khwaja Bana Mosque,Takhar,2,Chal,1,Khwaja Bana,18,Building,5,2,0,TRUE
+1805193,69.67668495,36.48411928,1,Sayaad Mosque,Takhar,2,Chal,1,Sayaad,18,Building,5,2,0,TRUE
+1806081,69.72206533,36.52663091,3,Bagh Qazi Primary School,Takhar,5,Namak Ab,2,Bag Qazi,18,Building,6,5,0,TRUE
+1806082,69.703216239,36.576813541,2,Sad Bargan School,Takhar,3,Namak Ab,1,Sad Bargan,18,Building,6,3,0,TRUE
+1806083,69.64108956,36.59439838,3,District Office,Takhar,5,Namak Ab,2,Bekh Kotal,18,Building,6,5,0,TRUE
+1806194,69.76370633,36.43184663,1,Nakhjir Dara School,Takhar,2,Namak Ab,1,Nakhjir Dara,18,Building,6,2,0,TRUE
+1806205,69.621020065,36.573450783,2,Primary School,Takhar,3,Namak Ab,1,Tash Yalaq,18,Building,6,3,0,TRUE
+1807094,69.84615913,36.84483707,3,Mir Hassan Nawan Secondary School,Takhar,5,Kalafgan,2,Nawan,18,Building,7,5,0,TRUE
+1807095,69.97050021,36.8640258,3,Hazrat Khalid High School,Takhar,4,Kalafgan,1,Char Toot,18,Building,7,4,0,TRUE
+1807096,69.94330477,36.77588568,3,Abul Hassan Kherqani High School,Takhar,5,Kalafgan,2,Hawza Shahr,18,Building,7,5,0,TRUE
+1807097,69.944982,36.774088,4,Kalafgaan Girls High School,Takhar,5,Kalafgan,1,Markaz Shahr,18,Building,7,5,0,TRUE
+1807098,69.85475268,36.73146449,2,Abu Ubaida High School,Takhar,4,Kalafgan,2,Aaq Balaq,18,Building,7,4,0,TRUE
+1807099,69.82343138,36.69461097,2,Gazestan Secondary School,Takhar,4,Kalafgan,2,Gazestan,18,Building,7,4,0,TRUE
+1807100,69.94651683,36.75056528,3,Mohammad Hussain Shaheed High School,Takhar,4,Kalafgan,1,Zardaalo Dara Sufla,18,Building,7,4,0,TRUE
+1807195,69.8126286,36.78593645,1,Qoroq Saay Primary School,Takhar,2,Kalafgan,1,Qoroq Saay,18,Building,7,2,0,TRUE
+1807206,69.904674677,36.862899293,2,Emam Abo Hanifa Secondary School,Takhar,3,Kalafgan,1,Kharqan Khiar Dara,18,Building,7,3,0,TRUE
+1807207,69.973489228,36.917048318,2,Primary School,Takhar,3,Kalafgan,1,Garm Sir,18,Building,7,3,0,TRUE
+1808084,69.86498245,36.46439723,3,Chaman Khasdah,Takhar,5,Farkhar,2,Khasdah,18,Building,8,5,0,TRUE
+1808085,69.9306241,36.57470223,2,Qaneyat Shaheed High School,Takhar,4,Farkhar,2,Aardeshan,18,Building,8,4,0,TRUE
+1808086,69.85518241,36.5818308,5,Samimi Shaheed High School,Takhar,8,Farkhar,3,Markaz Shahr,18,Building,8,8,0,TRUE
+1808087,69.92886236,36.36854362,2,Lazhdah High School,Takhar,3,Farkhar,1,Lazhdah,18,Building,8,3,0,TRUE
+1808088,70.05710539,36.34733375,2,Mushtan School,Takhar,3,Farkhar,1,Mushtan,18,Building,8,3,0,TRUE
+1808089,69.91784793,36.59361687,2,Sayed Abdul Rahman Shaheed High School,Takhar,3,Farkhar,1,Khanqah,18,Building,8,3,0,TRUE
+1808090,69.81275315,36.62571112,1,Makhdoom Abdullah Shaheed School,Takhar,2,Farkhar,1,Koraani,18,Building,8,2,0,TRUE
+1808091,69.76858488,36.58058602,2,Nahr Aab Madrassa,Takhar,3,Farkhar,1,Nahr Aab,18,Building,8,3,0,TRUE
+1808092,69.87254,36.53298,2,Mohammad Nabi Shaheed High School,Takhar,3,Farkhar,1,Khufdara,18,Building,8,3,0,TRUE
+1808093,69.98069826,36.3255765,1,Pul Mushtan,Takhar,2,Farkhar,1,Sar Pul Mushtan,18,Building,8,2,0,TRUE
+1808208,69.749926567,36.630773852,2,Secondary School,Takhar,3,Farkhar,1,Kashkatan,18,Building,8,3,0,TRUE
+1809046,69.42329665,37.06625846,3,Khwaja Ghaar Girls High School,Takhar,5,Khwaja Ghar,2,Khwaja Ghaar,18,Building,9,5,0,TRUE
+1809047,69.42011062,37.06811532,4,Boys High School,Takhar,6,Khwaja Ghar,2,Khwaja Ghaar,18,Building,9,6,0,TRUE
+1809048,69.41569829,37.1036206,3,Jokdo Primary School,Takhar,4,Khwaja Ghar,1,Jokdo,18,Building,9,4,0,TRUE
+1809049,69.44231888,37.11321352,2,Laklakan Primary School,Takhar,3,Khwaja Ghar,1,Lalakan,18,Building,9,3,0,TRUE
+1809050,69.52418405,37.04273605,2,Aaqela Mama Ye High School,Takhar,4,Khwaja Ghar,2,Aaqela Mama Ye,18,Building,9,4,0,TRUE
+1809051,69.37394145,37.1437236,4,Qarooq Primary School,Takhar,6,Khwaja Ghar,2,Qarooq,18,Building,9,6,0,TRUE
+1809052,69.33071659,37.10143914,2,Subhani High School,Takhar,4,Khwaja Ghar,2,Meng Chaqoor,18,Building,9,4,0,TRUE
+1809053,69.38261004,36.97923402,3,Ghulam Sakhi High School,Takhar,4,Khwaja Ghar,1,Qala Cha Kaarez,18,Building,9,4,0,TRUE
+1809054,69.41659914,37.136819,2,Haji Mirza Mohammad Secondary School,Takhar,3,Khwaja Ghar,1,Jalom Khor,18,Building,9,3,0,TRUE
+1809055,69.38411449,36.92565137,2,Hamwar Say Primary School,Takhar,4,Khwaja Ghar,2,Hamwar Say,18,Building,9,4,0,TRUE
+1809056,69.37659629,37.0008006,2,Chebq Mosque,Takhar,4,Khwaja Ghar,2,Chebq,18,Building,9,4,0,TRUE
+1809057,69.398404427,37.055228244,1,Shahrwan Bagh Abdul Shakoor,Takhar,2,Khwaja Ghar,1,Shahrwan,18,District,9,2,0,TRUE
+1809058,69.3644,37.03369,1,Saaf Qarooq School,Takhar,2,Khwaja Ghar,1,Saaf Qarooq,18,Building,9,2,0,TRUE
+1809190,69.36678506,37.00993179,3,Hasamuddin Shaheed High School,Takhar,4,Khwaja Ghar,1,Keshwari,18,Building,9,4,0,TRUE
+1810101,69.7970337,37.14129302,5,Hazrat Omar Farooq High School,Takhar,7,Rustaq,2,Shahr Jadid Rostaq,18,Building,10,7,0,TRUE
+1810102,69.82498947,37.12956226,2,Shahr Kuhna Girls High School,Takhar,4,Rustaq,2,Shahr Kuhna Rostaq,18,Building,10,4,0,TRUE
+1810103,69.79591631,37.14218134,4,Rostaq Education Department,Takhar,6,Rustaq,2,Shahr Jadid Rostaq,18,Building,10,6,0,TRUE
+1810104,69.79670117,37.14050337,4,Rostaq Girls High School,Takhar,6,Rustaq,2,Shahr Jadid Rostaq,18,Building,10,6,0,TRUE
+1810105,69.76497298,37.20462566,3,Tolkai Wa Chapa Khana Secondary School,Takhar,5,Rustaq,2,Tolakai,18,Building,10,5,0,TRUE
+1810106,69.73227441,37.22815203,3,Hazrat Obai Ibn Kaab School,Takhar,5,Rustaq,2,Yaka Toot Nawabad,18,Building,10,5,0,TRUE
+1810107,69.91149878,37.26695283,1,Langar Sadat Mosque,Takhar,2,Rustaq,1,Langar Sadat,18,Building,10,2,0,TRUE
+1810108,69.83752346,37.245334,3,Faiz Abad Primary School,Takhar,4,Rustaq,1,Sayed Abad,18,Building,10,4,0,TRUE
+1810109,69.72115887,37.32317215,3,Hazrat Abdullah Bin Masood High School,Takhar,4,Rustaq,1,Kewan,18,Building,10,4,0,TRUE
+1810110,69.61262956,37.11401845,3,Sher Atla Secondary School,Takhar,4,Rustaq,1,Sher Atla,18,Building,10,4,0,TRUE
+1810111,69.64643781,37.0548519,3,Yamchi Primary School,Takhar,4,Rustaq,1,Yamchi,18,Building,10,4,0,TRUE
+1810112,69.90581502,37.10650301,4,Hazrat Khelali High School,Takhar,6,Rustaq,2,Sar Rostaq,18,Building,10,6,0,TRUE
+1810113,70.01367811,37.00581891,2,Mawlana Jalaluddin High School,Takhar,4,Rustaq,2,Aab Asyaba,18,Building,10,4,0,TRUE
+1810114,69.90656391,37.18514997,3,Hazar Smooch Secondary School,Takhar,5,Rustaq,2,Hazar Smooch,18,Building,10,5,0,TRUE
+1810115,69.97333588,37.16970579,2,Sar Ghaar Secondary School,Takhar,3,Rustaq,1,Sar Ghaar,18,Building,10,3,0,TRUE
+1810116,69.7738298,36.96552569,3,Qadaq Jawaz Khana Clinic,Takhar,4,Rustaq,1,Qadaq Jawaz Khana,18,Building,10,4,0,TRUE
+1810117,69.79212202,36.93446413,1,Chenar Village Mosque,Takhar,2,Rustaq,1,Chenar Village,18,Building,10,2,0,TRUE
+1810118,69.727214513,36.977548779,1,Narastan Primary School,Takhar,2,Rustaq,1,Narastan Village,18,Building,10,2,0,TRUE
+1810119,69.72089006,36.9165261,2,Koktaba High School,Takhar,3,Rustaq,1,Dasht Mirzayee,18,Building,10,3,0,TRUE
+1810120,69.80510956,37.16897375,2,Ganda Secondary School,Takhar,4,Rustaq,2,Ganda,18,Building,10,4,0,TRUE
+1810121,69.89801902,37.24085255,2,Abul Qaasam Gorgany High School,Takhar,4,Rustaq,2,Gorgan,18,Building,10,4,0,TRUE
+1810122,69.83943842,37.26847506,1,Tawheed Islami School,Takhar,2,Rustaq,1,Keshan,18,Building,10,2,0,TRUE
+1810123,69.65880156,37.14133788,3,Qadaq Tajikan Mosque,Takhar,4,Rustaq,1,Qadaq Tajikan,18,Building,10,4,0,TRUE
+1810124,69.53485818,37.04277144,2,Khwaja Alauddin High School,Takhar,4,Rustaq,2,Lala Maidan,18,Building,10,4,0,TRUE
+1810125,70.03219515,37.06867245,2,Hazrat Bilal Secondary School,Takhar,3,Rustaq,1,Elkashan,18,Building,10,3,0,TRUE
+1810126,69.97054678,36.95981788,1,Abu Huraira Secondary School,Takhar,2,Rustaq,1,Shingar Aab,18,Building,10,2,0,TRUE
+1810127,69.94942945,37.08291909,3,Mawlawi Abdul Qudoos Shaheed Secondary School,Takhar,4,Rustaq,1,Ghenj,18,Building,10,4,0,TRUE
+1810128,69.99485915,37.19416332,2,Dashtak Ulya Secondary School,Takhar,4,Rustaq,2,Dashtak Ulya,18,Building,10,4,0,TRUE
+1810129,69.75703418,37.0602883,3,Hazrat Usman High School,Takhar,4,Rustaq,1,Saqaba,18,Building,10,4,0,TRUE
+1810130,69.84155742,37.04651602,2,Chabdara Wabtash Secondary School,Takhar,4,Rustaq,2,Chabdara Wabtash,18,Building,10,4,0,TRUE
+1810131,69.67880504,37.27690596,1,Qara Deng Primary School,Takhar,2,Rustaq,1,Qara Deng,18,Building,10,2,0,TRUE
+1810196,69.9918422,37.23392251,1,Zaan Payan Mosque,Takhar,2,Rustaq,1,Zaan Payan,18,Building,10,2,0,TRUE
+1810197,69.945730308,36.933804094,1,Aabzan Secondary School,Takhar,2,Rustaq,1,Aabzan,18,Building,10,2,0,TRUE
+1810209,70.12431706,37.046219474,2,Mosque,Takhar,3,Rustaq,1,Dasht Amani,18,Building,10,3,0,TRUE
+1810210,69.938795519,37.038918632,2,Secondary School,Takhar,3,Rustaq,1,Khwaja Khirab,18,Building,10,3,0,TRUE
+1810211,69.765293815,37.025418737,2,Primary School,Takhar,3,Rustaq,1,Dashtak Sufla,18,Building,10,3,0,TRUE
+1811064,69.32748499,36.38252189,6,Tariq Shaheed High School,Takhar,9,Eshkamesh,3,Shahr Kuhna Ashkmash,18,Building,11,9,0,TRUE
+1811065,69.32772106,36.3464719,2,Deen Mohammad Shaheed School,Takhar,4,Eshkamesh,2,Panchiri,18,Building,11,4,0,TRUE
+1811066,69.5407648,36.36289995,2,Dahan Sheera High School,Takhar,4,Eshkamesh,2,Sheera,18,Building,11,4,0,TRUE
+1811067,69.26420673,36.35347514,2,Tarsak Primary School,Takhar,4,Eshkamesh,2,Tarsak,18,Building,11,4,0,TRUE
+1811068,69.24821218,36.31237433,2,Koka Balaq School,Takhar,4,Eshkamesh,2,Koka Balaq,18,Building,11,4,0,TRUE
+1811069,69.40336631,36.43132053,3,Qenar Secondary School,Takhar,5,Eshkamesh,2,Qenar,18,Building,11,5,0,TRUE
+1811070,69.33475815,36.44213996,3,Baad Guzar Primary School,Takhar,4,Eshkamesh,1,Baad Guzar,18,Building,11,4,0,TRUE
+1811071,69.2155138,36.50850986,1,Qashlaq Say Mosque,Takhar,2,Eshkamesh,1,Qashlaq Say,18,Building,11,2,0,TRUE
+1811072,69.22077728,36.43768124,1,Boyerak Mosque,Takhar,2,Eshkamesh,1,Boyerak,18,Building,11,2,0,TRUE
+1811073,69.43546013,36.41845522,2,Nawabad Markaz Mosque,Takhar,3,Eshkamesh,1,Nawabad,18,Building,11,3,0,TRUE
+1811074,69.39138335,36.31576563,2,Dara-E-Kalan Primary School,Takhar,3,Eshkamesh,1,Dara-E-Kalan,18,Building,11,3,0,TRUE
+1811075,69.37841835,36.43851785,2,Qandahari Fakhrak Mosque,Takhar,3,Eshkamesh,1,Fakhrak,18,Building,11,3,0,TRUE
+1811191,69.50978424,36.44231341,1,Siyah Dara Mosque,Takhar,2,Eshkamesh,1,Siyah Dara,18,Building,11,2,0,TRUE
+1811192,69.34699072,36.39317185,1,Aabro Primary School,Takhar,2,Eshkamesh,1,Aabro,18,Building,11,2,0,TRUE
+1812169,69.44858,37.15441,4,Shahr Boys High School,Takhar,6,Dasht-E-Qala,2,Shahr Jadid,18,Building,12,6,0,TRUE
+1812170,69.43646944,37.15040833,2,Girls High School,Takhar,4,Dasht-E-Qala,2,Shahr Kuhna,18,Building,12,4,0,TRUE
+1812171,69.48422777,37.19848611,2,Bagh Bayan High School,Takhar,3,Dasht-E-Qala,1,Bagh Bayan,18,Building,12,3,0,TRUE
+1812172,69.47505833,37.20228888,3,Ghaz Tipa Mosque,Takhar,5,Dasht-E-Qala,2,Ghaz Tipa,18,Building,12,5,0,TRUE
+1812173,69.477,37.08961,2,Sareegh High School,Takhar,3,Dasht-E-Qala,1,Sareegh,18,Building,12,3,0,TRUE
+1812174,69.5124152,37.16919924,2,Nawabad Secondary School,Takhar,4,Dasht-E-Qala,2,Nawabad,18,Building,12,4,0,TRUE
+1812175,69.50500256,37.24628586,2,Laayeqa Primary School,Takhar,3,Dasht-E-Qala,1,Laayeqa,18,Building,12,3,0,TRUE
+1812200,69.49292777,37.21244444,1,Bagh Bayan Mosque,Takhar,2,Dasht-E-Qala,1,Bagh Bayan,18,Building,12,2,0,TRUE
+1812201,69.47595999,37.24508,1,Arabkakul Secondary School,Takhar,2,Dasht-E-Qala,1,Arabkakul,18,Building,12,2,0,TRUE
+1812212,69.43175411,37.168735886,2,Ai Khanum High School,Takhar,3,Dasht-E-Qala,1,Ai Khanum,18,Building,12,3,0,TRUE
+1813176,69.91302824,36.22989514,5,Sayed Ikramuddin Shaheed High School,Takhar,7,Warsaj,2,Tarasht,18,Building,13,7,0,TRUE
+1813177,70.01206433,36.07257331,2,Sardasht Mosque,Takhar,3,Warsaj,1,Sardasht,18,Building,13,3,0,TRUE
+1813178,70.00495,36.20305,4,Sayed Zafaruddin Shaheed High School,Takhar,6,Warsaj,2,Khanqah,18,Building,13,6,0,TRUE
+1813179,70.07396004,36.19749619,2,Insaf Shaheed High School,Takhar,4,Warsaj,2,Sar Yawaar,18,Building,13,4,0,TRUE
+1813180,69.96602738,36.28176721,2,Past Aab Secondary School,Takhar,3,Warsaj,1,Past Aab,18,Building,13,3,0,TRUE
+1813181,70.02469494,36.1512419,2,Ishrafia High School,Takhar,4,Warsaj,2,Miyan Shahr,18,Building,13,4,0,TRUE
+1813182,70.24337571,36.11807266,2,Pyo Primary School,Takhar,3,Warsaj,1,Pyo,18,Building,13,3,0,TRUE
+1813202,70.03027765,35.98678433,1,Sarweghnan Mosque,Takhar,2,Warsaj,1,Sarweghnan,18,Building,13,2,0,TRUE
+1813203,70.14583205,36.23112784,1,Iskowan Mosque,Takhar,2,Warsaj,1,Iskowan,18,Building,13,2,0,TRUE
+1813213,69.87946229,36.20651738,2,Secondary School,Takhar,3,Warsaj,1,Trsht,18,Building,13,3,0,TRUE
+1814155,69.53992667,37.33827908,3,Khwaja Bahauddin Boys High School,Takhar,4,Khwaja Bahawudin,1,Markaz Shahr,18,Building,14,4,0,TRUE
+1814156,69.53044711,37.33687851,2,Imam Abu Hanifa High School,Takhar,3,Khwaja Bahawudin,1,Afghania,18,Building,14,3,0,TRUE
+1814157,69.49193,37.30916,2,Katak Jar Boys High School,Takhar,3,Khwaja Bahawudin,1,Katak Jar,18,Building,14,3,0,TRUE
+1814158,69.54459904,37.40453475,2,Abdul Shakoor Shaheed High School,Takhar,3,Khwaja Bahawudin,1,Kuhna Shakh,18,Building,14,3,0,TRUE
+1814159,69.56883895,37.3660858,2,Lala Guzar School,Takhar,3,Khwaja Bahawudin,1,Lala Guzar,18,Building,14,3,0,TRUE
+1814160,69.51162732,37.30768965,2,Shortoghai Mosque,Takhar,3,Khwaja Bahawudin,1,Shortoghai,18,Building,14,3,0,TRUE
+1814199,69.59364006,37.38320828,1,Aroq Qashlaq Primary School,Takhar,2,Khwaja Bahawudin,1,Aroq Qashlaq,18,Building,14,2,0,TRUE
+1815161,69.45505,37.38694444,3,Darqad Boys High School,Takhar,4,Darqad,1,Darqad,18,Building,15,4,0,TRUE
+1815162,69.42913,37.42088,2,Qara Tapa Boys High School,Takhar,3,Darqad,1,Qara Tapa,18,Building,15,3,0,TRUE
+1815163,69.51085935,37.48043093,2,Qaghni Boys High School,Takhar,3,Darqad,1,Qaghni,18,Building,15,3,0,TRUE
+1815164,69.41785,37.38081,2,Musa Zai Secondary School,Takhar,3,Darqad,1,Taraki,18,Building,15,3,0,TRUE
+1815165,69.51143888,37.52062777,2,Lala Maidan School,Takhar,3,Darqad,1,Lala Maidan,18,Building,15,3,0,TRUE
+1815166,69.53602307,37.43969279,2,Qol Abad Boys High School,Takhar,3,Darqad,1,Qol Abad,18,Building,15,3,0,TRUE
+1815167,69.49079166,37.36511111,1,Darwaza Pata Secondary School,Takhar,2,Darqad,1,Darwaza Pata,18,Building,15,2,0,TRUE
+1815168,69.52294722,37.50453055,2,Kol Toot Mosque,Takhar,3,Darqad,1,Kol Toot,18,Building,15,3,0,TRUE
+1815214,69.508848726,37.408874757,2,Darwaza Female School,Takhar,3,Darqad,1,Shor Arab,18,Building,15,3,0,TRUE
+1816132,69.80574714,37.39656296,4,Eidgah Madrassa,Takhar,6,Chah Ab,2,Markaz Shahr,18,Building,16,6,0,TRUE
+1816133,69.80882027,37.39746619,4,Chaah Aab Boys High School,Takhar,6,Chah Ab,2,Markaz Shahr,18,Building,16,6,0,TRUE
+1816134,69.81906761,37.39460959,3,Chaah Aab Primary School,Takhar,6,Chah Ab,3,Markaz Shahr,18,Building,16,6,0,TRUE
+1816135,69.80869,37.29311,2,Imam Azam High School,Takhar,4,Chah Ab,2,Khulyan,18,Building,16,4,0,TRUE
+1816136,69.89111965,37.44495999,2,Arg Shah Secondary School,Takhar,4,Chah Ab,2,Arg Shah,18,Building,16,4,0,TRUE
+1816137,69.86777777,37.59583333,2,Samti Secondary School,Takhar,4,Chah Ab,2,Samti,18,Building,16,4,0,TRUE
+1816138,69.82402725,37.49352474,2,Khasaar Primary School,Takhar,4,Chah Ab,2,Khasaar,18,Building,16,4,0,TRUE
+1816139,69.74333333,37.535,2,Hody Secondary School,Takhar,4,Chah Ab,2,Hody,18,Building,16,4,0,TRUE
+1816140,69.87341488,37.37011315,2,Warankhwah Secondary School,Takhar,4,Chah Ab,2,Warankhwah,18,Building,16,4,0,TRUE
+1816141,69.94914463,37.33794995,2,Shah Dara Secondary School,Takhar,4,Chah Ab,2,Shah Dara,18,Building,16,4,0,TRUE
+1816142,69.89604395,37.48105749,2,Anjeer Secondary School,Takhar,4,Chah Ab,2,Anjeer,18,Building,16,4,0,TRUE
+1816143,69.89178471,37.40580521,1,Gazan Primary School,Takhar,2,Chah Ab,1,Gazan,18,Building,16,2,0,TRUE
+1816144,70.05272822,37.39449795,1,Rabaat Hameeduddin Mosque,Takhar,2,Chah Ab,1,Rabaat Hameeduddin,18,Building,16,2,0,TRUE
+1816145,69.95286145,37.56468846,1,Enjeez Central Mosque,Takhar,2,Chah Ab,1,Markazi Enjeez,18,Building,16,2,0,TRUE
+1816198,69.88651889,37.37950979,1,Guzar Safkan Primary School,Takhar,2,Chah Ab,1,Guzar Safkan,18,Building,16,2,0,TRUE
+1816215,69.969489654,37.31883716,2,Mosque,Takhar,3,Chah Ab,1,Dara Bashir,18,Building,16,3,0,TRUE
+1817146,69.60491809,37.41006555,4,Kaftar Ali Secondary School,Takhar,7,Yangi Qala,3,Kaftar Ali,18,Building,17,7,0,TRUE
+1817147,69.59790143,37.44670159,2,Irmajar Mosque,Takhar,4,Yangi Qala,2,Irmajar,18,Building,17,4,0,TRUE
+1817148,69.70248393,37.47510051,2,Jalga High School,Takhar,4,Yangi Qala,2,Jalga,18,Building,17,4,0,TRUE
+1817149,69.61461095,37.46662471,3,Yangi Qala High School,Takhar,4,Yangi Qala,1,Makhmal Guzar,18,Building,17,4,0,TRUE
+1817150,69.56224547,37.4301412,2,Umar Khel School,Takhar,4,Yangi Qala,2,Umar Khel,18,Building,17,4,0,TRUE
+1817151,69.63841732,37.47221885,2,Raheem Abad School,Takhar,4,Yangi Qala,2,Raheem Abad,18,Building,17,4,0,TRUE
+1817152,69.7377365,37.40977759,1,Mughlan Secondary School,Takhar,2,Yangi Qala,1,Mughlan,18,Building,17,2,0,TRUE
+1817153,69.68014154,37.50643774,2,Jarbashi School,Takhar,3,Yangi Qala,1,Jarbashi,18,Building,17,3,0,TRUE
+1817154,69.58568804,37.52344887,1,Eshan Abad High School,Takhar,2,Yangi Qala,1,Eshan Abad,18,Building,17,2,0,TRUE
+1901001,68.86200577,36.72560181,7,Takharestan Mosque,Kunduz,7,Kunduz,0,D02 - Nahia 2,19,Building,1,6,1,TRUE
+1901002,68.85351826,36.71477922,3,Veterinary Clinic,Kunduz,5,Kunduz,2,14Th Road,19,Building,1,5,0,TRUE
+1901003,68.878826,36.70589307,7,Ghazi Khan High School,Kunduz,10,Kunduz,3,D05 - Nahia 5,19,Building,1,11,0,TRUE
+1901004,68.87379756,36.72259749,3,Fatima Zahra High School,Kunduz,6,Kunduz,3,D01 - Nahia 1,19,Building,1,6,0,TRUE
+1901005,68.85709949,36.72819679,3,Speen Zar Company,Kunduz,5,Kunduz,2,D03 - Nahia 3,19,Building,1,5,0,TRUE
+1901006,68.88428099,36.72398589,4,Khwaja Mashhad High School,Kunduz,5,Kunduz,1,D04 - Nahia 4,19,Building,1,6,0,TRUE
+1901007,68.86837624,36.72394432,6,Sher Khan High School,Kunduz,8,Kunduz,2,D02 - Nahia 2,19,Building,1,8,0,TRUE
+1901008,68.86171283,36.72748189,2,Girls Central High School,Kunduz,8,Kunduz,6,D02 - Nahia 2,19,Building,1,8,0,TRUE
+1901009,68.8622415,36.71765339,3,Speen Zar Hospital,Kunduz,6,Kunduz,3,D02 - Nahia 2,19,Building,1,6,0,TRUE
+1901010,68.86304798,36.71288946,5,Hazrat Ali High School,Kunduz,7,Kunduz,2,D02 - Nahia 2,19,Building,1,8,0,TRUE
+1901011,68.86846013,36.72269586,5,Law Department,Kunduz,7,Kunduz,2,D02 - Nahia 2,19,Building,1,7,0,TRUE
+1901012,68.86292863,36.71660525,3,Women Affairs Department,Kunduz,7,Kunduz,4,D02 - Nahia 2,19,Building,1,7,0,TRUE
+1901013,68.86020882,36.74599016,3,Turkmans Secondary School,Kunduz,6,Kunduz,3,D03 - Nahia 3,19,Building,1,6,0,TRUE
+1901014,68.86636625,36.73787679,3,Bibi Ayesha Sediqa High School,Kunduz,8,Kunduz,5,D03 - Nahia 3,19,Building,1,8,0,TRUE
+1901015,68.87099521,36.72249638,3,Municipality Office,Kunduz,5,Kunduz,2,D01 - Nahia 1,19,Building,1,5,0,TRUE
+1901016,68.86087271,36.73004842,4,Central Statistics Office,Kunduz,6,Kunduz,2,D03 - Nahia 3,19,Building,1,6,0,TRUE
+1901017,68.87672856,36.72574396,5,Mawlawi Sirajuddin High School,Kunduz,8,Kunduz,3,D04 - Nahia 4,19,Building,1,8,0,TRUE
+1901018,68.85103612,36.73224211,5,Zakhil High School,Kunduz,8,Kunduz,3,D03 - Nahia 3,19,Building,1,8,0,TRUE
+1901019,68.87174422,36.73619119,3,Immigrants & Returnees Department,Kunduz,5,Kunduz,2,D03 - Nahia 3,19,Building,1,5,0,TRUE
+1901020,68.86723702,36.74705784,4,Kuhan Duzh High School,Kunduz,6,Kunduz,2,D03 - Nahia 3,19,Building,1,6,0,TRUE
+1901021,68.84858644,36.70317013,4,Zakhil Khamdan,Kunduz,5,Kunduz,1,D03 - Nahia 3,19,Building,1,6,0,TRUE
+1901022,68.92806091,36.75547068,3,Bota Kashan High School,Kunduz,5,Kunduz,2,Bota Kashan Village,19,Building,1,5,0,TRUE
+1901023,68.78248984,36.82496862,3,Asqalan High School,Kunduz,5,Kunduz,2,Asqalan Village,19,Building,1,5,0,TRUE
+1901024,68.83572382,36.75407945,3,Zar Khareed Otmanzai High School,Kunduz,5,Kunduz,2,D03 - Nahia 3,19,Building,1,5,0,TRUE
+1901025,68.7147415,36.85171182,3,Tobra Kash School,Kunduz,4,Kunduz,1,Tobra Kash,19,Village,1,4,0,TRUE
+1901026,68.88841092,36.79462406,4,Taimori Alcheen School,Kunduz,5,Kunduz,1,Taimori Alcheen,19,Building,1,5,0,TRUE
+1901027,68.90944444,36.75916666,5,Hazrat Sultan High School,Kunduz,8,Kunduz,3,Hazrat Sultan,19,Building,1,8,0,TRUE
+1901028,68.96579177,36.7317496,5,Qochi Kalan School,Kunduz,8,Kunduz,3,Qochi Kalan,19,Building,1,8,0,TRUE
+1901029,68.98337469,36.65954073,3,Malraghi Girls High School,Kunduz,4,Kunduz,1,Malraghi,19,Building,1,1,3,TRUE
+1901030,68.89776826,36.71145551,3,Chala Mazar School,Kunduz,5,Kunduz,2,D01 - Nahia 1,19,Building,1,5,0,TRUE
+1901031,68.81002074,36.80085835,3,Taloka Girls School,Kunduz,5,Kunduz,2,Taloka,19,Building,1,5,0,TRUE
+1901032,68.99194444,36.72388888,3,Kobahi High School,Kunduz,5,Kunduz,2,Kobahi,19,Building,1,5,0,TRUE
+1901033,68.88914245,36.667296,3,Angoor Bagh School,Kunduz,5,Kunduz,2,Angoor Bagh,19,Building,1,5,0,TRUE
+1901034,68.9462846,36.68827771,3,Bagh Meri High School,Kunduz,4,Kunduz,1,Bagh Meri Payeen,19,Building,1,4,0,TRUE
+1901035,68.68163358,36.82882598,2,Wakil Qara High School,Kunduz,3,Kunduz,1,Wakil Qara,19,Building,1,3,0,TRUE
+1901036,68.92083377,36.68202651,3,Bolak Awal Secondary School,Kunduz,4,Kunduz,1,Bolak Awal,19,Building,1,3,1,TRUE
+1901038,68.9440444,36.67753118,3,Kata Khel Secondary School,Kunduz,4,Kunduz,1,Kata Khel,19,Building,1,3,1,TRUE
+1901039,68.70892894,36.79114775,2,Gharma Kamar School,Kunduz,3,Kunduz,1,Gharma Kamar Village,19,Village,1,3,0,TRUE
+1901040,68.74374111,36.79856963,2,Sultan Ghiyasuddin High School,Kunduz,3,Kunduz,1,Larkhabi,19,Building,1,3,0,TRUE
+1901041,68.70075021,36.8107896,2,Gul Tipa Secondary School,Kunduz,3,Kunduz,1,Arabha Village,19,Building,1,3,0,TRUE
+1901042,68.76344488,36.77886502,2,Shinwari Secondary School,Kunduz,3,Kunduz,1,Shinwari Village,19,Building,1,3,0,TRUE
+1901043,68.892646491,36.655840985,2,Qazaq Mosque,Kunduz,4,Kunduz,2,Qaraq Village,19,Building,1,6,0,TRUE
+1901044,68.91916666,36.73083333,2,Khazani Secondary School,Kunduz,4,Kunduz,2,Khazani Village,19,Building,1,2,2,TRUE
+1901045,68.9770713,36.70316925,2,Tarno School,Kunduz,4,Kunduz,2,Tarnaw Village,19,Building,1,4,0,TRUE
+1901046,68.81255843,36.75727237,2,Bagh Shirkat Secondary School,Kunduz,3,Kunduz,1,Bagh Shirkat,19,Building,1,3,0,TRUE
+1901047,68.68143154,36.82878112,2,Qashlesh School,Kunduz,3,Kunduz,1,Qashlesh Wakil Qara Village,19,Village,1,3,0,TRUE
+1901048,68.98758546,36.74977559,2,Choqor Qishlaq School,Kunduz,4,Kunduz,2,Choqor Qishlaq Village,19,Building,1,4,0,TRUE
+1901049,68.88341666,36.69805555,2,Medyoteek Markaz,Kunduz,3,Kunduz,1,D05 - Nahia 5,19,Building,1,4,0,TRUE
+1901050,68.745034,36.8460467,2,Besh Bala Mosque,Kunduz,4,Kunduz,2,Asqalan Village,19,Village,1,4,0,TRUE
+1901052,68.80833333,36.82972222,2,Arbab Chari Secondary School,Kunduz,4,Kunduz,2,Qoy Guzar,19,Building,1,4,0,TRUE
+1901053,68.85138117,36.8192875,2,Arbab Mohammad Ali School,Kunduz,4,Kunduz,2,Alu Shah Village,19,Building,1,4,0,TRUE
+1901054,68.83113969,36.75686472,2,Zarkhareed Zakhil Mosque,Kunduz,3,Kunduz,1,Zarkhareed Zakhil,19,Building,1,3,0,TRUE
+1901055,68.85946526,36.813574,2,Haji Nasruddin Mosque,Kunduz,3,Kunduz,1,Asqalan Village,19,Building,1,3,0,TRUE
+1901056,68.83289682,36.7950676,2,Damshaakh Secondary School,Kunduz,4,Kunduz,2,Damshaakh Aalchin,19,Building,1,4,0,TRUE
+1901197,68.89328844,36.69371522,2,Rostaq Abad Secondary School,Kunduz,3,Kunduz,1,D05 - Nahia 5,19,Building,1,4,0,TRUE
+1901198,68.94231976,36.75126637,2,Qochi Khord Secondary School,Kunduz,3,Kunduz,1,Qochi Khord Village,19,Building,1,3,0,TRUE
+1901199,68.92178364,36.80369965,2,Tapa Ali School,Kunduz,3,Kunduz,1,Tapa Ali Village,19,Building,1,3,0,TRUE
+1902114,68.7968554,36.69200327,3,Jamiyat High School,Kunduz,5,Char Dara,2,Chardara Markaz,19,Building,2,5,0,TRUE
+1902115,68.849979684,36.632766822,2,Salarzai Mosque,Kunduz,3,Char Dara,1,Naqil Salarzai,19,Building,2,3,0,TRUE
+1902116,68.857271302,36.594924153,2,Mohammad Fataah Shaheed High School,Kunduz,3,Char Dara,1,Qasab Village,19,Building,2,3,0,TRUE
+1902117,68.837517,36.6485806,4,Gharo Qeshlaq High School,Kunduz,6,Char Dara,2,Gharo Qeshlaq,19,Building,2,4,2,TRUE
+1902118,68.83384954,36.65961796,2,Amir Mohammad Shinwari Mosque,Kunduz,3,Char Dara,1,Qatl Aam,19,Village,2,3,0,TRUE
+1902120,68.81701077,36.73469508,5,Yateem Village School,Kunduz,7,Char Dara,2,Yateem Village,19,Building,2,7,0,TRUE
+1902122,68.68682829,36.78070283,2,Ainul Majar High School,Kunduz,4,Char Dara,2,Ainul Majar,19,Building,2,2,2,TRUE
+1902123,68.64297649,36.74570128,1,Dagh Aaraq Primary School,Kunduz,2,Char Dara,1,Dagh Aaraq,19,Building,2,2,0,TRUE
+1902125,68.64747777,36.78242777,2,Juma Bazar Mosque,Kunduz,3,Char Dara,1,Juma Bazar,19,Building,2,3,0,TRUE
+1902127,68.72986111,36.70166111,5,Nawabad School,Kunduz,7,Char Dara,2,Nawabad,19,Building,2,7,0,TRUE
+1903129,68.90697406,36.50373223,3,Ali Abad Boys High School,Kunduz,5,Ali Abad,2,Laqi Ha,19,Building,3,5,0,TRUE
+1903130,68.87198228,36.5813091,3,Mir Shekh High School,Kunduz,5,Ali Abad,2,Mir Shekh Village,19,Building,3,5,0,TRUE
+1903131,68.87433149,36.52009674,3,Lala Maidan Secondary School,Kunduz,5,Ali Abad,2,Lala Maidan Village,19,Building,3,5,0,TRUE
+1903132,68.90158987,36.60156843,3,Samiullah  Shaheed Secondary School,Kunduz,5,Ali Abad,2,Madrassa Village,19,Building,3,5,0,TRUE
+1903133,68.90688788,36.55056997,3,Larkhabi Boys High School,Kunduz,5,Ali Abad,2,Arbab Ramazani Village,19,Building,3,5,0,TRUE
+1903134,68.88099484,36.44345373,2,Qazal Say Secondary School,Kunduz,4,Ali Abad,2,Qazal Say Village,19,Building,3,4,0,TRUE
+1903135,68.87547461,36.54254131,1,Sayed Ahmad Boys School,Kunduz,2,Ali Abad,1,Sayed Ahmad Village,19,Building,3,2,0,TRUE
+1903136,68.90026763,36.54038154,3,Haji Hussain Girls Secondary School,Kunduz,5,Ali Abad,2,Haji Hussain,19,Building,3,5,0,TRUE
+1903137,68.89259566,36.62197523,3,Shana Tipa High School,Kunduz,4,Ali Abad,1,Sheen Tipa,19,Building,3,4,0,TRUE
+1903138,68.90064465,36.51907004,3,Khel Gada Mosque,Kunduz,5,Ali Abad,2,Khel Gada Village,19,Building,3,5,0,TRUE
+1903139,69.045039581,36.439059549,2,Zangi Say School,Kunduz,4,Ali Abad,2,Zangi Say Village,19,Village,3,4,0,TRUE
+1903140,68.904435,36.576103,2,Pul Kheshti High School,Kunduz,4,Ali Abad,2,Pul Kheshti Village,19,Building,3,4,0,TRUE
+1903208,68.89014772,36.5615817,2,Arza Begi Girls Secondary School,Kunduz,4,Ali Abad,2,Arz Begi Village,19,Building,3,4,0,TRUE
+1903209,68.8566453,36.57698835,1,Mir Shekh Secondary School,Kunduz,2,Ali Abad,1,Mir Shekh Village,19,Building,3,2,0,TRUE
+1903217,68.9198675,36.48289588,2,Cheep Secondary School,Kunduz,4,Ali Abad,2,Cheep Village,19,Building,3,4,0,TRUE
+1903218,68.919768789,36.482876602,2,Secondary School,Kunduz,3,Ali Abad,1,Cheep,19,Building,3,3,0,TRUE
+1904141,69.11995638,36.68411019,5,Mohammad Hassan Miakhel High School,Kunduz,5,Khan Abad,0,D01 - Nahia 1,19,Building,4,5,0,TRUE
+1904142,69.18399433,36.69974173,2,Chogha High School,Kunduz,3,Khan Abad,1,Chogha Village,19,Building,4,3,0,TRUE
+1904143,69.08195543,36.73439478,2,Aaqtash High School,Kunduz,3,Khan Abad,1,Aaqtash Village,19,Building,4,3,0,TRUE
+1904144,69.03577269,36.72209831,2,Haji Yusuf Bohin High School,Kunduz,3,Khan Abad,1,Boheen Sufla,19,Building,4,3,0,TRUE
+1904145,69.01943716,36.7028623,2,Nikpay Village Mosque,Kunduz,3,Khan Abad,1,Nekpay Village,19,Building,4,3,0,TRUE
+1904147,69.04026659,36.65933467,1,Swedan Primary School,Kunduz,2,Khan Abad,1,Adam Khan Village,19,Building,4,2,0,TRUE
+1904148,69.17391954,36.60591463,1,Sweka Mosque,Kunduz,2,Khan Abad,1,Sweka Village,19,Building,4,2,0,TRUE
+1904149,69.03992191,36.57633979,1,Musa Zai School,Kunduz,2,Khan Abad,1,Shorab Village,19,Building,4,2,0,TRUE
+1904150,69.11793826,36.48750198,1,Chonai Secondary School,Kunduz,2,Khan Abad,1,Chonai Village,19,Building,4,2,0,TRUE
+1904151,69.10770113,36.66545241,1,Chahar Toot High School,Kunduz,2,Khan Abad,1,Chahar Toot Oryakhel,19,Building,4,2,0,TRUE
+1904152,69.06063069,36.67390468,1,Chahar Sari School,Kunduz,2,Khan Abad,1,Chahar Sari Village,19,Building,4,2,0,TRUE
+1904153,69.21393388,36.73814906,1,Abshor Jolicha High School,Kunduz,2,Khan Abad,1,Jolicha Village,19,Building,4,2,0,TRUE
+1904154,69.1133358,36.67996765,0,Khan Abad Girls High School,Kunduz,3,Khan Abad,3,D04 - Nahia 4 Khan Abad City,19,Building,4,3,0,TRUE
+1904155,69.15790724,36.645819,1,Wadan Kalai Secondary School,Kunduz,2,Khan Abad,1,Dahan Deh Weran,19,Building,4,2,0,TRUE
+1904156,69.12034998,36.44235409,1,Zangi Say Primary School,Kunduz,2,Khan Abad,1,Zangi Say Village,19,Building,4,2,0,TRUE
+1904158,69.01959603,36.6930872,1,Sadr Ramazan Boys High School,Kunduz,2,Khan Abad,1,Sadr Ramazan Village,19,Building,4,2,0,TRUE
+1904159,69.01726078,36.67582271,1,Khwaja Pasta Secondary School,Kunduz,2,Khan Abad,1,Khwaja Pasta Village,19,Building,4,2,0,TRUE
+1904160,69.13513209,36.70512121,1,Kuhna Qala Secondary School,Kunduz,2,Khan Abad,1,Band-E-Barq,19,Building,4,2,0,TRUE
+1904161,69.05851833,36.69563012,1,Jangal Bashi Boys High School,Kunduz,2,Khan Abad,1,Jangal Bashi,19,Building,4,2,0,TRUE
+1904162,69.00090854,36.68219139,1,Nikpay Khord Girls High School,Kunduz,2,Khan Abad,1,Nikpay Village,19,Building,4,4,0,TRUE
+1904163,69.04875937,36.71277315,1,Boheen Clinic,Kunduz,2,Khan Abad,1,Boheen Ulya Village,19,Building,4,2,0,TRUE
+1904164,69.07301559,36.74992984,1,Taqa Chinar Secondary School,Kunduz,2,Khan Abad,1,Taqa Chinar Village,19,Building,4,2,0,TRUE
+1904165,69.0384,36.77918,1,Laghmani School,Kunduz,2,Khan Abad,1,Laghmani Village,19,Village,4,2,0,TRUE
+1904166,69.02256893,36.78528391,1,Ibrahim Khel School,Kunduz,2,Khan Abad,1,Ibrahim Khel Village,19,Building,4,2,0,TRUE
+1904167,69.08243442,36.71205862,1,Basoos Mosaque,Kunduz,2,Khan Abad,1,Basoos Village,19,Building,4,2,0,TRUE
+1904168,69.0004576,36.79421081,1,Parcha Dasht School,Kunduz,2,Khan Abad,1,Parcha Dasht Village,19,Building,4,2,0,TRUE
+1904170,69.20871819,36.53660462,1,Ochqadaq Juma Khowani Mosque,Kunduz,2,Khan Abad,1,Ochqadaq Village,19,Building,4,2,0,TRUE
+1904171,69.09747447,36.57941545,1,Sondoq Say Juma Khowani Mosque,Kunduz,2,Khan Abad,1,Sondoq Say Village,19,Building,4,2,0,TRUE
+1904173,69.10776418,36.69258124,2,Hayatullah Abad Clinic,Kunduz,3,Khan Abad,1,Hayatullah Abad Village,19,Building,4,3,0,TRUE
+1904174,69.12361111,36.53083333,1,Arab Qadaq School,Kunduz,2,Khan Abad,1,Arab Qadaq Village,19,Building,4,2,0,TRUE
+1904175,69.15901857,36.51872131,2,Lala Kai Secondary School,Kunduz,3,Khan Abad,1,Lalai Kai Village,19,Building,4,3,0,TRUE
+1904176,69.07045269,36.73299298,2,Srai Qeshlaq Madrassa,Kunduz,3,Khan Abad,1,Srai Qeshlaq Village,19,Building,4,3,0,TRUE
+1904177,69.02222388,36.78551271,1,Ibrahim Khel Kochi School,Kunduz,2,Khan Abad,1,Ibrahim Khel Kochi Village,19,Building,4,2,0,TRUE
+1904210,69.1211009,36.58659054,1,Miyali Mosque,Kunduz,2,Khan Abad,1,Dara-E-Miyali Awal Village,19,Building,4,2,0,TRUE
+1904211,69.05490445,36.76565211,2,Sajjani School,Kunduz,3,Khan Abad,1,Sajjani Village,19,Building,4,3,0,TRUE
+1904212,69.09327358,36.64066403,3,Dagaree Secondary School,Kunduz,4,Khan Abad,1,Dagaree Chahartoot Village,19,Building,4,4,0,TRUE
+1904213,69.12721338,36.35334263,1,Nayman Mosque,Kunduz,2,Khan Abad,1,Nayman Village,19,Building,4,2,0,TRUE
+1905057,69.18715305,37.10871587,4,Kulbad School,Kunduz,6,Hazrat-E-Imam Sahib,2,Kulbad Village,19,Building,5,6,0,TRUE
+1905058,69.08615869,37.10703345,3,Kol Daman School,Kunduz,6,Hazrat-E-Imam Sahib,3,Kol Daman Village,19,Building,5,6,0,TRUE
+1905059,68.87216748,37.13813843,3,Majar School,Kunduz,5,Hazrat-E-Imam Sahib,2,Majar Village,19,Building,5,5,0,TRUE
+1905060,68.85426729,37.15892612,3,Ajghan High School,Kunduz,4,Hazrat-E-Imam Sahib,1,Ajghan Village,19,Building,5,4,0,TRUE
+1905061,69.06742308,37.11896264,1,Qotr Blaaq School,Kunduz,2,Hazrat-E-Imam Sahib,1,Qotr Blaaq,19,Building,5,2,0,TRUE
+1905062,69.00267664,37.04520989,1,Jan Chashma School,Kunduz,2,Hazrat-E-Imam Sahib,1,Jan Chashma Village,19,Village,5,2,0,TRUE
+1905063,68.61221443,37.1908391,3,Sher Khan Bandar School,Kunduz,4,Hazrat-E-Imam Sahib,1,Sher Khan Bandar,19,Building,5,4,0,TRUE
+1905064,68.79745014,37.17330944,3,Basoos School,Kunduz,5,Hazrat-E-Imam Sahib,2,Basoos,19,Building,5,5,0,TRUE
+1905065,69.00382111,37.18507514,3,Eshantop Primary School,Kunduz,6,Hazrat-E-Imam Sahib,3,Eshantop,19,Building,5,6,0,TRUE
+1905067,68.94444444,37.21777777,3,Qarghan Tapa Secondary School,Kunduz,4,Hazrat-E-Imam Sahib,1,Qorghan Tapa,19,Building,5,4,0,TRUE
+1905068,68.90152126,37.24561028,2,Aaq Masjid School,Kunduz,3,Hazrat-E-Imam Sahib,1,Aaq Masjid Village,19,Building,5,3,0,TRUE
+1905069,68.97763517,37.17923809,3,Ismail Qashlaq Secondary School,Kunduz,4,Hazrat-E-Imam Sahib,1,Ismail Qashlaq Village,19,Building,5,4,0,TRUE
+1905070,69.03041795,37.1883554,2,Hechkalai School,Kunduz,4,Hazrat-E-Imam Sahib,2,Hechkalai Village,19,Building,5,4,0,TRUE
+1905071,69.02833333,37.17472222,2,Gujar School,Kunduz,4,Hazrat-E-Imam Sahib,2,Gujar Village,19,Building,5,4,0,TRUE
+1905072,69.0681485,37.1832035,2,Yaka Toot School,Kunduz,3,Hazrat-E-Imam Sahib,1,Yaka Toot Village,19,Building,5,3,0,TRUE
+1905073,68.90350455,37.18603908,2,Naswan Markazi High School,Kunduz,5,Hazrat-E-Imam Sahib,3,D03 - Nahia 3,19,Building,5,5,0,TRUE
+1905074,68.97864311,37.20008673,5,Alef Berdy School,Kunduz,7,Hazrat-E-Imam Sahib,2,Alef Berdy Village,19,Building,5,7,0,TRUE
+1905075,68.98873314,37.24019986,1,Aamoo School,Kunduz,2,Hazrat-E-Imam Sahib,1,Pul Mudeer Jangal,19,Building,5,2,0,TRUE
+1905077,68.95078373,37.14290079,1,Joy Begum School,Kunduz,2,Hazrat-E-Imam Sahib,1,Joy Begum Village,19,Village,5,2,0,TRUE
+1905078,68.97445482,37.14156612,2,Gunbad Secondary School,Kunduz,3,Hazrat-E-Imam Sahib,1,Gunbad,19,Building,5,3,0,TRUE
+1905079,69.04003128,37.13732282,3,Aalchin School,Kunduz,4,Hazrat-E-Imam Sahib,1,Aalcheen Village,19,Village,5,4,0,TRUE
+1905080,69.14002885,37.09299595,1,Tash Guzar School,Kunduz,2,Hazrat-E-Imam Sahib,1,Tash Guzar Village,19,Village,5,2,0,TRUE
+1905081,69.11845785,37.10887069,2,Gharo School,Kunduz,4,Hazrat-E-Imam Sahib,2,Gharo Village,19,Building,5,4,0,TRUE
+1905082,68.92431278,37.1818277,2,Imam Sahib Number 1 School,Kunduz,4,Hazrat-E-Imam Sahib,2,D04 - Nahia 4,19,Building,5,4,0,TRUE
+1905083,69.08935999,37.15723,2,Khatoon Qala School,Kunduz,3,Hazrat-E-Imam Sahib,1,Khatoon Qala Village,19,Building,5,3,0,TRUE
+1905084,69.06483988,37.14494839,3,Aftab Laq High School,Kunduz,4,Hazrat-E-Imam Sahib,1,Aftab Laq Village,19,Building,5,4,0,TRUE
+1905085,68.6875416,37.15412301,3,Kotrama High School,Kunduz,4,Hazrat-E-Imam Sahib,1,Kotrama Barzangi Village,19,Building,5,6,0,TRUE
+1905086,68.83959884,37.13920278,4,Besh Kapa Secondary School,Kunduz,6,Hazrat-E-Imam Sahib,2,Besh Kapa,19,Building,5,6,0,TRUE
+1905087,68.75873177,37.15174841,3,Zard Kamar School,Kunduz,4,Hazrat-E-Imam Sahib,1,Zard Kamar,19,Building,5,4,0,TRUE
+1905088,68.85840906,37.19465167,3,Qanjogha School,Kunduz,4,Hazrat-E-Imam Sahib,1,Qanjogha,19,Building,5,4,0,TRUE
+1905089,68.77955692,37.21948104,3,Qara Wol School,Kunduz,4,Hazrat-E-Imam Sahib,1,Qara Wol,19,Building,5,4,0,TRUE
+1905090,68.8067087,37.19832569,3,Noori Primary School,Kunduz,4,Hazrat-E-Imam Sahib,1,Arab Qashlaq,19,Building,5,4,0,TRUE
+1905091,68.90239835,37.18062858,4,Imam Sahib Boys High School,Kunduz,5,Hazrat-E-Imam Sahib,1,D03 - Nahia 3,19,Building,5,5,0,TRUE
+1905092,68.91420156,37.19689203,3,Imam Sahib Number 2 High School,Kunduz,4,Hazrat-E-Imam Sahib,1,Aqbaay,19,Building,5,4,0,TRUE
+1905093,68.89822911,37.19456548,3,Nomania Secondary School,Kunduz,4,Hazrat-E-Imam Sahib,1,Imam Sahib City,19,Building,5,4,0,TRUE
+1905094,68.90591411,37.15549619,3,Ortablaqi School,Kunduz,4,Hazrat-E-Imam Sahib,1,Ota Blaqiha Village,19,Building,5,4,0,TRUE
+1905095,68.90664522,37.22435285,3,Aab Froshan School,Kunduz,4,Hazrat-E-Imam Sahib,1,Aab Froshan,19,Building,5,4,0,TRUE
+1905096,68.89104174,37.22026304,3,Jaihoon Primary School,Kunduz,4,Hazrat-E-Imam Sahib,1,Halqa Kol,19,Building,5,4,0,TRUE
+1905097,68.82056095,37.15849385,2,Mirza Abdul Qadir Bedal High School,Kunduz,4,Hazrat-E-Imam Sahib,2,Bataash Village,19,Building,5,4,0,TRUE
+1905098,68.80953311,37.21531323,2,Bota Kashan Secondary School,Kunduz,4,Hazrat-E-Imam Sahib,2,Bota Kashan,19,Building,5,4,0,TRUE
+1905200,68.76687552,37.19376564,3,Murad Shaikh Secondary School,Kunduz,4,Hazrat-E-Imam Sahib,1,Murad Shaikh,19,Building,5,6,0,TRUE
+1905201,69.04223763,37.13017502,2,Juma Khowani Payeen Mosque,Kunduz,3,Hazrat-E-Imam Sahib,1,Qarya Chaghar,19,Building,5,3,0,TRUE
+1905202,68.902202,37.180855,3,Astaamang Mosque,Kunduz,4,Hazrat-E-Imam Sahib,1,Astameng Village,19,Village,5,4,0,TRUE
+1905203,68.88588963,37.25176804,2,Qari Khana Mosque,Kunduz,4,Hazrat-E-Imam Sahib,2,Qari Khana,19,Building,5,4,0,TRUE
+1906178,69.24043135,37.03393587,4,Jamhoriat High School,Kunduz,6,Dasht-E-Archi,2,Markaz Archi,19,Building,6,6,0,TRUE
+1906179,69.2657402,37.05068483,3,Qashqari Secondary School,Kunduz,4,Dasht-E-Archi,1,Tajik Qashlaq Village,19,Building,6,4,0,TRUE
+1906180,69.30041186,37.06969202,3,Hamid Qarlaq High Schoo,Kunduz,4,Dasht-E-Archi,1,Mirza Khel Village,19,Building,6,4,0,TRUE
+1906181,69.22566916,37.06053189,3,Kal Tarash School,Kunduz,4,Dasht-E-Archi,1,Kal Tarash Village,19,Building,6,4,0,TRUE
+1906182,69.29292288,37.06296645,4,Kobichi Mosque,Kunduz,6,Dasht-E-Archi,2,Kobichi Village,19,Building,6,6,0,TRUE
+1906183,69.15790732,37.03900074,2,Dawran Kalay Secondary School,Kunduz,3,Dasht-E-Archi,1,Dawran Kalay Village,19,Building,6,3,0,TRUE
+1906185,69.17453754,37.08745351,2,Mula Qali High School,Kunduz,3,Dasht-E-Archi,1,Mula Qali Village,19,Building,6,3,0,TRUE
+1906187,69.19323717,37.08433138,2,Habib Mosque,Kunduz,3,Dasht-E-Archi,1,Bagh Habib Village,19,Building,6,2,1,TRUE
+1906188,69.22347985,37.09148556,2,Shah Rawan School,Kunduz,3,Dasht-E-Archi,1,Shah Rawan Village,19,Building,6,3,0,TRUE
+1906189,69.27934477,36.91752539,3,Jaame Mosque,Kunduz,5,Dasht-E-Archi,2,Qara Ghoshi Uzbekya Village,19,Building,6,5,0,TRUE
+1906190,69.21916666,36.87805555,4,Gul Balaq Secondary School,Kunduz,5,Dasht-E-Archi,1,Gul Balaq,19,Building,6,5,0,TRUE
+1906193,69.10411987,37.08465025,3,Mesbaah School,Kunduz,5,Dasht-E-Archi,2,Jama Rajab Village,19,Building,6,5,0,TRUE
+1906194,69.25326023,36.92924731,1,Qara Ghoshi Pashtonia Mosque,Kunduz,2,Dasht-E-Archi,1,Qara Ghoshi Pashtonia Village,19,Building,6,1,1,TRUE
+1906214,69.13833333,37.05472222,1,Aamer Sadeq Mosque,Kunduz,2,Dasht-E-Archi,1,Aamer Sadeq Village,19,Building,6,2,0,TRUE
+1906215,69.21068933,37.03486767,1,Hajda Nehri Mosque,Kunduz,2,Dasht-E-Archi,1,Hajda Nehri Village,19,Building,6,1,1,TRUE
+1906216,69.26407131,36.87523939,3,Shereen Mosque,Kunduz,5,Dasht-E-Archi,2,Qozm Blaq Village,19,Building,6,4,1,TRUE
+1907099,68.43593494,37.00825714,4,Markazi Qala Zaal High School,Kunduz,5,Qala-E-Zal,1,Aarsari,19,Building,7,5,0,TRUE
+1907100,68.46818484,37.00067342,3,Orta Boz School,Kunduz,4,Qala-E-Zal,1,Orta Boz,19,Building,7,4,0,TRUE
+1907101,68.40754477,36.99315571,3,Dorman School,Kunduz,4,Qala-E-Zal,1,Dorman Village,19,Building,7,4,0,TRUE
+1907102,68.43523238,36.99311113,2,Saaleh High School,Kunduz,3,Qala-E-Zal,1,Saaleh Abad,19,Building,7,3,0,TRUE
+1907103,68.52374665,36.96084564,3,Tarbooz Guzar High School,Kunduz,4,Qala-E-Zal,1,Tarbooz Guzar,19,Building,7,4,0,TRUE
+1907104,68.19699003,36.98783315,3,Kolokh Tapa School,Kunduz,4,Qala-E-Zal,1,Kolokh Tapa,19,Building,7,4,0,TRUE
+1907105,68.62305903,36.90433139,2,Yangee Aaraq School,Kunduz,4,Qala-E-Zal,2,Yangee Aaraq,19,Building,7,4,0,TRUE
+1907106,68.60136352,36.89541021,1,Safi Kot School,Kunduz,2,Qala-E-Zal,1,Safi Kot,19,Building,7,2,0,TRUE
+1907107,68.58376371,36.93412301,2,Char Gul Tapa High School,Kunduz,3,Qala-E-Zal,1,Char Gul Tapa,19,Building,7,3,0,TRUE
+1907108,68.54270622,36.98160672,3,Aaq Tapa High School,Kunduz,4,Qala-E-Zal,1,Aaq Tapa,19,Building,7,4,0,TRUE
+1907109,68.52304527,37.01114514,3,Etihaad High School,Kunduz,4,Qala-E-Zal,1,Qoq Masjid,19,Building,7,3,1,TRUE
+1907110,68.39715131,37.03714247,2,Halqa Kol School,Kunduz,3,Qala-E-Zal,1,Halqa Kol,19,Building,7,3,0,TRUE
+1907111,68.06874757,36.92208757,1,Khesht Tapa School,Kunduz,2,Qala-E-Zal,1,Khesh Tapa,19,Building,7,2,0,TRUE
+1907112,68.132773,36.947773,1,Baghicha Secondary School,Kunduz,2,Qala-E-Zal,1,Baghicha,19,Building,7,2,0,TRUE
+1907113,68.54887437,36.92346851,1,Zulm Aabad School,Kunduz,2,Qala-E-Zal,1,Zulm Abad,19,Building,7,2,0,TRUE
+1907204,68.5395471,37.00601871,2,Haji Mula Ibrahim Mosque,Kunduz,3,Qala-E-Zal,1,Haji Ibrahim,19,Building,7,2,1,TRUE
+1907205,68.48010444,36.98186518,1,Se Kaparak School,Kunduz,2,Qala-E-Zal,1,Se Kaparak,19,Building,7,2,0,TRUE
+1907206,68.4795048,37.03603489,1,Sakhsa Kol School,Kunduz,2,Qala-E-Zal,1,Sakhsa Kol,19,Building,7,2,0,TRUE
+1907219,68.579586645,36.96337173,2,Secondary School,Kunduz,3,Qala-E-Zal,1,Shor Aruq,19,Building,7,3,0,TRUE
+2001001,67.961028,36.26489285,2,Manghar Madrassa,Samangan,3,Aybak,1,Manghar Village,20,Building,1,3,0,TRUE
+2001002,67.96102906,36.26491496,2,Qoch Nehal Secondary School,Samangan,4,Aybak,2,Qoch Nehal Village,20,Building,1,4,0,TRUE
+2001003,67.98770053,36.29106191,3,Joy Zhowandoon High School,Samangan,5,Aybak,2,Joy Zhowandoon Village,20,Building,1,6,0,TRUE
+2001004,67.93614158,36.34134364,3,Dalkhaky Secondary School,Samangan,4,Aybak,1,Dalkhalky Village,20,Building,1,5,0,TRUE
+2001005,68.00481111,36.30122222,3,Larghan Secondary School,Samangan,5,Aybak,2,Larghan Village,20,Building,1,5,0,TRUE
+2001006,68.00462688,36.30107661,4,Karte Khorasan Girls Secondary School,Samangan,6,Aybak,2,Aibak City,20,Building,1,7,0,TRUE
+2001007,68.01436191,36.26736187,0,Ajani Malki Girls High School,Samangan,9,Aybak,9,Aibak City,20,Building,1,9,0,TRUE
+2001008,68.01445748,36.26570462,9,Aibak Girls High School,Samangan,9,Aybak,0,Aibak City,20,Building,1,9,1,TRUE
+2001009,68.01336109,36.2640745,4,Sarqad Secondary School,Samangan,6,Aybak,2,Aibak City,20,Building,1,7,0,TRUE
+2001010,68.03055485,36.26679609,5,Aayencha High School,Samangan,8,Aybak,3,Aibak City,20,Building,1,9,0,TRUE
+2001011,68.03910147,36.25527062,3,Zahrabi Secondary School,Samangan,6,Aybak,3,Zahrabi Village,20,Building,1,7,0,TRUE
+2001012,68.05875612,36.21732567,4,Dara Zandan Girls School,Samangan,6,Aybak,2,Dare-E-Zendan Village,20,Building,1,6,0,TRUE
+2001013,68.07191163,36.17917273,3,Sara Kanda Secondary School,Samangan,4,Aybak,1,Sara Kanda Village,20,Building,1,4,0,TRUE
+2001014,68.02972845,36.32217109,1,Shalkato High School,Samangan,2,Aybak,1,Shalkato Village,20,Building,1,2,0,TRUE
+2001015,68.2231657,36.31685896,2,Sherekyaar Secondary School,Samangan,3,Aybak,1,Sherekyaar Village,20,Building,1,3,0,TRUE
+2001016,68.39623932,36.14580142,2,Rabatak Secondary School,Samangan,3,Aybak,1,Rabatak Village,20,Building,1,4,0,TRUE
+2001017,68.418950955,36.262881129,1,Baba Lar Primary School,Samangan,2,Aybak,1,Baba Lar Village,20,Building,1,2,0,TRUE
+2001018,68.479789377,36.234285089,2,Tekhonak Secondary School,Samangan,4,Aybak,2,Tekhonak Village,20,Building,1,4,0,TRUE
+2001087,68.04465693,36.24870062,3,Shahr Qadeem Girls School,Samangan,4,Aybak,1,Shahr Qadeem Village,20,Building,1,5,0,TRUE
+2001088,68.41353374,36.26575916,1,Chehl Kapa Mosque,Samangan,2,Aybak,1,Chehl Kapa Village,20,Village,1,2,0,TRUE
+2001089,68.044181537,36.268519488,2,Khwaja Burhan Secondary Schoo,Samangan,3,Aybak,1,Qara Ghaj Village,20,District,1,3,0,TRUE
+2002019,68.34083065,36.49362761,2,Omli Mosque,Samangan,3,Hazrat-E-Sultan,1,Omli Village,20,Building,2,3,0,TRUE
+2002020,68.07866966,36.49822874,2,Kulcha Girls Secondary School,Samangan,4,Hazrat-E-Sultan,2,Kulcha Village,20,Building,2,4,0,TRUE
+2002021,67.946166136,36.480708733,2,Qosh Bara Secondary School,Samangan,3,Hazrat-E-Sultan,1,Qosh Bara Village,20,Building,2,3,0,TRUE
+2002022,67.82924916,36.52187461,2,Dawlat Abad Secondary School,Samangan,3,Hazrat-E-Sultan,1,Dawlat Abad Village,20,Building,2,3,0,TRUE
+2002023,67.89622142,36.45507944,3,District Office,Samangan,4,Hazrat-E-Sultan,1,District Compound,20,Building,2,6,0,TRUE
+2002024,67.91642058,36.34153387,2,Kokjar Secondary School,Samangan,3,Hazrat-E-Sultan,1,Kokjar Village,20,Building,2,4,0,TRUE
+2002025,67.52104608,36.23256029,3,Chochman Primary School,Samangan,4,Hazrat-E-Sultan,1,Chochman Village,20,Building,2,5,0,TRUE
+2002026,67.54968933,36.18230922,2,Qadam Ali Mosque,Samangan,3,Hazrat-E-Sultan,1,Qadam Ali Village,20,Building,2,3,0,TRUE
+2002027,67.91529026,36.3595959,1,Boylar Mosque,Samangan,2,Hazrat-E-Sultan,1,Boylar Village,20,Village,2,2,0,TRUE
+2002028,67.64132429,36.10483752,1,Baba Murad Mosque,Samangan,2,Hazrat-E-Sultan,1,Neman Village,20,Village,2,2,0,TRUE
+2002029,68.36097219,36.53222723,1,Gawdara Mosque,Samangan,2,Hazrat-E-Sultan,1,Och Qadoq Village,20,Village,2,2,0,TRUE
+2003077,68.01100758,35.93115567,3,Andar Sher Khuram High School,Samangan,5,Khuram Wa Sarbagh,2,Khuram Village,20,Building,3,5,0,TRUE
+2003078,68.03693815,35.95907792,2,Ghazi Mard Primary School,Samangan,3,Khuram Wa Sarbagh,1,Ghazi Murad Village,20,Building,3,3,0,TRUE
+2003079,68.05764523,35.99673877,3,Sayed Jamaluddin High School,Samangan,4,Khuram Wa Sarbagh,1,District Compound,20,Building,3,5,0,TRUE
+2003080,68.06241482,36.02662052,2,Hazrat Numan Secondary School,Samangan,3,Khuram Wa Sarbagh,1,Dakhil Zo Village,20,Building,3,3,0,TRUE
+2003081,68.18602243,36.04954772,2,Baba Qambar Secondary School,Samangan,3,Khuram Wa Sarbagh,1,Baba Qambar Village,20,Building,3,4,0,TRUE
+2003082,68.21965147,36.11863731,1,Shorabak Primary School,Samangan,2,Khuram Wa Sarbagh,1,Shorabak Village,20,Building,3,2,0,TRUE
+2003083,68.30591854,36.07655932,1,Tatarchal Madrassa,Samangan,2,Khuram Wa Sarbagh,1,Tatarchal Village,20,Building,3,2,0,TRUE
+2003084,68.22435371,35.94441702,1,Shaakh Safid Primary School,Samangan,2,Khuram Wa Sarbagh,1,Shaakh Safid Village,20,Building,3,2,0,TRUE
+2003085,68.30776735,35.86555622,2,Aaq Chashma High School,Samangan,3,Khuram Wa Sarbagh,1,Aaq Chashma Village,20,Building,3,3,0,TRUE
+2003086,68.13013075,35.79015757,2,Qenar Secondary School,Samangan,3,Khuram Wa Sarbagh,1,Qenar Village,20,Building,3,3,0,TRUE
+2003096,68.2877825,35.95634956,1,Noblaq School,Samangan,2,Khuram Wa Sarbagh,1,Noblaq Village,20,Building,3,2,0,TRUE
+2003097,68.283933007,36.043779348,2,Khwaja Quch Qar Secondary School,Samangan,3,Hazrat-E-Sultan,1,Khwaja Quch Qar,20,Building,3,3,0,TRUE
+2003098,68.321900294,36.084236408,2,Primary School,Samangan,3,Hazrat-E-Sultan,1,Surkhak Chashma,20,Building,3,3,0,TRUE
+2004030,67.52834816,36.42311326,2,Qosh Mola Mosque,Samangan,3,Feroz Nakhcheer,1,Nakhchir Feroz,20,Building,4,3,0,TRUE
+2004031,67.693097,36.52812435,3,Feroz Nakhchir Boys School,Samangan,5,Feroz Nakhcheer,2,District Compound,20,Building,4,5,0,TRUE
+2004032,67.69600633,36.50611048,1,Naw Abad Primary School,Samangan,2,Feroz Nakhcheer,1,Naw Abad Village,20,Building,4,3,0,TRUE
+2005065,67.86500558,35.77396818,4,Abdul Aziz High School,Samangan,6,Roi-Do-Ab,2,Royee Village,20,Building,5,6,0,TRUE
+2005066,68.03410965,35.74396591,2,Joplaal Primary School,Samangan,4,Roi-Do-Ab,2,Joplaal Village,20,Building,5,4,0,TRUE
+2005067,67.70553858,35.83300534,1,Chahar Chashma Primary School,Samangan,2,Roi-Do-Ab,1,Chahar Chashma Village,20,Building,5,2,0,TRUE
+2005068,67.88852633,35.70273194,2,Moho Primary School,Samangan,3,Roi-Do-Ab,1,Moho Village,20,Building,5,3,0,TRUE
+2005069,67.66084799,35.64911323,2,Qashqa Madrassa,Samangan,4,Roi-Do-Ab,2,Qashqa Village,20,Building,5,4,0,TRUE
+2005070,67.57324385,35.56658857,2,Alauddin Madrassa,Samangan,4,Roi-Do-Ab,2,Alauddin Village,20,Building,5,4,0,TRUE
+2005071,67.62122106,35.49679375,2,Pechgah Madrassa,Samangan,3,Roi-Do-Ab,1,Pechgah Village,20,Building,5,3,0,TRUE
+2005072,67.76274366,35.50397325,3,Aabkhorak Madrassa,Samangan,4,Roi-Do-Ab,1,Aabkhorak Village,20,Building,5,4,0,TRUE
+2005073,67.81933833,35.56491998,2,Do Aab Madrassa,Samangan,3,Roi-Do-Ab,1,District Compound,20,Building,5,3,0,TRUE
+2005074,67.8986311,35.50666492,2,Mudirak Madrassa,Samangan,3,Roi-Do-Ab,1,Mudeerak Village,20,Building,5,3,0,TRUE
+2005075,68.00954016,35.50718126,2,Khami Bayaz Madrassa,Samangan,3,Roi-Do-Ab,1,Khami Bayaz Village,20,Building,5,3,0,TRUE
+2005076,68.05960385,35.52527708,1,Ze Sahibuddin Madrassa,Samangan,2,Roi-Do-Ab,1,Ze Sahibuddin Village,20,Building,5,2,0,TRUE
+2005094,67.87525825,35.54622433,2,Jaame Mosque Madrassa,Samangan,3,Roi-Do-Ab,1,Paytangi Village,20,Building,5,3,0,TRUE
+2005095,67.56750451,35.60692005,2,Balghali Menbar,Samangan,3,Roi-Do-Ab,1,Balghali Village,20,Building,5,3,0,TRUE
+2005099,67.781901069,35.627907917,2,Khwaja Zahed Madrasa,Samangan,3,Roi-Do-Ab,1,Khwaja Zahed,20,Building,5,3,0,TRUE
+2005100,67.966526376,35.523909685,2,Sorkh Qala Female School,Samangan,3,Roi-Do-Ab,1,Choqurak,20,Building,5,3,0,TRUE
+2006048,67.44596731,35.93901337,4,Baghak Primary School,Samangan,5,Dara-E-Soof-E-Payin,1,Bafak Village,20,Building,6,5,0,TRUE
+2006049,67.38280423,35.93242567,2,Bayanan Secondary School,Samangan,3,Dara-E-Soof-E-Payin,1,Bayanan Village,20,Building,6,3,0,TRUE
+2006050,67.26799204,35.95861099,4,Dehi Boys School,Samangan,6,Dara-E-Soof-E-Payin,2,District Compound,20,Building,6,6,0,TRUE
+2006051,67.23298886,35.99047211,1,Chobaki Secondary School,Samangan,2,Dara-E-Soof-E-Payin,1,Chobaki Village,20,Building,6,2,0,TRUE
+2006052,67.15379028,35.99727134,2,Ali Khel Primary School,Samangan,4,Dara-E-Soof-E-Payin,2,Ali Khel Village,20,Building,6,4,0,TRUE
+2006053,67.13084952,35.87208379,2,Ota Mosque,Samangan,4,Dara-E-Soof-E-Payin,2,Ota Village,20,Building,6,4,0,TRUE
+2006054,67.086930454,35.758575972,2,Bazarak Madrassa,Samangan,3,Dara-E-Soof-E-Payin,1,Bazarak Village,20,Building,6,3,0,TRUE
+2006055,67.10277077,35.986397,2,Namazgah Madrassa,Samangan,3,Dara-E-Soof-E-Payin,1,Namazgah Village,20,Building,6,3,0,TRUE
+2006056,67.15378192,35.99545978,1,Zaagh Payan Madrassa,Samangan,2,Dara-E-Soof-E-Payin,1,Zaagh Payan Village,20,Village,6,2,0,TRUE
+2006057,67.13878914,36.08719567,2,Oyemtan Mosque,Samangan,3,Dara-E-Soof-E-Payin,1,Oyemtan Village,20,Building,6,3,0,TRUE
+2006058,67.41718349,36.12529037,2,Khana Sangi Mosque,Samangan,4,Dara-E-Soof-E-Payin,2,Khana Sangi Village,20,Building,6,4,0,TRUE
+2006059,67.29845327,36.11215037,3,Toqsan Secondary School,Samangan,5,Dara-E-Soof-E-Payin,2,Toqsan Village,20,Building,6,5,0,TRUE
+2006060,67.40485839,36.13661195,2,Kata Qaq Madrassa,Samangan,4,Dara-E-Soof-E-Payin,2,Kata Qaq Village,20,Building,6,4,0,TRUE
+2006061,67.40687117,36.04681753,2,Lababi Madrassa,Samangan,4,Dara-E-Soof-E-Payin,2,Lababi Village,20,Building,6,4,0,TRUE
+2006062,67.29878056,36.03747258,2,Tolai Ghazi Mosque,Samangan,4,Dara-E-Soof-E-Payin,2,Tolai Ghazi Village,20,Building,6,4,0,TRUE
+2006063,67.50330298,35.99413783,2,Nai Zaar Mosque,Samangan,3,Dara-E-Soof-E-Payin,1,Nai Zaar Village,20,Building,6,3,0,TRUE
+2006064,67.47339471,35.97021884,1,Palez Paya Mosque,Samangan,2,Dara-E-Soof-E-Payin,1,Palez Paya Village,20,Building,6,2,0,TRUE
+2006092,67.015554613,35.734381779,2,Gola Hesar Jaame Mosque,Samangan,4,Dara-E-Soof-E-Payin,2,Gola Hesar Village,20,Building,6,4,0,TRUE
+2006093,67.560279913,35.949521037,1,Dai Kundi Jaame Mosque,Samangan,2,Dara-E-Soof-E-Payin,1,Dai Kundi Village,20,Building,6,2,0,TRUE
+2006101,67.339154017,35.910533051,2,School,Samangan,3,Dara-E-Soof-E-Payin,1,Qaria Taqchi,20,Building,6,3,0,TRUE
+2007033,67.28324128,35.90816951,3,Bazar Sokhta Boys High School,Samangan,5,Dara-E-Soof-E-Bala,2,District Compound,20,Building,7,5,0,TRUE
+2007034,67.28097554,35.85226842,2,Dahan Shorab School,Samangan,3,Dara-E-Soof-E-Bala,1,Dahan Shorab Village,20,Building,7,3,0,TRUE
+2007035,67.28558157,35.80577975,2,Zeraki Girls School,Samangan,3,Dara-E-Soof-E-Bala,1,Zeraki Village,20,Building,7,3,0,TRUE
+2007036,67.27872662,35.73859173,2,Menbar Hasani,Samangan,3,Dara-E-Soof-E-Bala,1,Hasani Village,20,Building,7,3,0,TRUE
+2007037,67.40183954,35.83234994,1,Menbar Kata Qeshlaq,Samangan,2,Dara-E-Soof-E-Bala,1,Kata Qashlaq Village,20,Building,7,2,0,TRUE
+2007038,67.51416466,35.82179952,1,Menbar Khami Hawz,Samangan,2,Dara-E-Soof-E-Bala,1,Khami Hawz Village,20,Building,7,2,0,TRUE
+2007039,67.37050066,35.81245742,2,Menbar Surkh Shahr,Samangan,3,Dara-E-Soof-E-Bala,1,Surkh Shahr Village,20,Building,7,3,0,TRUE
+2007040,67.41471903,35.71535204,3,Shekha School,Samangan,5,Dara-E-Soof-E-Bala,2,Shekha Village,20,Building,7,5,0,TRUE
+2007041,67.33182144,35.6733152,2,Zer Sang Menbar,Samangan,4,Dara-E-Soof-E-Bala,2,Zer Sang Village,20,Building,7,4,0,TRUE
+2007042,67.19631741,35.64904335,3,Beni Mang Menbar,Samangan,5,Dara-E-Soof-E-Bala,2,Beni Mang Village,20,Building,7,5,0,TRUE
+2007043,67.03989461,35.60565661,1,Surkh Deh Menbar,Samangan,2,Dara-E-Soof-E-Bala,1,Surkh Deh Village,20,Building,7,2,0,TRUE
+2007044,67.07644846,35.6748224,2,Menbar Oye Balaq,Samangan,3,Dara-E-Soof-E-Bala,1,Oye Balaq Village,20,Building,7,3,0,TRUE
+2007045,67.23121731,35.53307826,2,Menbar Chahar Deh,Samangan,4,Dara-E-Soof-E-Bala,2,Chahar Deh Village,20,Building,7,4,0,TRUE
+2007046,67.14064096,35.43251616,2,Menbar Kota,Samangan,3,Dara-E-Soof-E-Bala,1,Kota Village,20,Building,7,3,0,TRUE
+2007047,67.177738541,35.814884301,1,Menbar Hashtalez,Samangan,2,Dara-E-Soof-E-Bala,1,Hashtlez Village,20,Building,7,2,0,TRUE
+2007090,67.40992945,35.69172373,1,Menbar Jaihoon,Samangan,2,Dara-E-Soof-E-Bala,1,Jaihoon Village,20,Building,7,2,0,TRUE
+2007091,67.27783027,35.86157537,1,Sar Olang School,Samangan,2,Dara-E-Soof-E-Bala,1,Jambogha,20,Building,7,2,0,TRUE
+2101001,67.12111521,36.70712248,6,Sultan Razia High School,Balkh,10,Mazar-E-Sharif,4,D01 - Nahia 1 Mazar,21,Building,1,10,0,TRUE
+2101002,67.12157672,36.70113143,5,Wazir Akbar Khan School,Balkh,8,Mazar-E-Sharif,3,D01 - Nahia 1 Guzar Chatgari,21,Building,1,8,0,TRUE
+2101003,67.11483468,36.70713745,3,Mazar Municipality Office,Balkh,5,Mazar-E-Sharif,2,D01 - Nahia 1,21,Building,1,6,0,TRUE
+2101004,67.08633998,36.7203425,3,Ghazi Amanullah High School,Balkh,6,Mazar-E-Sharif,3,D09 - Nahia 9,21,Building,1,6,0,TRUE
+2101005,67.08383044,36.71339,6,Agriculture Department,Balkh,10,Mazar-E-Sharif,4,D02 - Nahia 2,21,Building,1,10,0,TRUE
+2101006,67.08891609,36.7124089,3,Gawhar Shad Begum High School,Balkh,6,Mazar-E-Sharif,3,D02 - Nahia 2,21,Building,1,6,0,TRUE
+2101007,67.10775011,36.71629289,4,Tebi Medical School,Balkh,8,Mazar-E-Sharif,4,D02 - Nahia 2 Karta-E-Shafakhana,21,Building,1,8,0,TRUE
+2101008,67.11670163,36.71595849,5,Baktash School,Balkh,8,Mazar-E-Sharif,3,D03 - Nahia 3,21,Building,1,8,0,TRUE
+2101009,67.11873522,36.71292026,2,Aisha Afghan High School,Balkh,5,Mazar-E-Sharif,3,D03 - Nahia 3,21,Building,1,5,0,TRUE
+2101010,67.11484158,36.71029518,3,Sultan Ghiyasuddin School,Balkh,6,Mazar-E-Sharif,3,D03 - Nahia 3,21,Building,1,7,0,TRUE
+2101011,67.11101633,36.71823853,2,Bakhtar High School,Balkh,5,Mazar-E-Sharif,3,D03 - Nahia 3,21,Building,1,6,0,TRUE
+2101012,67.10846555,36.72025632,3,Tajrobawi High School,Balkh,5,Mazar-E-Sharif,2,D03 - Nahia 3,21,Building,1,5,0,TRUE
+2101013,67.12905292,36.72233349,2,Maqsoodullah Shaheed School,Balkh,4,Mazar-E-Sharif,2,D07 - Nahia 7,21,Building,1,4,0,TRUE
+2101014,67.09828087,36.706603,5,Fatima Balkhi High School,Balkh,8,Mazar-E-Sharif,3,D02 - Nahia 2,21,Building,1,8,0,TRUE
+2101015,67.09026701,36.7062249,5,Qazi Hamiduddin School,Balkh,9,Mazar-E-Sharif,4,D04 - Nahia 4,21,Building,1,9,0,TRUE
+2101016,67.09315266,36.69527902,2,Abu Muslim Khurasani School,Balkh,5,Mazar-E-Sharif,3,D04 - Nahia 4,21,Building,1,6,0,TRUE
+2101017,67.08689127,36.71009149,2,Asadya Darul Hefaaz,Balkh,4,Mazar-E-Sharif,2,D02 - Nahia 2,21,Building,1,4,1,TRUE
+2101018,67.10794136,36.70176548,6,Esteqlal High School,Balkh,10,Mazar-E-Sharif,4,D05 - Nahia 5,21,Building,1,10,0,TRUE
+2101019,67.10447976,36.69420915,2,Roshana Balkhi School,Balkh,5,Mazar-E-Sharif,3,D05 - Nahia 5,21,Building,1,5,0,TRUE
+2101020,67.1083994,36.69184647,4,Nahr Top School,Balkh,7,Mazar-E-Sharif,3,D05 - Nahia 5,21,Building,1,7,0,TRUE
+2101021,67.10731094,36.71514454,3,Gawhar Khatoon High School,Balkh,5,Mazar-E-Sharif,2,D05 - Nahia 5,21,Building,1,5,0,TRUE
+2101022,67.09171078,36.68235624,4,Yolmarab Girls School,Balkh,9,Mazar-E-Sharif,5,D05 - Nahia 5,21,Building,1,9,0,TRUE
+2101023,67.09460181,36.68296109,4,Sayed Ismail Balkhi School,Balkh,7,Mazar-E-Sharif,3,D05 - Nahia 5,21,Building,1,7,0,TRUE
+2101024,67.08301316,36.67879383,3,Nasaji,Balkh,5,Mazar-E-Sharif,2,D05 - Nahia 5,21,Building,1,5,0,TRUE
+2101025,67.13432229,36.70185055,5,Shaikh Shahab School,Balkh,10,Mazar-E-Sharif,5,D06 - Nahia 6,21,Building,1,10,0,TRUE
+2101026,67.12680759,36.70951129,2,Agriculture High School,Balkh,4,Mazar-E-Sharif,2,D06 - Nahia 6 Guzar Qasabha,21,Building,1,4,0,TRUE
+2101027,67.12481021,36.70763616,2,Ghulam Rasool Sanaye School,Balkh,4,Mazar-E-Sharif,2,D06 - Nahia 6 Guzar Qasabha,21,Building,1,4,0,TRUE
+2101028,67.1018591,36.67099334,2,Torabi School,Balkh,5,Mazar-E-Sharif,3,D07 - Nahia 7 Karta-E-Amani,21,Building,1,6,0,TRUE
+2101029,67.12259213,36.69122549,4,Khurasan Girls School,Balkh,8,Mazar-E-Sharif,4,D07 - Nahia 7 Karta-E-Khurasan,21,Building,1,9,0,TRUE
+2101030,67.13865026,36.71593479,1,Ustad Jaahed School,Balkh,3,Mazar-E-Sharif,2,D07 - Nahia 7 Karta-E-Sulh,21,Building,1,4,0,TRUE
+2101031,67.13316645,36.71789879,5,Daqiqi Balkhi High School,Balkh,10,Mazar-E-Sharif,5,D07 - Nahia 7 Karta-E-Daqiqi,21,Building,1,10,0,TRUE
+2101032,67.13328559,36.71709725,3,Setara High School,Balkh,6,Mazar-E-Sharif,3,D07 - Nahia 7 Behind Gumrak,21,Building,1,6,0,TRUE
+2101033,67.11715675,36.72676785,4,Bukhdi Boys Secondary School,Balkh,7,Mazar-E-Sharif,3,D08 - Nahia 8,21,Building,1,7,0,TRUE
+2101034,67.12203486,36.72788588,5,Shahid Abdul Ali Mazari School,Balkh,9,Mazar-E-Sharif,4,D03 - Nahia 3 Sayed Abad,21,Building,1,9,0,TRUE
+2101035,67.10860972,36.73129373,3,Hidayatullah Naqshbandi School,Balkh,6,Mazar-E-Sharif,3,D08 - Nahia 8 Kart-E-Naw,21,Building,1,6,0,TRUE
+2101036,67.10356925,36.7236746,5,Hashim Barat High School,Balkh,9,Mazar-E-Sharif,4,D02 - Nahia 2,21,Building,1,9,0,TRUE
+2101037,67.0962043,36.72754175,3,Naw Bahar School,Balkh,6,Mazar-E-Sharif,3,D09 - Nahia 9 Karta-E-Nawshad,21,Building,1,6,0,TRUE
+2101038,67.09788102,36.738277,4,Sayed Yahya Omari School,Balkh,6,Mazar-E-Sharif,2,D09- Nahia 9,21,Building,1,6,0,TRUE
+2101039,67.11867158,36.73597599,4,Noor Khuda School,Balkh,9,Mazar-E-Sharif,5,D08 - Nahia 8,21,Building,1,11,0,TRUE
+2101040,67.1445949,36.70897652,4,Ustad Wejdan High School,Balkh,8,Mazar-E-Sharif,4,D10 - Nahia 10 Karta-E-Aryana,21,Building,1,8,0,TRUE
+2101041,67.156912832,36.719204918,4,Shaheed Abdul Ali Mazari Number 2 School,Balkh,8,Mazar-E-Sharif,4,D10 - Nahia 10 Guzar Ali Chopan,21,Building,1,8,0,TRUE
+2101042,67.12696153,36.71042604,3,Neft O Gas Institute,Balkh,6,Mazar-E-Sharif,3,D06 - Nahia 6 Gas Institute,21,Building,1,6,0,TRUE
+2101043,67.09820431,36.68886432,2,Yolmareb Uzbekya School,Balkh,5,Mazar-E-Sharif,3,D05 - Nahia 5,21,Building,1,5,0,TRUE
+2101044,67.11869429,36.68042132,4,Cilo,Balkh,6,Mazar-E-Sharif,2,D01 - Nahia 1 Cilo,21,Building,1,8,0,TRUE
+2101045,67.15149005,36.696415163,2,Abdul Qader Khulmi Secondary School,Balkh,4,Mazar-E-Sharif,2,D08 - Nahia 8,21,Building,1,5,0,TRUE
+2101046,67.153504889,36.703621509,2,Ali Chopan High School,Balkh,5,Mazar-E-Sharif,3,D10 - Nahia 10 Ali Chopan Village,21,Building,1,6,0,TRUE
+2101047,67.13922919,36.6942921,2,Hilaluddin Balkhi School,Balkh,4,Mazar-E-Sharif,2,D06 - Nahia 6,21,Building,1,6,0,TRUE
+2101048,67.09640541,36.72442305,2,Mehdiya School,Balkh,5,Mazar-E-Sharif,3,D09 - Nahia 9,21,Building,1,5,0,TRUE
+2102063,67.21949655,36.73720109,4,Qala Qol Muhammad School,Balkh,7,Nahr-E-Shahi,3,Qol Mohammad Village,21,Building,2,7,0,TRUE
+2102064,67.03688461,36.728974126,3,Abul Motee Balkhi School,Balkh,5,Nahr-E-Shahi,2,Takhta Pul Village,21,Building,2,5,0,TRUE
+2102065,67.0646792,36.72330153,3,Mohammad Yosuf Khairkhowah High School,Balkh,4,Nahr-E-Shahi,1,Qala Aajari Village,21,Building,2,5,0,TRUE
+2102066,67.08263278,36.85945348,2,Shahrak Turkmania School,Balkh,3,Nahr-E-Shahi,1,Shahrak Turkmania,21,Building,2,3,0,TRUE
+2102067,67.0793953,36.70261691,5,Maulana Jalaluddin School,Balkh,8,Nahr-E-Shahi,3,Baba Yadgar Village,21,Building,2,9,0,TRUE
+2102068,67.08311471,36.93157884,2,Siyah Gerd School,Balkh,3,Nahr-E-Shahi,1,Siyah Gerd Village,21,Village,2,3,0,TRUE
+2102069,67.16551836,36.89946435,2,Shahrak Afghania School,Balkh,4,Nahr-E-Shahi,2,Shahrak Afghania,21,Village,2,4,0,TRUE
+2102070,67.170961151,36.719329187,3,Ali Sena Balkhi Primary School,Balkh,5,Nahr-E-Shahi,2,Seena Village,21,Building,2,6,0,TRUE
+2102321,67.211489492,36.520363438,1,Shadiyan Mosque,Balkh,2,Nahr-E-Shahi,1,Shadiyan Village,21,Building,2,2,0,TRUE
+2103049,66.92778608,36.65192192,3,Tokhta School,Balkh,4,Dehdadi,1,Tokhta Village,21,Building,3,4,0,TRUE
+2103050,66.99372339,36.6630595,3,Shaheed Balkhi High School,Balkh,5,Dehdadi,2,Dehdadi Center,21,Building,3,5,0,TRUE
+2103051,67.02849452,36.69042546,1,Shaikh Samaruddin Shahab School,Balkh,2,Dehdadi,1,Dehdadi Sher Abad,21,Building,3,3,0,TRUE
+2103052,66.93153895,36.66783093,4,Bibi Zainab School,Balkh,7,Dehdadi,3,Kod Wa Barq Familiha,21,Village,3,7,0,TRUE
+2103053,66.95107762,36.70424663,2,Kaka Kot School,Balkh,3,Dehdadi,1,Kaka Kot Village,21,Building,3,3,0,TRUE
+2103054,67.03684408,36.69670112,1,Sher Abad Clinic,Balkh,2,Dehdadi,1,Dehdadi Sher Abad Ulya,21,Building,3,2,0,TRUE
+2103055,67.00869633,36.66565832,2,Abeda Balkhi School,Balkh,3,Dehdadi,1,Pul Baboo,21,Building,3,4,0,TRUE
+2103056,67.00513582,36.6657706,3,Ghulam Mohammad Shaheed School,Balkh,4,Dehdadi,1,Pul Baboo Village,21,Building,3,4,0,TRUE
+2103057,66.96611752,36.65728069,2,Saleh Mohammad School,Balkh,4,Dehdadi,2,Pusht Bagh,21,Building,3,5,0,TRUE
+2103058,66.98938569,36.719292,2,Chehl Gazai School,Balkh,4,Dehdadi,2,Chehl Gazai Village,21,Building,3,4,0,TRUE
+2103059,67.04354691,36.69572506,2,Abu Zayed School,Balkh,4,Dehdadi,2,Sher Abad Sufla,21,Building,3,5,0,TRUE
+2103060,67.03515284,36.68421337,1,Ustad Zabihullah Shaheed High School,Balkh,2,Dehdadi,1,Sher Abad Ulya,21,Building,3,3,0,TRUE
+2103061,66.98805102,36.65792518,2,Qala Jangi Girls High School,Balkh,3,Dehdadi,1,Qala Jangi Village,21,Building,3,6,0,TRUE
+2103062,66.98563354,36.66921338,2,Shaikh Abad School,Balkh,4,Dehdadi,2,Shekh Abad Village,21,Building,3,4,0,TRUE
+2104274,67.18882246,36.41572155,2,Shar Shar Sufla School,Balkh,3,Char Kent,1,Shar Shar Village,21,Building,4,3,0,TRUE
+2104275,67.20541295,36.47530083,2,Naan Wayee School,Balkh,3,Char Kent,1,Naan Wayee Village,21,Building,4,3,0,TRUE
+2104276,67.17314422,36.39110607,1,Yaka Taal School,Balkh,2,Char Kent,1,Yaka Taal Village,21,Building,4,2,0,TRUE
+2104277,67.11611375,36.47441802,2,Shor Balaq School,Balkh,3,Char Kent,1,Shor Balaq Village,21,Village,4,3,0,TRUE
+2104278,67.100965,36.431297,2,Tandoorak School,Balkh,3,Char Kent,1,Tandoorak Village,21,Village,4,3,0,TRUE
+2104279,67.30786097,36.40438337,1,Jaan Balaq School,Balkh,2,Char Kent,1,Jaan Balaq Village,21,Building,4,2,0,TRUE
+2104280,67.32254111,36.37434718,1,Pas Qadoq School,Balkh,2,Char Kent,1,Pas Qadoq Village,21,Building,4,2,0,TRUE
+2104281,67.22183557,36.34296576,1,Shah Enjir School,Balkh,2,Char Kent,1,Shah Enjir Village,21,Building,4,2,0,TRUE
+2104282,67.19935289,36.30586617,1,Azom Chah School,Balkh,2,Char Kent,1,Azom Chah Village,21,Building,4,2,0,TRUE
+2104283,67.31716937,36.20536777,2,Kuhna Jar School,Balkh,3,Char Kent,1,Mir Haji Qara Ghaaj,21,Building,4,3,0,TRUE
+2104284,67.34777669,36.26115765,2,Mir Haji School,Balkh,3,Char Kent,1,Qaleem Qaaq Mir Haji Village,21,Building,4,3,0,TRUE
+2104285,67.19992287,36.44446317,2,Safid Chashma School,Balkh,3,Char Kent,1,Safid Chashma Village,21,Building,4,3,0,TRUE
+2104286,67.29103981,36.36121116,1,Khwaja Bandi School,Balkh,2,Char Kent,1,Khwaja Bandi Village,21,Building,4,2,0,TRUE
+2105071,67.31012561,36.54303329,3,Pasta Qaleech Clinic,Balkh,4,Marmul,1,Pasta Qaleech Village,21,Building,5,4,0,TRUE
+2105072,67.31733648,36.54165141,2,Abu Esmat High School,Balkh,3,Marmul,1,Lab Joy Village,21,Building,5,3,0,TRUE
+2105073,67.30701368,36.54216616,2,Marmal Lab Say Girls High School,Balkh,3,Marmul,1,Pasta Qaleech Village,21,Building,5,3,0,TRUE
+2105074,67.29299942,36.54025152,2,Parwaz School,Balkh,3,Marmul,1,Parwaz Ulya Village,21,Building,5,3,0,TRUE
+2105075,67.31952381,36.53868166,1,Mula Afghan Mosque,Balkh,2,Marmul,1,Mula Afghan Village,21,Building,5,2,0,TRUE
+2106147,66.89427592,36.75484187,1,Farida Girls High School,Balkh,4,Balkh,3,District Compound,21,Building,6,4,0,TRUE
+2106148,66.88842734,36.75909542,2,Veterinary Clinic,Balkh,3,Balkh,1,District Compound,21,Building,6,3,0,TRUE
+2106149,66.89287681,36.73866946,2,Amir Mohammad Tokhi School,Balkh,3,Balkh,1,Rabat Village,21,Building,6,3,0,TRUE
+2106151,66.8982958,36.75115568,2,Sehat Aama Clinic,Balkh,3,Balkh,1,District Compound,21,Building,6,3,0,TRUE
+2106152,66.90904503,36.69384904,2,Kashkak School,Balkh,3,Balkh,1,Kashkak Village,21,Building,6,3,0,TRUE
+2106153,66.87599493,36.77809894,1,Speen Kot School,Balkh,2,Balkh,1,Qalacha Village,21,Building,6,3,0,TRUE
+2106154,66.91766455,36.74375309,2,Haji Kot School,Balkh,3,Balkh,1,Haji Kot Village,21,Building,6,3,0,TRUE
+2106155,66.85865575,36.7029401,2,Hesarak Girls School,Balkh,3,Balkh,1,Hesarak Village,21,Building,6,3,0,TRUE
+2106156,66.83680348,36.68607079,2,Samar Qandiyan Girls School,Balkh,4,Balkh,2,Samar Qandiyan Village,21,Building,6,4,0,TRUE
+2106157,66.81833771,36.72730019,2,Shaheed Rahmatullah School,Balkh,3,Balkh,1,Alam Khel,21,Building,6,3,0,TRUE
+2106158,66.83132984,36.70603084,3,Chahar Sang Boys School,Balkh,4,Balkh,1,Chahar Sang,21,Building,6,4,0,TRUE
+2106159,66.77677677,36.89227926,2,Elqechee School,Balkh,3,Balkh,1,Elqechee Village,21,Building,6,3,0,TRUE
+2106160,66.81593856,36.7489017,2,Boka School,Balkh,3,Balkh,1,Boka Village,21,Building,6,3,0,TRUE
+2106161,66.98169921,36.89642959,2,Bar Mazet School,Balkh,4,Balkh,2,Bar Mazet Village,21,Building,6,4,0,TRUE
+2106162,66.94018596,36.8331655,1,Colombo School,Balkh,2,Balkh,1,Colombo Village,21,Building,6,2,0,TRUE
+2106163,66.91052784,36.90615655,2,Dewali Maidan School,Balkh,3,Balkh,1,Dewali Maidan Village,21,Building,6,3,0,TRUE
+2106164,66.86912057,36.72563219,2,Dehrazi School,Balkh,3,Balkh,1,Dehrazi Village,21,Building,6,3,0,TRUE
+2106165,66.95046092,36.7519769,2,Deragi School,Balkh,3,Balkh,1,Hewad Village,21,Building,6,3,0,TRUE
+2106166,66.85632417,36.75219386,2,Char Bagh Gulshan School,Balkh,3,Balkh,1,Shenkay Village,21,Building,6,3,0,TRUE
+2106167,66.85599709,36.83949381,3,Muhmandan School,Balkh,5,Balkh,2,Muhmandan Village,21,Building,6,5,0,TRUE
+2106168,66.85710193,36.88078431,2,Shahab Mosque,Balkh,3,Balkh,1,Shahab Village,21,Building,6,3,0,TRUE
+2106169,66.9221513,36.77539075,2,Baha'Uddin School,Balkh,3,Balkh,1,Baha'Uddin Village,21,Building,6,3,0,TRUE
+2106170,66.82178848,36.81650309,1,Salarzai School,Balkh,2,Balkh,1,Salarzai Village,21,Building,6,2,0,TRUE
+2106171,66.799612591,36.792931373,2,Walagai School,Balkh,3,Balkh,1,Walagai (Khaspak) Village,21,Building,6,3,0,TRUE
+2106172,66.96907944,36.80016235,1,Arghoon School,Balkh,2,Balkh,1,Arghoon Village,21,Building,6,2,0,TRUE
+2106173,66.78835042,36.82595595,1,Arghandab Mosque,Balkh,2,Balkh,1,Arghandab Village,21,Building,6,2,0,TRUE
+2106174,66.87986969,36.6876157,2,Oof Maleek School,Balkh,3,Balkh,1,Oof Maleek Village,21,Building,6,3,0,TRUE
+2106176,66.89965559,36.75737964,3,Municipality Guesthouse,Balkh,6,Balkh,3,Balk District Compound,21,Building,6,6,0,TRUE
+2106177,66.848346863,36.910654936,1,Shamsullah Private House,Balkh,2,Balkh,1,Shahab Afghania Village,21,Building,6,2,0,TRUE
+2106320,66.84947026,36.77838924,2,Kata Khel School,Balkh,4,Balkh,2,Kata Khel,21,Building,6,4,0,TRUE
+2107237,66.88473366,36.31695014,3,Qadeem High School,Balkh,5,Sholgara,2,Qadeem Village,21,Building,7,5,0,TRUE
+2107238,66.88564558,36.31882396,2,Districts New Building,Balkh,3,Sholgara,1,Qadeem Village,21,Building,7,3,0,TRUE
+2107239,66.88002025,36.3403114,2,Takya Khana Mahmudia,Balkh,3,Sholgara,1,Qepchaq Village,21,Village,7,3,0,TRUE
+2107240,66.78848563,36.33803118,1,Tabyaq School,Balkh,2,Sholgara,1,Tabyaq Village,21,Building,7,2,0,TRUE
+2107241,66.67654699,36.11627792,2,Kandali School,Balkh,3,Sholgara,1,Kandali Village,21,Building,7,3,0,TRUE
+2107242,66.66610465,36.19748892,1,Kecha Qazal School,Balkh,2,Sholgara,1,Kuhna Qashlaq,21,Building,7,2,0,TRUE
+2107243,67.03788305,36.32739173,1,Qaq Losai School,Balkh,2,Sholgara,1,Qaq Losai Village,21,Building,7,2,0,TRUE
+2107244,66.88584901,36.38632024,2,Bibi Amena School,Balkh,3,Sholgara,1,Qor Baqa Khana Village,21,Building,7,3,0,TRUE
+2107245,66.88643168,36.39942851,1,Agha Jan School,Balkh,2,Sholgara,1,Agha Jan Village,21,Building,7,2,0,TRUE
+2107246,66.90731474,36.44355088,2,Bagh Pahlawan High School,Balkh,3,Sholgara,1,Bagh Pahlawan,21,Building,7,3,0,TRUE
+2107247,66.91365201,36.49129348,3,Astar Kot School,Balkh,4,Sholgara,1,Astar Kot Village,21,Building,7,4,0,TRUE
+2107248,66.90695027,36.2217896,2,Pul Barq School,Balkh,3,Sholgara,1,Pul Barq Village,21,Village,7,3,0,TRUE
+2107249,66.90307898,36.19686011,1,Char Khab School,Balkh,2,Sholgara,1,Char Khab Village,21,Building,7,2,0,TRUE
+2107250,66.88052238,36.36404936,2,Ahmad Alkhadroya School,Balkh,4,Sholgara,2,Baba Ewaz Village,21,Building,7,4,0,TRUE
+2107251,66.88051663,36.34903405,2,Bibi Maryam School,Balkh,3,Sholgara,1,Sar Asyab Village,21,Building,7,3,0,TRUE
+2107252,66.87777615,36.37830298,2,Bibi Fatima School,Balkh,3,Sholgara,1,Haji Nazar Village,21,Building,7,3,0,TRUE
+2107253,66.89122417,36.2395141,1,Qazal Kant School,Balkh,2,Sholgara,1,Qazal Kant Village,21,Building,7,2,0,TRUE
+2107254,67.0461013,36.31537495,2,Arlaat Mosque,Balkh,3,Sholgara,1,Arlaat Village,21,Building,7,3,0,TRUE
+2107255,66.98754636,36.44377544,1,Rahmat Abad School,Balkh,2,Sholgara,1,Rahmat Abad Village,21,Building,7,2,0,TRUE
+2107256,66.9329974,36.41312523,2,Qaland Khalili School,Balkh,3,Sholgara,1,Qaland Khalili Village,21,Building,7,3,0,TRUE
+2107257,66.91434837,36.31602631,2,Ai Latan School,Balkh,3,Sholgara,1,Ai Latan Village,21,Building,7,3,0,TRUE
+2107258,67.16835454,36.21577685,2,Dalan Girls School,Balkh,3,Sholgara,1,Dalan Village,21,Building,7,3,0,TRUE
+2107259,66.95532102,36.4988233,3,Paikan Dara School,Balkh,4,Sholgara,1,Paikan Dara Village,21,Building,7,4,0,TRUE
+2107260,67.11110484,36.2284368,2,Takya Khana Aqcha Dalan,Balkh,3,Sholgara,1,Aqcha Dalan Village,21,Building,7,3,0,TRUE
+2107261,66.91807728,36.40541421,2,Siyab School,Balkh,3,Sholgara,1,Siyab Village,21,Building,7,3,0,TRUE
+2107262,66.91380067,36.35913867,2,Zowarha Mosque,Balkh,3,Sholgara,1,Zowarha Village,21,Building,7,3,0,TRUE
+2107263,66.91415782,36.34361102,2,Sayed Jamaluddin Afghani High School,Balkh,3,Sholgara,1,Raheem Sar Khel Village,21,Building,7,3,0,TRUE
+2107264,66.97829766,36.35823196,1,Aghar Say Mosque,Balkh,2,Sholgara,1,Aghar Say Village,21,Building,7,2,0,TRUE
+2107265,67.17385024,36.20872826,2,Dalan Secondary School,Balkh,3,Sholgara,1,Dalan Village,21,Building,7,3,0,TRUE
+2107266,67.0914451,36.19042247,2,Shorcha Mosque,Balkh,4,Sholgara,2,Shorcha Village,21,Building,7,4,0,TRUE
+2107267,66.74389767,36.17911087,1,Naw Qeshlaq Mosque,Balkh,2,Sholgara,1,Naw Qashlaq Village,21,Building,7,2,0,TRUE
+2107268,66.713290034,36.12681265,1,Janyato School,Balkh,2,Sholgara,1,Janyato Village,21,Building,7,2,0,TRUE
+2107269,66.91102327,36.3093927,1,Tajik School,Balkh,2,Sholgara,1,Tajik Village,21,Building,7,2,0,TRUE
+2107270,66.91303417,36.34040607,1,Khair Mohammad Private House,Balkh,2,Sholgara,1,Khwaja Sikandar Village,21,Building,7,2,0,TRUE
+2107271,66.90845968,36.2207309,1,Tila Qarya Dar Private House,Balkh,2,Sholgara,1,Pul Barq,21,Village,7,2,0,TRUE
+2107272,66.77155926,36.31365944,2,Tabyaq Mosque,Balkh,3,Sholgara,1,Kangori Village,21,Building,7,3,0,TRUE
+2107273,66.88757994,36.39270831,1,Lal Mohammad Private House,Balkh,2,Sholgara,1,Qor Baqa Khana,21,Building,7,2,0,TRUE
+2108211,66.90842625,36.64142692,2,Mir Qasim Jan School,Balkh,3,Chimtal,1,Mir Qasim Jan Village,21,Building,8,3,0,TRUE
+2108212,66.75530152,36.67499043,2,Bay Taimoor Clinic,Balkh,3,Chimtal,1,Bai Taimoor Village,21,Building,8,3,0,TRUE
+2108213,66.80741523,36.67925041,2,Chamtal School,Balkh,3,Chimtal,1,Chamtaal Village,21,Village,8,3,0,TRUE
+2108214,66.87568592,36.64524892,2,Sar Asyab School,Balkh,3,Chimtal,1,Sar Asyab Village,21,Building,8,3,0,TRUE
+2108215,66.62629323,36.68383765,1,Arab Mazari School,Balkh,2,Chimtal,1,Arab Mazari Village,21,Village,8,2,0,TRUE
+2108216,66.79414987,36.65496218,2,Paloo Zolai School,Balkh,3,Chimtal,1,Paloo Zolai Village,21,Building,8,3,0,TRUE
+2108217,66.51201298,36.66181372,1,Emam Sahib Awal School,Balkh,2,Chimtal,1,Emam Sahib Awal Village,21,Village,8,2,0,TRUE
+2108218,66.56770138,36.67156254,2,Pashm Qala School,Balkh,3,Chimtal,1,Pashm Qala Village,21,Village,8,3,0,TRUE
+2108219,66.68028237,36.67262359,2,Asyab Gorg Mosque,Balkh,3,Chimtal,1,Asyab Gorg Village,21,Building,8,3,0,TRUE
+2108220,66.53918151,36.49898077,1,Emam Sahib Number 2 School,Balkh,2,Chimtal,1,Emam Sahib 2 Village,21,Village,8,2,0,TRUE
+2108221,66.6780782,36.68968118,2,Qala-E-Raziq School,Balkh,3,Chimtal,1,Qala-E-Raziq Village,21,Village,8,3,0,TRUE
+2108222,66.64654328,36.71874996,1,Nawshahr Alizai Mosque,Balkh,2,Chimtal,1,Alizai Village,21,Village,8,2,0,TRUE
+2108223,66.6340571,36.70593375,1,Nawshar Baloch Mosque,Balkh,2,Chimtal,1,Nawshar Baloch Village,21,Village,8,2,0,TRUE
+2108224,66.43746664,36.65448188,3,Bargah School,Balkh,5,Chimtal,2,Bargaay Turkmania,21,Village,8,5,0,TRUE
+2108225,66.56887229,36.56975166,4,Mula Juma Khan School,Balkh,7,Chimtal,3,Mula Juma Khan Village,21,Building,8,7,0,TRUE
+2108226,66.54375631,36.50527521,3,Haji Barfi School,Balkh,5,Chimtal,2,Haji Barfi Village,21,Building,8,5,0,TRUE
+2108227,66.54541456,36.49285074,5,Chaqnaq Clinic,Balkh,8,Chimtal,3,Chaqnaq Village,21,Building,8,8,0,TRUE
+2108228,66.50705704,36.36242651,3,Machaldi Mosque,Balkh,5,Chimtal,2,Machaldi Village,21,Building,8,0,5,FALSE
+2108229,66.76543571,36.69926831,2,Jangal Mosque,Balkh,3,Chimtal,1,Jangal Village,21,Village,8,3,0,TRUE
+2108230,66.75367172,36.66360877,1,District New Building,Balkh,2,Chimtal,1,District Compound,21,Building,8,2,0,TRUE
+2108231,66.7227691,36.69700327,1,Jar Qala School,Balkh,2,Chimtal,1,Jangal Village,21,Village,8,2,0,TRUE
+2108232,66.94397298,36.59627844,1,Rabat School,Balkh,2,Chimtal,1,Rabat Village,21,Building,8,2,0,TRUE
+2108233,66.57765352,36.72690038,2,Nawshahr Alizai Mosque,Balkh,3,Chimtal,1,Nawshahr Alizai Village,21,Village,8,3,0,TRUE
+2108234,66.53719788,36.73173895,1,Nawshahr Baloch Village Mosque,Balkh,2,Chimtal,1,Nawshahr Baloch,21,Village,8,2,0,TRUE
+2108235,66.72418529,36.54928886,1,Qadeem Private House,Balkh,2,Chimtal,1,Sad Mesh Village,21,Village,8,2,0,TRUE
+2108236,66.37010921,36.44696931,1,Doctar Dastageer Private House,Balkh,2,Chimtal,1,Char Say Afghania Village,21,Building,8,0,2,FALSE
+2108323,66.48404324,36.48190505,1,Mohammad Dawood Private House,Balkh,2,Chimtal,1,Kaltash Village,21,Village,8,2,0,TRUE
+2109118,66.82169871,36.98804151,3,Dawlat Abad Municipality Building,Balkh,4,Dawlat Abad,1,Dawlat Abad Center,21,Building,9,4,0,TRUE
+2109119,66.82017521,36.98692556,1,Rabia Balkhi School,Balkh,2,Dawlat Abad,1,Dawlat Abad Center,21,Building,9,2,0,TRUE
+2109120,66.78211537,37.03844966,2,Qarshigak Clinic,Balkh,4,Dawlat Abad,2,Qarshi Gak Village,21,Building,9,4,0,TRUE
+2109121,66.81046621,36.99160967,1,Abu Nasr Farabi High School,Balkh,2,Dawlat Abad,1,Dawlat Abad Center,21,Building,9,2,0,TRUE
+2109122,67.00618278,36.97283838,2,Maulana Wayezi Boys High School,Balkh,2,Dawlat Abad,0,Qara Ghajla Village,21,Building,9,2,0,TRUE
+2109123,67.00316007,36.98097094,1,Wazyezi Girls High School,Balkh,2,Dawlat Abad,1,Qara Ghajla Village,21,Building,9,2,0,TRUE
+2109124,66.68564393,36.98921528,2,Chaahee School,Balkh,4,Dawlat Abad,2,Chaahee Village,21,Building,9,4,0,TRUE
+2109125,66.73193726,36.96941651,1,Sadr Abad School,Balkh,2,Dawlat Abad,1,Sadr Abad Village,21,Building,9,2,0,TRUE
+2109126,66.5522439,36.99545135,2,Delbar Jeen School,Balkh,3,Dawlat Abad,1,Delbar Jeen Village,21,Building,9,3,0,TRUE
+2109127,66.62062734,37.0177857,2,Anwari School,Balkh,3,Dawlat Abad,1,Qazan Village,21,Building,9,3,0,TRUE
+2109128,66.6789573,36.93162941,2,Murad Bakhsh Wali Secondary School,Balkh,3,Dawlat Abad,1,Ghashi (Deh Daraz) Village,21,Building,9,3,0,TRUE
+2109129,66.7636778,36.90954875,1,Khowala Bachgan School,Balkh,2,Dawlat Abad,1,Khowala Bachgan Village,21,Building,9,2,0,TRUE
+2109130,66.75654304,37.00031125,1,Hayatan School,Balkh,2,Dawlat Abad,1,Hayatan Village,21,Building,9,2,0,TRUE
+2109131,66.75360773,36.94337414,3,Bedo School,Balkh,5,Dawlat Abad,2,Bedo Village,21,Building,9,5,0,TRUE
+2109132,66.72337315,37.04611896,3,Farokh Abad School,Balkh,4,Dawlat Abad,1,Farokh Abad Village,21,Building,9,4,0,TRUE
+2109133,66.77331454,37.02582625,2,Tali Gag School,Balkh,3,Dawlat Abad,1,Tali Gag Village,21,Building,9,3,0,TRUE
+2109134,66.87380091,36.96468585,1,Hashim Abad Mosque,Balkh,2,Dawlat Abad,1,Hashim Abad Watani Village,21,Building,9,2,0,TRUE
+2109135,67.0015043,36.93966012,1,Shakh Moghelan School,Balkh,2,Dawlat Abad,1,Shakh Moghelan Village,21,Building,9,2,0,TRUE
+2109136,66.91691244,36.96110982,1,Shengal Abad School,Balkh,2,Dawlat Abad,1,Shengal Abad Village,21,Building,9,2,0,TRUE
+2109137,66.91690998,36.96108304,2,Surkh Gumbad School,Balkh,3,Dawlat Abad,1,Surkh Gumbad Village,21,Building,9,3,0,TRUE
+2109138,67.06050663,36.97422816,1,Khair Abad School,Balkh,2,Dawlat Abad,1,Khair Abad Village,21,Building,9,2,0,TRUE
+2109139,66.94331175,37.02871516,1,Zadiyan School,Balkh,2,Dawlat Abad,1,Zadiyan Village,21,Building,9,2,0,TRUE
+2109140,66.8254389,36.94535127,1,Bay Mashhad School,Balkh,2,Dawlat Abad,1,Bay Mashhad Village,21,Building,9,2,0,TRUE
+2109141,66.89040373,37.00294513,1,Nakhchir Abad School,Balkh,2,Dawlat Abad,1,Nakhchir Abad Village,21,Building,9,2,0,TRUE
+2109142,66.78566135,36.97798211,1,Chahar Bagh Saydan School,Balkh,2,Dawlat Abad,1,Chahar Bagh Saydan Village,21,Building,9,2,0,TRUE
+2109143,66.83122948,36.92662271,1,Baghshor Mosque,Balkh,2,Dawlat Abad,1,Baghshor Village,21,Building,9,2,0,TRUE
+2109144,66.81653969,36.95979943,1,Yakhdan Mosque,Balkh,2,Dawlat Abad,1,Yakhdan Village,21,Building,9,2,0,TRUE
+2109145,66.84463998,36.95715655,1,Afghania Mosque,Balkh,2,Dawlat Abad,1,Pay Mashhad Afghania,21,Building,9,2,0,TRUE
+2109146,66.87263245,36.96854045,1,Sufi Tajuddin Private House,Balkh,2,Dawlat Abad,1,Hashim Abad Afghania,21,Building,9,2,0,TRUE
+2110076,67.69261473,36.69774587,5,Khulm Boys High School,Balkh,7,Khulm,2,Abdar Markaz Khulm Village,21,Building,10,7,0,TRUE
+2110077,67.69793831,36.69508249,2,Mahesti High Schoo,Balkh,5,Khulm,3,Dewardagi Village,21,Building,10,5,0,TRUE
+2110078,67.72710189,36.70438286,2,Khwaja Burhan Boys School,Balkh,3,Khulm,1,Sarhang Village,21,Building,10,3,0,TRUE
+2110079,67.7277756,36.70437375,1,Khwaja Burhan Girls School,Balkh,3,Khulm,2,Sarhang,21,Building,10,3,0,TRUE
+2110080,67.68690377,36.71153203,1,Amin Hussain Girls School,Balkh,3,Khulm,2,Khanqah Mirza Khairuddin,21,Building,10,3,0,TRUE
+2110081,67.68701478,36.68859416,2,Pohand Abdul Rawoof Khulmi High School,Balkh,3,Khulm,1,Seerat,21,Building,10,3,0,TRUE
+2110082,67.7046496,36.71893284,1,Nahid Shaheed School,Balkh,3,Khulm,2,Teba Shekhi Afghania (Laghmani),21,Building,10,3,0,TRUE
+2110083,67.68674702,36.71468987,2,Shahee Ahmad Shah Masood High School,Balkh,3,Khulm,1,Ameen Hussain Village,21,Building,10,3,0,TRUE
+2110084,67.77397422,36.73259354,1,Ghazi Abad Secondary School,Balkh,2,Khulm,1,Ghazi Abad Village,21,Building,10,2,0,TRUE
+2110085,67.88820316,36.70215524,2,Yangee Areeq School,Balkh,3,Khulm,1,Yangee Areeq Village,21,Building,10,3,0,TRUE
+2110086,67.69836277,36.77376408,2,Deh Hassan School,Balkh,3,Khulm,1,Deh Hassan Village,21,Building,10,3,0,TRUE
+2110087,67.71197321,36.71125968,2,Mirza Shams School,Balkh,3,Khulm,1,Mirza Shams Village,21,Building,10,3,0,TRUE
+2110088,67.6975574,36.67659592,2,Tangi School,Balkh,3,Khulm,1,Haji Karim Village,21,Building,10,3,0,TRUE
+2110089,67.76801332,36.58979125,2,Siyad Boys School,Balkh,3,Khulm,1,Siyad Village,21,Building,10,3,0,TRUE
+2110090,67.62544879,36.71927509,2,Oljato Secondary School,Balkh,3,Khulm,1,Oljato Village,21,Building,10,3,0,TRUE
+2110091,67.68909667,36.69767289,1,Khulm Hospital,Balkh,2,Khulm,1,Markaz Khulm Guzar Aabdar,21,Building,10,2,0,TRUE
+2110092,67.71453841,36.76514215,1,Khulm Old Village Primary School,Balkh,2,Khulm,1,Salozai - Khulm Old Village,21,Building,10,2,0,TRUE
+2110093,67.7880537,36.7084691,1,Haji Ali Clinic,Balkh,2,Khulm,1,Haji Ali Village,21,Building,10,2,0,TRUE
+2110094,67.68883433,36.78506281,1,Deh Warda Village Mosque,Balkh,2,Khulm,1,Deh Warda Village,21,Building,10,2,0,TRUE
+2110096,68.0649628,36.58631829,1,Khoshtoot Secondary School,Balkh,2,Khulm,1,Khoshtoot Village,21,Building,10,2,0,TRUE
+2110097,67.74348906,36.70870632,1,Khwaja Burhan Boys High School,Balkh,2,Khulm,1,Sarhang Ismail Khel Village,21,Building,10,2,0,TRUE
+2110098,67.70547402,36.72949182,1,Nahid Shaheed Secondary School,Balkh,2,Khulm,1,Salozai Village,21,Building,10,2,0,TRUE
+2111178,66.68571924,36.79515431,2,Mudiryat Maaref,Balkh,4,Char Bolak,2,Chahar Bolak Markaz,21,Building,11,4,0,TRUE
+2111179,66.75712287,36.72778609,2,Ali Abad School,Balkh,3,Char Bolak,1,Ali Abad Village,21,Building,11,3,0,TRUE
+2111180,66.67056431,36.75380946,1,Abu Shakoor Balkhi School,Balkh,2,Char Bolak,1,Aaq Tapa,21,Building,11,2,0,TRUE
+2111181,66.62354126,36.89589412,2,Ahmad Abad School,Balkh,3,Char Bolak,1,Ahmad Abad Village,21,Building,11,3,0,TRUE
+2111182,66.43320189,36.75858224,1,Salar Tapa School,Balkh,2,Char Bolak,1,Salar Tapa Village,21,Building,11,2,0,TRUE
+2111183,66.64074471,36.83778795,2,Dilbar Jeen School,Balkh,3,Char Bolak,1,Dilbar Jeen Village,21,Building,11,3,0,TRUE
+2111184,66.68034754,36.82546374,2,Arnagha School,Balkh,3,Char Bolak,1,Arnagha Village,21,Building,11,3,0,TRUE
+2111185,66.70254091,36.89436801,1,Adeena Mosque,Balkh,2,Char Bolak,1,Aadina Mosque Village,21,Building,11,2,0,TRUE
+2111186,66.7434611,36.84257631,1,Shekh Tash Taimur School,Balkh,2,Char Bolak,1,Shekh Tash Taimor Village,21,Building,11,2,0,TRUE
+2111187,66.61080856,36.73005905,1,Zegzag School,Balkh,2,Char Bolak,1,Zegzag Village,21,Building,11,2,0,TRUE
+2111188,66.60177912,36.91701633,1,Khwaja Roshnaye School,Balkh,2,Char Bolak,1,Dahno Village,21,Building,11,2,0,TRUE
+2111189,66.55505932,36.95175304,1,Dahno School,Balkh,2,Char Bolak,1,Dahno Village,21,Building,11,2,0,TRUE
+2111190,66.56485238,36.92522358,1,Borolok School,Balkh,2,Char Bolak,1,Borolok Village,21,Building,11,2,0,TRUE
+2111191,66.59436644,36.77254882,1,Badaye Bakhli School,Balkh,2,Char Bolak,1,Taimorak Village,21,Building,11,2,0,TRUE
+2111192,66.50974991,36.75891063,2,Bist Paikal School,Balkh,3,Char Bolak,1,Bist Paikal Village,21,Building,11,3,0,TRUE
+2111193,66.56456633,36.77650779,2,Choba School,Balkh,3,Char Bolak,1,Choba Village,21,Building,11,3,0,TRUE
+2111194,66.78652814,36.7297278,2,Yalman School,Balkh,3,Char Bolak,1,Yalman Village,21,Building,11,3,0,TRUE
+2111195,66.74931222,36.754114,1,Sikandar Khel Zhangora School,Balkh,2,Char Bolak,1,Zhangora Watani,21,Building,11,2,0,TRUE
+2111196,66.778864751,36.782281157,1,Tahana School,Balkh,2,Char Bolak,1,Tahana Village,21,Building,11,2,0,TRUE
+2111197,66.67497353,36.72159453,1,Qazi Farooq Shaheed School,Balkh,2,Char Bolak,1,Arzankar Village,21,Building,11,2,0,TRUE
+2111198,66.73626122,36.71606193,2,Nawai Kot School,Balkh,3,Char Bolak,1,Nawai Kot (Yangareq) Village,21,Building,11,3,0,TRUE
+2111199,66.53066819,36.94226761,2,Sal Baron School,Balkh,3,Char Bolak,1,Sal Baron Village,21,Building,11,3,0,TRUE
+2111200,66.59715879,36.83548677,2,Rahmat Abad School,Balkh,3,Char Bolak,1,Rahmat Abad Village,21,Building,11,3,0,TRUE
+2111201,66.70557881,36.76744425,1,Districts Building,Balkh,2,Char Bolak,1,Chahar Bolak District Office,21,Building,11,2,0,TRUE
+2111202,66.59314553,36.87782087,1,Mangoli School,Balkh,2,Char Bolak,1,Mangoli Village,21,Building,11,2,0,TRUE
+2111203,66.72585345,36.77615944,2,Shoray Inkeshafi Building,Balkh,3,Char Bolak,1,Zhangora Maawen Zaman Village,21,Building,11,3,0,TRUE
+2111205,66.57782651,36.76151826,1,Hameed Baba School,Balkh,2,Char Bolak,1,Taimorak Village,21,Building,11,2,0,TRUE
+2111206,66.743505,36.84249054,1,Jame Mosque,Balkh,2,Char Bolak,1,Shekh Tash Taimor Village,21,Building,11,2,0,TRUE
+2111207,66.74912891,36.78573044,1,Mula Shaheen Private House,Balkh,2,Char Bolak,1,Mula Shaheen Village,21,Building,11,2,0,TRUE
+2111209,66.61225679,36.741095,1,Ainuddin Private House,Balkh,2,Char Bolak,1,Nawarad Zagzag Village,21,Building,11,2,0,TRUE
+2111210,66.72251304,36.75594129,1,Sardar Mohammad Private House,Balkh,2,Char Bolak,1,Shenkai Village,21,Building,11,2,0,TRUE
+2111322,66.704988304,36.728354623,1,Qarya Soryan Mosque,Balkh,2,Char Bolak,1,Soryan Village,21,Building,11,2,0,TRUE
+2112108,66.82437106,37.32937171,3,Baz Areeq School,Balkh,4,Shortepa,1,Baz Areeq Village,21,Building,12,4,0,TRUE
+2112109,67.32541634,37.17481985,2,Jirtan School,Balkh,3,Shortepa,1,Jirtan Village,21,Building,12,3,0,TRUE
+2112110,67.21001137,37.20217915,2,Tashguzar School,Balkh,3,Shortepa,1,Hazara Toqi Village,21,Building,12,3,0,TRUE
+2112111,66.97145158,37.34821912,2,Abu Jafar School,Balkh,3,Shortepa,1,Joy Wakeel Village,21,Building,12,3,0,TRUE
+2112112,66.7254941,37.30235583,2,Shor Aareeq School,Balkh,3,Shortepa,1,Shor Aareeq Village,21,Building,12,3,0,TRUE
+2112113,66.62026665,37.31211864,3,Dali School,Balkh,4,Shortepa,1,Dali Village,21,Building,12,4,0,TRUE
+2112114,66.47382707,37.29857827,2,Islam Ulya School,Balkh,3,Shortepa,1,Islam Ulya Village,21,Building,12,3,0,TRUE
+2112115,66.97226293,37.34843839,2,Joy Wakil Clinic,Balkh,3,Shortepa,1,Joy Wakeel Village,21,Building,12,3,0,TRUE
+2112116,67.24631232,37.16623885,1,Arenji Bashirli School,Balkh,2,Shortepa,1,Sayed Abad Kama Guzar,21,Building,12,2,0,TRUE
+2112117,66.33774106,37.28882213,1,Islam Sufla Clinic,Balkh,2,Shortepa,1,Islam Sufla Village,21,Building,12,2,0,TRUE
+2113099,67.47379837,37.21612683,4,Nasir Khisraw Balkhi High School,Balkh,5,Kaldar,1,Hairan Shahrak,21,Building,13,6,0,TRUE
+2113100,67.60401657,37.20160712,2,Joy Jadid Secondary School,Balkh,3,Kaldar,1,Joy Jadeed Village,21,Building,13,3,0,TRUE
+2113101,67.5054935,37.23345408,2,Tazlaq Secondary School,Balkh,3,Kaldar,1,Tazlaq Village,21,Building,13,3,0,TRUE
+2113102,67.74368254,37.18503166,1,Haji Wali Private House,Balkh,2,Kaldar,1,Taza Areekh Village,21,Building,13,2,0,TRUE
+2113103,67.76891358,37.16992764,1,Kuhna Kaldar Village Secondary School,Balkh,2,Kaldar,1,Kuhna Kaldar Village,21,Building,13,2,0,TRUE
+2113104,67.63516925,37.19644513,1,Toqi Qarn School,Balkh,2,Kaldar,1,Qarn Toqi Village,21,Building,13,2,0,TRUE
+2113105,67.7200387,37.19529916,1,Bozareekh Secondary School,Balkh,2,Kaldar,1,Boz Areekh Village,21,Building,13,2,0,TRUE
+2113106,67.67817135,37.19878578,1,Kareem Qaryadar Private House,Balkh,2,Kaldar,1,Qaraja Village,21,Building,13,2,0,TRUE
+2113107,67.70988319,37.19905808,1,Abdul Raheem Qaryadar Private House,Balkh,2,Kaldar,1,Kado Areekh Village,21,Building,13,2,0,TRUE
+2114287,66.83682277,36.08030738,4,Aaq Koprok School,Balkh,6,Kishindeh,2,Aaq Koprok Village,21,Building,14,6,0,TRUE
+2114288,66.91351874,36.00898689,2,Sarab School,Balkh,3,Kishindeh,1,Sarab Village,21,Building,14,3,0,TRUE
+2114289,66.99145951,36.1089611,1,Chakana Payana School,Balkh,2,Kishindeh,1,Chakana Payeen Village,21,Building,14,2,0,TRUE
+2114290,66.90077498,36.07968956,2,Kushenda Bala School,Balkh,3,Kishindeh,1,Kushenda Bala Village,21,Building,14,3,0,TRUE
+2114291,66.92153775,36.15308457,2,Kushenda Payan School,Balkh,3,Kishindeh,1,Kushenda Payan Village,21,Building,14,3,0,TRUE
+2114292,66.99139233,36.10892588,1,Chakana Bala School,Balkh,2,Kishindeh,1,Chakana Bala Village,21,Building,14,2,0,TRUE
+2114293,66.87117595,35.89831577,2,Tonj School,Balkh,3,Kishindeh,1,Tonj Village,21,Building,14,3,0,TRUE
+2114294,66.88800391,35.77086736,2,Yarghan School,Balkh,3,Kishindeh,1,Yarghan Village,21,Building,14,3,0,TRUE
+2114295,66.959255843,35.773908401,1,Qara Bay School,Balkh,2,Kishindeh,1,Wakheshk Village,21,Building,14,2,0,TRUE
+2114296,66.88340723,35.96665403,2,Qara Bay Mosque,Balkh,3,Kishindeh,1,Qara Bay Village,21,Building,14,3,0,TRUE
+2114297,66.98162128,35.9010186,1,Karam Shahee Mosque,Balkh,2,Kishindeh,1,Karam Shahee Village,21,Building,14,2,0,TRUE
+2114298,66.9804445,36.12064806,2,Kushenda Bala Clinic,Balkh,3,Kishindeh,1,Kushenda Bala Village,21,Building,14,3,0,TRUE
+2114299,66.87010872,36.02204931,1,Qarya Sokhta School,Balkh,2,Kishindeh,1,Sokhta Village,21,Building,14,2,0,TRUE
+2114300,66.82324834,36.0168098,1,Baam Pusht Mosque,Balkh,2,Kishindeh,1,Baam Pusht Village,21,Building,14,2,0,TRUE
+2114301,66.85158067,35.76681959,2,Qarya Shekh Sar Dara Mosque,Balkh,3,Kishindeh,1,Shekh Sar Dara Village,21,Building,14,3,0,TRUE
+2114302,66.98546541,35.95935469,1,Qoshmsay Mosque,Balkh,2,Kishindeh,1,Qoshmasai Bala Village,21,Building,14,2,0,TRUE
+2115303,66.69411846,35.95956159,3,Abul Qasim School,Balkh,4,Zari,1,Naqichi Village,21,Building,15,4,0,TRUE
+2115304,66.72184857,35.9662066,2,Khwaja Ahmad Siwi School,Balkh,3,Zari,1,Mirzayee Village,21,Building,15,3,0,TRUE
+2115305,66.67716121,35.9471487,2,Elaqya Girls School,Balkh,4,Zari,2,Boland Areegh Village,21,Building,15,4,0,TRUE
+2115306,66.64924657,35.81957717,1,Bakhtgaan Mosque,Balkh,2,Zari,1,Bakhtgaan Village,21,Building,15,2,0,TRUE
+2115307,66.65655685,35.79864902,2,Bazar Kuhna Mosque,Balkh,3,Zari,1,Bazar Kuhna Hamrukh Village,21,Building,15,3,0,TRUE
+2115308,66.712397889,35.97729811,1,Mir Hashim School,Balkh,2,Zari,1,Naw Abad Baloch Village,21,Building,15,2,0,TRUE
+2115309,66.664744262,35.737647126,2,Imam Hassan School,Balkh,3,Zari,1,Murghzar Village,21,Building,15,3,0,TRUE
+2115310,66.62999539,35.74090222,2,Khwaja Roshnaye School,Balkh,3,Zari,1,Khiyabak Village,21,Building,15,3,0,TRUE
+2115311,66.80556436,35.90608225,2,Chaqorak School,Balkh,3,Zari,1,Chaqorak Village,21,Building,15,3,0,TRUE
+2115312,66.73820253,35.80622039,1,Dasht Qadoq Mosque,Balkh,3,Zari,2,Dasht Qadoq Village,21,Building,15,3,0,TRUE
+2115313,66.73298013,35.8317105,3,Abdaalgan Secondary School,Balkh,4,Zari,1,Banigo Village,21,Building,15,4,0,TRUE
+2115314,66.778095979,36.043529027,1,Pasta Baloch School,Balkh,2,Zari,1,Pasta Baloch Village,21,Building,15,2,0,TRUE
+2115315,66.79250229,35.76460253,1,Baya School,Balkh,2,Zari,1,Baya Village,21,Building,15,0,2,FALSE
+2115316,66.7878697,36.03721605,1,Baloch Mosque,Balkh,2,Zari,1,Qashlaq Kalan Baloch,21,Building,15,2,0,TRUE
+2115317,66.79616272,35.86633564,1,Hazar Paimana Mosque,Balkh,2,Zari,1,Folad Village,21,Building,15,2,0,TRUE
+2115318,66.73298269,35.71117501,1,Khatimul Anbiya High School,Balkh,3,Zari,2,Baam Shakh Village,21,Building,15,3,0,TRUE
+2115319,66.61382963,35.71459043,1,Abu Zar Ghaffari School,Balkh,3,Zari,2,Khair Abad Village,21,Building,15,3,0,TRUE
+2115324,66.6365111,36.0309601,2,Omaki Primary School,Balkh,3,Zari,1,Omaki Village,21,Building,15,3,0,TRUE
+2201001,65.92988642,36.22020241,7,Jowzjan Girls High School,Sar-E-Pul,11,Sar-E-Pul,4,Shahr Naw Nahai 1,22,Building,1,11,0,TRUE
+2201002,65.93867212,36.20824577,8,Minhaj-U-Siraj High School,Sar-E-Pul,13,Sar-E-Pul,5,Alqani Khord,22,Building,1,13,0,TRUE
+2201003,65.93437488,36.22578867,6,Rahmat Abad High School,Sar-E-Pul,9,Sar-E-Pul,3,Rahmat Abad Village,22,Building,1,9,0,TRUE
+2201004,65.9493037,36.21489948,5,Imam Yahya High School,Sar-E-Pul,8,Sar-E-Pul,3,Imam Khord Village,22,Building,1,8,0,TRUE
+2201005,65.91951723,36.21931838,3,Alqani Mosque,Sar-E-Pul,6,Sar-E-Pul,3,Alqani Kalan Village,22,Building,1,6,0,TRUE
+2201006,65.89527174,36.25962356,3,Qaragho High School,Sar-E-Pul,5,Sar-E-Pul,2,Qaragho Village,22,Building,1,5,0,TRUE
+2201007,65.93271631,36.30508886,4,Shah Chinar High School,Sar-E-Pul,7,Sar-E-Pul,3,Shah Chinar Village,22,Building,1,7,0,TRUE
+2201008,65.87225272,36.28150717,3,Korak Uzbekya Secondary School,Sar-E-Pul,5,Sar-E-Pul,2,Korak Uzbekya Village,22,Building,1,5,0,TRUE
+2201009,66.07767318,36.17798779,4,Baghawi Uzbekya Secondary School,Sar-E-Pul,6,Sar-E-Pul,2,Baghawi Uzbekya Village,22,Building,1,6,0,TRUE
+2201010,65.89139495,36.34297924,5,Qosh Tapa High School,Sar-E-Pul,6,Sar-E-Pul,1,Qosh Tapa Village,22,Building,1,6,0,TRUE
+2201011,66.06900931,36.09333958,3,Adrang Secondary School,Sar-E-Pul,4,Sar-E-Pul,1,Adrang Village,22,Building,1,4,0,TRUE
+2201013,66.02667266,36.18797381,3,Uzbekya Angot High School,Sar-E-Pul,4,Sar-E-Pul,1,Angot Uzbekya Village,22,Building,1,4,0,TRUE
+2201015,66.2253,36.2389,3,Zakir Primary School,Sar-E-Pul,4,Sar-E-Pul,1,Zakir Village,22,Village,1,4,0,TRUE
+2201017,66.1091197,36.04439427,2,Qala-E-Sokhta Primary School,Sar-E-Pul,3,Sar-E-Pul,1,Sokhta Qala Village,22,Building,1,3,0,TRUE
+2201020,66.17719715,36.23309756,2,Qadam Jay Madrassa,Sar-E-Pul,3,Sar-E-Pul,1,Qadam Jay Village,22,Village,1,3,0,TRUE
+2201021,65.85593587,36.36853045,2,Sayed Abad High School,Sar-E-Pul,4,Sar-E-Pul,2,Sayed Abad Village,22,Building,1,4,0,TRUE
+2201026,65.82585071,36.45521506,2,Had Badakhshi Primary School,Sar-E-Pul,4,Sar-E-Pul,2,Had Bakhshi Village,22,Building,1,4,0,TRUE
+2201027,66.0283413,36.14920994,2,Qashqari Village School,Sar-E-Pul,4,Sar-E-Pul,2,Qashqari Village,22,Building,1,4,0,TRUE
+2201029,65.95950228,36.05489981,3,Qarya Latee Mosque,Sar-E-Pul,4,Sar-E-Pul,1,Latee Village,22,Building,1,4,0,TRUE
+2201030,66.06646713,35.93584268,2,Alaf Safid Mosque,Sar-E-Pul,3,Sar-E-Pul,1,Alaf Safid Village,22,Village,1,3,0,TRUE
+2201031,65.86276832,36.33154756,1,Khanqah Mulki Mosque,Sar-E-Pul,3,Sar-E-Pul,2,Khanqah Mulki Village,22,Building,1,3,0,TRUE
+2201032,66.06207679,36.16837267,3,Baghawi Sufla High School,Sar-E-Pul,5,Sar-E-Pul,2,Baghawi Sufla,22,Building,1,5,0,TRUE
+2201034,66.03938707,36.03248143,1,Se Toot Village Mosque,Sar-E-Pul,2,Sar-E-Pul,1,Se Toot Village,22,Building,1,2,0,TRUE
+2202048,65.83224888,36.14023822,4,Mula Sakhidad Girls High School,Sar-E-Pul,6,Sayad,2,Mula Sakhidad,22,Building,2,6,0,TRUE
+2202049,65.85870416,36.18022533,2,Angushka Secondary School,Sar-E-Pul,3,Sayad,1,Angushka,22,Building,2,3,0,TRUE
+2202050,65.83297145,36.06410842,2,Quflatoon Village Mosque,Sar-E-Pul,3,Sayad,1,Quflatoon Village,22,Building,2,3,0,TRUE
+2202051,65.90595251,36.10334154,1,Tarbalaq Secondary School,Sar-E-Pul,2,Sayad,1,Tarbalaq,22,Building,2,2,0,TRUE
+2202052,65.7058002,36.0969887,2,Dara-E-Band Mosque Property,Sar-E-Pul,4,Sayad,2,Dara-E-Band Village,22,Village,2,4,0,TRUE
+2202053,65.64685523,36.03979421,2,Qara Khowal Mosque Property,Sar-E-Pul,4,Sayad,2,Qara Khowal Village,22,Village,2,4,0,TRUE
+2202054,65.54751382,36.00950696,2,Shah Toot Village Madrassa,Sar-E-Pul,3,Sayad,1,Shah Toot Village,22,Village,2,3,0,TRUE
+2202055,65.60493756,36.1578003,1,Chahar Gunbad Madrassa,Sar-E-Pul,2,Sayad,1,Chahar Gunbad Village,22,Village,2,2,0,TRUE
+2202056,65.926465,35.99513639,2,Khwaja Almato Primary School,Sar-E-Pul,3,Sayad,1,Khwaja Almato,22,Village,2,3,0,TRUE
+2202057,65.79474113,35.99268518,1,Mirza Walang Secondary School,Sar-E-Pul,3,Sayad,2,Mirza Walang,22,Building,2,3,0,TRUE
+2202059,65.82346383,36.09957925,1,Primary School,Sar-E-Pul,3,Sayad,2,Beland Ghor Village,22,Village,2,3,0,TRUE
+2202060,65.63719264,36.05939853,1,Primary School,Sar-E-Pul,2,Sayad,1,Hajda Bala Village,22,Village,2,2,0,TRUE
+2203061,65.94055242,35.91348145,4,Jarghan High School,Sar-E-Pul,6,Kohistanat,2,Jarghan,22,Building,3,6,0,TRUE
+2203062,65.88383982,35.91189592,1,Nagala Mosque,Sar-E-Pul,2,Kohistanat,1,Nagala,22,Building,3,2,0,TRUE
+2203063,65.89634291,35.83589729,2,Sar Deh Mosque,Sar-E-Pul,4,Kohistanat,2,Sar Deh,22,Building,3,4,0,TRUE
+2203064,65.83120161,35.77926114,2,Khumdan Madrassa,Sar-E-Pul,3,Kohistanat,1,Khumdan,22,Building,3,3,0,TRUE
+2203065,65.77179256,35.76667834,2,Himat Deh Surkh O Pas Nai High School,Sar-E-Pul,3,Kohistanat,1,Deh Surkh Village,22,Building,3,3,0,TRUE
+2203066,65.72762063,35.76568847,2,Imam Abu Hanifa Madrassa,Sar-E-Pul,3,Kohistanat,1,Khwal Village,22,Building,3,3,0,TRUE
+2203069,65.56829456,35.54631387,1,Qala-E-Shahr Madrassa,Sar-E-Pul,2,Kohistanat,1,Qala-E-Shahr Madrassa,22,Building,3,2,0,TRUE
+2203070,65.55233503,35.52415506,2,Haji Mula Qurban Mosque,Sar-E-Pul,3,Kohistanat,1,Naw Qala Shahr,22,Building,3,3,0,TRUE
+2203082,66.19626033,35.28273861,2,Azadi High School,Sar-E-Pul,3,Kohistanat,1,Safid Maidan Shina,22,Building,3,3,0,TRUE
+2203083,66.23395703,35.13366593,1,Shaheed Mazari High School,Sar-E-Pul,2,Kohistanat,1,Dahna Kashan,22,Building,3,2,0,TRUE
+2203084,66.2816785,35.07931932,1,Qala-E-Kuhna Village Mosque,Sar-E-Pul,2,Kohistanat,1,Qala-E-Kuhna,22,Building,3,2,0,TRUE
+2203085,66.33574177,35.04822122,1,Deh Bezan Mosque,Sar-E-Pul,2,Kohistanat,1,Deh Bezan,22,Building,3,2,0,TRUE
+2203137,65.88690258,35.784470376,2,Haji Zaher Mosque,Sar-E-Pul,3,Kohistanat,1,Kunji Ha,22,Village,3,3,0,TRUE
+2203138,65.836398912,35.478998602,2,Mosque,Sar-E-Pul,3,Kohistanat,1,Khamida,22,Village,3,3,0,TRUE
+2203139,65.569336464,35.546213014,2,Mosque,Sar-E-Pul,3,Kohistanat,1,Nimak,22,Village,3,0,3,FALSE
+2204035,66.22503581,36.0959293,3,Mohammad Amin Shaheed High School,Sar-E-Pul,5,Sozma Qala,2,District Compound,22,Building,4,5,0,TRUE
+2204036,66.23491332,36.02450553,2,Gorkaab Ulya Mosque,Sar-E-Pul,3,Sozma Qala,1,Gorkaab Ulya,22,Building,4,3,0,TRUE
+2204037,66.22241207,36.00471307,1,Tanzeel Mosque,Sar-E-Pul,2,Sozma Qala,1,Tanzeel,22,Building,4,2,0,TRUE
+2204038,66.21064031,35.98072867,2,Charak High School,Sar-E-Pul,3,Sozma Qala,1,Charak Sufla,22,Building,4,3,0,TRUE
+2204039,66.18852775,35.92101697,2,Kata Qala Mosque,Sar-E-Pul,3,Sozma Qala,1,Kata Qala,22,Building,4,3,0,TRUE
+2204041,66.14349231,35.88455294,3,Khanqah Girls Secondary School,Sar-E-Pul,4,Sozma Qala,1,Khanqah,22,Building,4,4,0,TRUE
+2204043,66.28385007,36.11104887,1,Sabzi Kalan Mosque,Sar-E-Pul,2,Sozma Qala,1,Sabzi Kalan,22,Building,4,2,0,TRUE
+2204044,66.34099154,36.04318815,2,Do-Aba Boys School,Sar-E-Pul,3,Sozma Qala,1,Do-Aba,22,Building,4,3,0,TRUE
+2204045,66.22620745,36.07793943,1,Faiz Abad Mosque,Sar-E-Pul,2,Sozma Qala,1,Faiz Abad,22,Building,4,2,0,TRUE
+2204047,66.29019732,36.06989894,1,Bagh Ishaaq Village Mosque,Sar-E-Pul,2,Sozma Qala,1,Bagh Ishaaq Village,22,Building,4,2,0,TRUE
+2204140,66.124362818,35.875472772,2,School,Sar-E-Pul,3,Sozma Qala,1,Malek Uzbakia Village,22,Building,4,3,0,TRUE
+2204141,66.236171748,36.043066468,2,Mosque,Sar-E-Pul,3,Sozma Qala,1,Safar Qeshlaq,22,Building,4,3,0,TRUE
+2205101,66.40867715,35.71459969,3,Qashlaq Kuhna Village Madrassa,Sar-E-Pul,4,Sang Charak,1,Qashlaq Kuhna Village,22,Building,5,4,0,TRUE
+2205102,66.28953992,35.77705931,1,Dehmarda Village Mosque,Sar-E-Pul,2,Sang Charak,1,Dehmarda Village,22,Building,5,2,0,TRUE
+2205103,66.33688544,35.86624099,2,Sabz Village Mosque,Sar-E-Pul,4,Sang Charak,2,Sabz Village,22,Building,5,4,0,TRUE
+2205104,66.35143747,35.8968961,2,Topkhana Village Mosque,Sar-E-Pul,3,Sang Charak,1,Topkhana Village,22,Building,5,3,0,TRUE
+2205105,66.35576151,35.94041887,2,Qatar Darakht Mosque,Sar-E-Pul,4,Sang Charak,2,Qatar Darakht,22,Building,5,4,0,TRUE
+2205106,66.36867878,35.96487932,2,Irfan Secondary School,Sar-E-Pul,4,Sang Charak,2,Khulkhana Tafaikhor Village,22,Building,5,4,0,TRUE
+2205107,66.3778922,35.98860967,2,Tabeer-O-Taghai Khwaja High School,Sar-E-Pul,4,Sang Charak,2,Bahar Naw Tabra,22,Building,5,4,0,TRUE
+2205108,66.41758237,35.94983207,2,Shahr-E-Kuhna Takzar Boys Secondary School,Sar-E-Pul,4,Sang Charak,2,Shahr-E-Kuhna Takzaz,22,Building,5,4,0,TRUE
+2205109,66.41060503,35.89590492,1,Baharak Village Mosque,Sar-E-Pul,2,Sang Charak,1,Baharak Village,22,Building,5,2,0,TRUE
+2205110,66.3884242,35.86045593,1,Shbokand Village Mosque,Sar-E-Pul,2,Sang Charak,1,Shabokand Village,22,Building,5,2,0,TRUE
+2205111,66.44215851,35.95968159,2,Chinar Mosque,Sar-E-Pul,4,Sang Charak,2,Farshaqan Kalan Village,22,Building,5,4,0,TRUE
+2205112,66.46231784,35.8845023,1,Aaq Pai Village Madrassa,Sar-E-Pul,2,Sang Charak,1,Aaq Pai Village,22,Building,5,2,0,TRUE
+2205113,66.44255611,35.8593959,1,Charoo Mosque,Sar-E-Pul,2,Sang Charak,1,Charoo Ulya,22,Building,5,2,0,TRUE
+2205116,66.39752112,36.01072321,2,Archatoo Primary School,Sar-E-Pul,4,Sang Charak,2,Archatoo,22,Building,5,4,0,TRUE
+2205117,66.35737447,35.99685151,2,Number 2 Village Primary School,Sar-E-Pul,3,Sang Charak,1,Abdeen Kol,22,Building,5,3,0,TRUE
+2205118,66.38167982,36.05966847,1,Arab Bay Village Primary School,Sar-E-Pul,2,Sang Charak,1,Arab Bai Village,22,Building,5,2,0,TRUE
+2205119,66.45884443,35.93637667,1,Farshqan Miyana Mosque,Sar-E-Pul,2,Sang Charak,1,Farshaqan Miyana,22,Building,5,2,0,TRUE
+2205120,66.4097305,36.05550148,1,Rostam Qaryadar Mosque,Sar-E-Pul,2,Sang Charak,1,Larak Afghania,22,Building,5,2,0,TRUE
+2205121,66.36859865,35.73040866,1,Kabood Aab Mosque,Sar-E-Pul,2,Sang Charak,1,Pushta Kabood Aab Village,22,Building,5,2,0,TRUE
+2205142,66.373931824,36.039848479,2,Khwaja Surkh School,Sar-E-Pul,3,Sang Charak,1,Khwaja Sorkh,22,Village,5,3,0,TRUE
+2206123,66.44830765,36.19745471,4,Kaarez Village Secondary School,Sar-E-Pul,6,Gosfandi,2,Karez Village,22,Building,6,6,0,TRUE
+2206124,66.57553751,36.06651494,1,Shekyar Village Mosque,Sar-E-Pul,2,Gosfandi,1,Shekyar Village,22,Building,6,2,0,TRUE
+2206125,66.52937007,35.99770917,2,Alghan Village Mosque,Sar-E-Pul,3,Gosfandi,1,Alghan Village,22,Building,6,3,0,TRUE
+2206126,66.46556373,36.03007173,1,Uzbekya Larak Mosque,Sar-E-Pul,2,Gosfandi,1,Larak Uzbekya,22,Village,6,2,0,TRUE
+2206127,66.519408892,35.939272002,2,Qotnamest Village Boys School,Sar-E-Pul,4,Gosfandi,2,Qotnamest Village,22,Building,6,4,0,TRUE
+2206128,66.50507112,35.91552843,2,Maleekan Village Madrassa,Sar-E-Pul,3,Gosfandi,1,Maleekan Village,22,Building,6,3,0,TRUE
+2206129,66.48618482,35.86972977,2,Shah Mard Village Madrassa,Sar-E-Pul,3,Gosfandi,1,Shah Mard Village,22,Building,6,3,0,TRUE
+2206130,66.52368167,35.91086629,2,Karan Village Madrassa,Sar-E-Pul,4,Gosfandi,2,Karan Village,22,Building,6,4,0,TRUE
+2206131,66.51866337,35.87475985,2,Khwaja Nahan Mosque,Sar-E-Pul,3,Gosfandi,1,Khasar Village,22,Building,6,3,0,TRUE
+2206132,66.56350641,35.7682304,1,Aabdara Village Mosque,Sar-E-Pul,2,Gosfandi,1,Aabdara Village,22,Building,6,2,0,TRUE
+2206133,66.59494873,35.90627849,2,Haji Sarwar Mosque,Sar-E-Pul,3,Gosfandi,1,Sayad Ulya Village,22,Building,6,3,0,TRUE
+2206134,66.53189742,36.00027945,2,Alghan Afghania Mosque,Sar-E-Pul,4,Gosfandi,2,Alghan Afghania,22,Building,6,4,0,TRUE
+2206135,66.56782719,35.86274392,1,Qarya Aabkhor Secondary School,Sar-E-Pul,2,Gosfandi,1,Aabkhor Village,22,Building,6,2,0,TRUE
+2206136,66.51863414,35.95484356,2,Yoltarab Girls Secondary School,Sar-E-Pul,3,Gosfandi,1,Yoltarab Village,22,Building,6,3,0,TRUE
+2206143,66.666373394,36.091067853,2,Mosque,Sar-E-Pul,3,Gosfandi,1,Chaghdan,22,Building,6,3,0,TRUE
+2207087,66.91759075,35.65852671,3,Tagab Takht Madrassa,Sar-E-Pul,4,Balkhab,1,Tagab Takht,22,Building,7,4,0,TRUE
+2207088,66.84727053,35.60949204,2,Tal Aashoqan Madrassa,Sar-E-Pul,3,Balkhab,1,Tal Ashoqan,22,Building,7,3,0,TRUE
+2207089,66.74628893,35.57185504,3,Shaheed Arefi High School,Sar-E-Pul,5,Balkhab,2,Zo Village,22,Building,7,5,0,TRUE
+2207090,66.79544838,35.4636563,3,Doshakh School,Sar-E-Pul,5,Balkhab,2,Doshakh,22,Building,7,5,0,TRUE
+2207091,66.71674994,35.57724984,2,Tolo Jorazi High School,Sar-E-Pul,4,Balkhab,2,Jorazi,22,Building,7,4,0,TRUE
+2207092,66.59740448,35.49975181,3,Qarya Osh School,Sar-E-Pul,5,Balkhab,2,Osh Village,22,Building,7,5,0,TRUE
+2207093,66.52040993,35.5032326,4,Sayed Jamaluddin Primary School,Sar-E-Pul,6,Balkhab,2,Takhoj,22,Building,7,6,0,TRUE
+2207094,66.44140698,35.45935187,3,Pay Ziarat Mosque,Sar-E-Pul,5,Balkhab,2,Pay Ziarat,22,Building,7,5,0,TRUE
+2207095,66.33172895,35.41564898,2,Peghola Madrassa,Sar-E-Pul,4,Balkhab,2,Peghola,22,Building,7,4,0,TRUE
+2207096,66.52322972,35.38185455,3,Khormatakht Madrassa,Sar-E-Pul,4,Balkhab,1,Khormatakht,22,Building,7,4,0,TRUE
+2207097,66.40347416,35.30891734,2,Zawj Madrassa,Sar-E-Pul,4,Balkhab,2,Zawj,22,Building,7,4,0,TRUE
+2207098,66.60898963,35.67001757,3,Bajgah Madrassa,Sar-E-Pul,4,Balkhab,1,Shekh Mang,22,Building,7,4,0,TRUE
+2207099,66.48435665,35.51310267,2,Khowal Siyagak Mosque,Sar-E-Pul,3,Balkhab,1,Khowal Siyagak,22,Building,7,3,0,TRUE
+2207100,66.56947356,35.66846562,2,Pitab Secondar School,Sar-E-Pul,4,Balkhab,2,Pitab,22,Building,7,4,0,TRUE
+2301001,65.25869389,34.52115061,6,Sultan Alauddin Ghori High School,Ghor,10,Chighcheran,4,Taht Shahr,23,Building,1,10,0,TRUE
+2301002,65.25763548,34.52486889,5,Sultan Razia Ghori High School,Ghor,9,Chighcheran,4,Dahn Kasi,23,Building,1,9,0,TRUE
+2301003,65.11681846,34.5440849,4,Alandar School,Ghor,6,Chighcheran,2,Alandar,23,Building,1,6,0,TRUE
+2301004,65.29813308,34.47103847,3,Shekh-Ul-Mond Mosque,Ghor,5,Chighcheran,2,Shekh-Ul-Mond,23,Building,1,5,0,TRUE
+2301005,65.40862607,34.32874465,4,Zartali School,Ghor,6,Chighcheran,2,Kanjak,23,Building,1,6,0,TRUE
+2301006,65.40259383,34.2057611,4,Bazaar Qibi,Ghor,5,Chighcheran,1,Qebi Dahna Shor Qol,23,Building,1,5,0,TRUE
+2301007,65.08616143,34.65585925,4,Khwaja Ghaar Primary School,Ghor,6,Chighcheran,2,Khwaja Ghaar,23,Building,1,6,0,TRUE
+2301008,65.1207597,34.45342651,4,Tagha-E-Taimur School,Ghor,5,Chighcheran,1,Tagha-E-Taimur,23,Village,1,5,0,TRUE
+2301009,65.29291044,34.60099389,4,Kaasi Ulya School,Ghor,6,Chighcheran,2,Sar Pul Kasi,23,Building,1,6,0,TRUE
+2301010,65.4412381,34.45102053,3,Tasraghi School,Ghor,5,Chighcheran,2,Dahn Qiyaghak,23,Building,1,5,0,TRUE
+2301011,64.6885369,34.60557258,4,Sar Tagab Secondary School,Ghor,6,Chighcheran,2,Shahr-E-Naw,23,Building,1,0,6,FALSE
+2301012,65.00104257,34.67500197,4,Lal Mohammad Private House,Ghor,6,Chighcheran,2,Shora Bazar,23,Village,1,6,0,TRUE
+2301013,65.48809266,34.52073045,4,Badgah Girls High School,Ghor,5,Chighcheran,1,Badgah,23,Building,1,5,0,TRUE
+2301014,65.05962008,34.47078839,4,Ahengaran School,Ghor,7,Chighcheran,3,Ahengaran,23,Village,1,7,0,TRUE
+2301015,64.98555787,34.43377261,3,Amrotak Mosque,Ghor,5,Chighcheran,2,Amrotak,23,Village,1,5,0,TRUE
+2301016,64.96471488,34.55616574,4,Bara Khana Clinic,Ghor,6,Chighcheran,2,Bara Khana,23,Building,1,6,0,TRUE
+2301017,64.92134177,34.64503323,3,Abdul Ahmad Open Space,Ghor,5,Chighcheran,2,Lashara Sufla,23,Village,1,5,0,TRUE
+2301018,65.30353115,34.87356121,4,That Ghelmeen High School,Ghor,6,Chighcheran,2,Kashkak,23,Building,1,0,6,FALSE
+2301019,64.64632327,34.6325231,4,Dahna Do-Abi,Ghor,6,Chighcheran,2,Aab Kalan,23,Village,1,6,0,TRUE
+2301020,65.48174425,34.5220623,3,Badgah Showech,Ghor,5,Chighcheran,2,Badgah,23,Village,1,5,0,TRUE
+2301021,64.81806433,34.60377287,4,Bara Khana Maidan High School,Ghor,5,Chighcheran,1,Tangai Zard,23,Building,1,5,0,TRUE
+2301022,65.183419136,34.73448532,3,Abdul Rahman Private House,Ghor,4,Chighcheran,1,Sar Ji,23,District,1,4,0,TRUE
+2301023,65.85197676,35.03999785,2,Abdul Haq Open Space,Ghor,4,Chighcheran,2,Aab Reem,23,Village,1,4,0,TRUE
+2301024,65.55135784,34.28206278,3,Nadir Khan Pahlo Sang Qala,Ghor,4,Chighcheran,1,Pahlo Sang,23,Village,1,4,0,TRUE
+2301025,64.94778507,34.44865723,2,Sokhta-E-Sufla Mosque,Ghor,4,Chighcheran,2,Sokhta-E-Sufla,23,Building,1,4,0,TRUE
+2301026,65.157064637,34.239301675,2,Dahak Ghoriha Mosque,Ghor,4,Chighcheran,2,Dahna,23,Building,1,4,0,TRUE
+2301027,65.18328385,34.45914619,2,Bahari Sufla Mosque,Ghor,4,Chighcheran,2,Bahari Sufla,23,Building,1,6,0,TRUE
+2301028,65.36159133,34.56424449,2,Qots Sufla Secondary School,Ghor,4,Chighcheran,2,Qots Sufla,23,Building,1,4,1,TRUE
+2301029,65.24894707,34.87349369,3,Sadmen Ghelmeen Primary School,Ghor,5,Chighcheran,2,Darband,23,Building,1,0,5,FALSE
+2301030,64.85337765,34.52802515,2,Plal Gorgi Village Mosque,Ghor,4,Chighcheran,2,Plal Gorgi Village,23,Building,1,4,0,TRUE
+2301031,64.769593198,35.216059952,2,Hawz Saaleh,Ghor,4,Chighcheran,2,Hawz Saaleh,23,Village,1,4,0,TRUE
+2301032,65.34720404,34.23514805,2,Abdul Zahir Private House,Ghor,4,Chighcheran,2,Abul Ghaibi,23,Village,1,4,0,TRUE
+2301033,64.98175567,34.72115669,2,Lakhshak Bazar,Ghor,3,Chighcheran,1,Lakhshak,23,Building,1,3,0,TRUE
+2301034,64.81748049,34.71326514,1,Sanmay Rakhna Safid Mosque,Ghor,3,Chighcheran,2,Sanmay Rakhna Safid,23,Village,1,3,0,TRUE
+2301035,64.65098401,34.55458393,4,Ghulaman School,Ghor,5,Chighcheran,1,Ghulaman,23,Building,1,5,0,TRUE
+2301039,65.70398113,34.99556325,3,Jandak School,Ghor,5,Chighcheran,2,Jandak,23,Village,1,0,5,FALSE
+2301040,65.64286237,34.97977395,2,Istarman Mosque,Ghor,4,Chighcheran,2,Markaz Istarman,23,Village,1,0,4,FALSE
+2301041,64.94832252,34.62829209,2,Chashma Kaj Mosque,Ghor,3,Chighcheran,1,Chashma Kaj,23,Village,1,3,0,TRUE
+2301042,65.78807713,35.00158748,2,Khema Safid Mosque,Ghor,3,Chighcheran,1,Khel Azam,23,Village,1,3,0,TRUE
+2301045,65.44099928,34.88362632,3,Tameer Hassan,Ghor,5,Chighcheran,2,Ghaar Siyagak,23,Village,1,0,5,FALSE
+2301235,64.81949201,34.6045462,2,Maidan Bara Khana,Ghor,4,Chighcheran,2,Bara Khana,23,Building,1,4,0,TRUE
+2301236,65.26293459,34.47116433,3,Dahn Kandiwal,Ghor,5,Chighcheran,2,Dahn Kandiwal,23,Village,1,5,0,TRUE
+2301239,64.703197214,34.566674924,2,Shakh Malan Mosque,Ghor,3,Chighcheran,1,Shakh Malan_Cheshma Sakina,23,Building,1,3,0,TRUE
+2302098,64.83259277,33.92293207,2,Zameen Dasht Farah Rod,Ghor,3,Duleena,1,Farah Rod,23,Village,2,3,0,TRUE
+2302099,64.69151874,34.04978444,1,Shaheedan Mosque,Ghor,2,Duleena,1,Shaheedan,23,Village,2,2,0,TRUE
+2302100,64.90466557,33.88372044,1,Mohammad Yaqoob Private House,Ghor,2,Duleena,1,Chashma Safid,23,Village,2,2,0,TRUE
+2302101,64.88174259,34.27261155,1,Gala Asyaab Bazar,Ghor,3,Duleena,2,Gala Asyaab,23,Village,2,3,0,TRUE
+2302102,64.78336585,34.15672576,2,Dolina School,Ghor,3,Duleena,1,Markaz Dolina,23,Building,2,3,0,TRUE
+2302103,65.10441923,34.18577622,2,Garma Bak Arbab Maazallah,Ghor,3,Duleena,1,Qala-E-Naqshi,23,Building,2,3,0,TRUE
+2302104,64.859652245,34.444350772,2,Fazal Ahmad Bagh,Ghor,4,Duleena,2,Khwaja Gan,23,Village,2,4,0,TRUE
+2302105,64.69357218,34.39352751,1,Arbab Sakhi Private House,Ghor,3,Duleena,2,Razqan,23,Village,2,3,0,TRUE
+2302106,65.47292569,34.00245591,2,Siya Chob Bazar,Ghor,3,Duleena,1,Siya Chob,23,Village,2,3,0,TRUE
+2302108,64.80037387,34.4074557,1,Salmeen School,Ghor,3,Duleena,2,Salmeen,23,Building,2,3,0,TRUE
+2302110,64.85495172,34.00716375,2,Sar Chehl Gazai Mosque,Ghor,3,Duleena,1,Chehl Gazai,23,Village,2,3,0,TRUE
+2302238,64.77924563,34.18169312,1,Dolina Bazar Tent,Ghor,2,Duleena,1,Bazar Dolina,23,Village,2,2,0,TRUE
+2303046,65.78680996,34.55552929,3,Dawlatyar School,Ghor,4,Dawlatyar,1,Markaz Dawlat Yar,23,Building,3,4,0,TRUE
+2303047,65.91717699,34.63458067,2,Poshta Noor School,Ghor,4,Dawlatyar,2,Joy Nashr,23,Village,3,4,0,TRUE
+2303048,65.79939867,34.43940497,1,Darwaza Mosque,Ghor,2,Dawlatyar,1,Darwaza,23,Village,3,2,0,TRUE
+2303049,65.66050378,34.52478221,2,Shiniya Mosque,Ghor,3,Dawlatyar,1,Shiniya,23,Building,3,3,0,TRUE
+2303050,65.7166036,34.58221754,2,Khairullah Mosque,Ghor,3,Dawlatyar,1,Sharshar,23,Building,3,3,0,TRUE
+2303051,65.76989614,34.44035306,2,Sang Shora Mosque,Ghor,4,Dawlatyar,2,Sang Shora,23,Village,3,4,0,TRUE
+2303052,65.83823426,34.66676784,1,Bazar Samak Tent,Ghor,2,Dawlatyar,1,Samak Village,23,Building,3,0,2,FALSE
+2303053,65.86803751,34.43509059,1,Narm Tih Mosque,Ghor,2,Dawlatyar,1,Narm Tih,23,Building,3,2,0,TRUE
+2303054,65.66908157,34.44386177,1,Geri Imam Dad School,Ghor,2,Dawlatyar,1,Geri Imam Dad,23,Village,3,2,0,TRUE
+2303055,65.85712162,34.55180943,2,Ali Bazar Village Mosque,Ghor,3,Dawlatyar,1,Ali Bazar Village,23,Village,3,3,0,TRUE
+2303056,65.78412716,34.55874311,1,Deh Morda Bazar,Ghor,2,Dawlatyar,1,Deh Morda,23,Building,3,2,0,TRUE
+2303057,65.67075304,34.44121009,2,Loka Mazar Mosque,Ghor,3,Dawlatyar,1,Loka Mazar,23,Building,3,3,0,TRUE
+2303058,65.73594199,34.66988765,1,Jira School,Ghor,3,Dawlatyar,2,Awlad Qadam,23,Building,3,3,0,TRUE
+2303237,65.79551043,34.55153232,1,Bazar Tent,Ghor,2,Dawlatyar,1,Bazar,23,Building,3,2,0,TRUE
+2304059,64.95196839,35.14103838,2,Mohammad Ibrahim Private House,Ghor,4,Char Sada,2,Malmanj,23,Building,4,4,0,TRUE
+2304060,65.0722261,35.03095756,3,Khafak Mosque,Ghor,4,Char Sada,1,Khafak,23,Building,4,4,0,TRUE
+2304061,65.05811208,35.05536874,2,Khonia Village Mosque,Ghor,3,Char Sada,1,Khonia,23,Building,4,3,0,TRUE
+2304062,65.20050902,35.16310548,2,Shamaroq Village Mosque,Ghor,3,Char Sada,1,Shamaroq,23,Village,4,3,0,TRUE
+2304063,65.18763308,35.03931853,2,Deh Haji School,Ghor,3,Char Sada,1,Deh Haji,23,Building,4,0,3,FALSE
+2304064,65.1315262,35.17707778,3,Qala Gawhar High School,Ghor,4,Char Sada,1,Gawhar Qala,23,Building,4,4,0,TRUE
+2304066,64.87965093,35.1918517,2,Najibullah Private House,Ghor,3,Char Sada,1,Pas Archa,23,Village,4,3,0,TRUE
+2304067,65.25089541,35.11118596,2,Falakhor Mosque,Ghor,3,Char Sada,1,Falakhor,23,Village,4,3,0,TRUE
+2304069,65.05918863,35.1751676,2,Maseen Mosque,Ghor,3,Char Sada,1,Maseen,23,Building,4,3,0,TRUE
+2304070,65.10760991,35.10481925,2,Korpai School,Ghor,4,Char Sada,2,Korpai,23,Building,4,4,0,TRUE
+2304071,64.89881573,35.17950238,2,Bagh Habibullah,Ghor,3,Char Sada,1,Kandakh,23,Building,4,3,0,TRUE
+2305111,65.0634923,33.57960026,2,Sangan School,Ghor,3,Pasaband,1,Bazar Sangan,23,Building,5,3,0,TRUE
+2305113,64.8916015,33.78764238,2,Takhta Tarma Bazar Tent,Ghor,3,Pasaband,1,Takhta Tarma Village,23,Building,5,3,0,TRUE
+2305114,65.10444131,33.70155416,2,Bazar Kalagi Tent,Ghor,4,Pasaband,2,Kalagi Village,23,Village,5,4,0,TRUE
+2305115,65.25619797,33.85572796,2,Khum Bolaq School,Ghor,3,Pasaband,1,Khum Bolaq,23,Building,5,3,0,TRUE
+2305116,65.40423408,33.67678929,1,Talmestan School,Ghor,4,Pasaband,3,Talmestan,23,Building,5,4,0,TRUE
+2305117,65.40511178,33.64279984,2,Aspi Boz School,Ghor,3,Pasaband,1,Aspi Boz,23,Village,5,3,0,TRUE
+2305118,64.848727,33.69216423,1,Kuhna Shenkot Bazar Tent,Ghor,2,Pasaband,1,Shinkot Village,23,Village,5,2,0,TRUE
+2305119,64.8814651,33.78655058,1,Norak Primary School,Ghor,2,Pasaband,1,Norak Markaz,23,Building,5,2,0,TRUE
+2305126,64.99374857,33.58383586,1,Khushka Aab Bazar Tent,Ghor,2,Pasaband,1,Khushka Aba,23,Building,5,2,0,TRUE
+2305129,65.19422547,33.70256215,1,Dahna Dewalak School,Ghor,3,Pasaband,2,Bazar Dahan Pushta Roq,23,Building,5,3,0,TRUE
+2305131,65.54864266,33.71168293,2,Petaab School,Ghor,3,Pasaband,1,Pitab,23,Village,5,3,0,TRUE
+2305133,65.09806065,33.6521137,1,Dahan Kalagi Mosque,Ghor,2,Pasaband,1,Dahan Kalagi,23,Building,5,2,0,TRUE
+2306072,64.31035099,34.10813606,3,Markaz Shahrak High School,Ghor,4,Shahrak,1,Markaz Shahrak,23,Building,6,4,0,TRUE
+2306073,64.50308604,34.10706276,2,Oshan School,Ghor,3,Shahrak,1,Dotaye Dahna,23,Building,6,3,0,TRUE
+2306074,64.36450817,34.3546592,1,Kamanj School,Ghor,3,Shahrak,2,Ghok,23,Building,6,3,0,TRUE
+2306075,64.41972424,34.13230083,1,Sar Chashma School,Ghor,3,Shahrak,2,Sarchashma,23,Building,6,3,0,TRUE
+2306076,64.27539915,34.37217401,2,Agricultural Land / Open Space,Ghor,3,Shahrak,1,Dahn Murgha,23,Village,6,3,0,TRUE
+2306077,64.24306711,33.99650487,1,Kaarez Ishaq Mosque,Ghor,2,Shahrak,1,Kaarez Ishaq,23,Building,6,2,0,TRUE
+2306078,64.07092777,34.15309857,1,Dahn Hisar School,Ghor,3,Shahrak,2,Dahn Hisar,23,Village,6,3,0,TRUE
+2306079,64.34763666,34.38438752,1,Girls School,Ghor,2,Shahrak,1,Kamanj,23,Village,6,2,0,TRUE
+2306080,64.5456252,34.0081014,2,Khara Sang Mosque,Ghor,3,Shahrak,1,Khara Sang,23,Village,6,3,0,TRUE
+2306083,64.11548882,34.26801824,1,Nasfanj Primary School,Ghor,2,Shahrak,1,Nasfanji,23,Village,6,2,0,TRUE
+2306084,64.34968755,34.53247332,2,Jalga Mazar Primary School,Ghor,4,Shahrak,2,Jalga Mazar,23,Village,6,4,0,TRUE
+2306085,64.49711037,34.3649083,1,Jaam Primary School,Ghor,2,Shahrak,1,Jaam,23,Village,6,2,0,TRUE
+2306086,64.09427826,34.5055969,2,Barzo Primary School,Ghor,3,Shahrak,1,Barzo,23,Village,6,3,0,TRUE
+2306087,64.26494728,34.35146229,1,Margha Primary School,Ghor,2,Shahrak,1,Margha,23,Village,6,2,0,TRUE
+2306088,64.55199495,34.36338565,1,Ostwa Primary School,Ghor,2,Shahrak,1,Ostwa,23,Village,6,2,0,TRUE
+2306089,64.39221649,34.29115912,1,Yak Sang School,Ghor,2,Shahrak,1,Yaka Sang Village,23,Building,6,2,0,TRUE
+2306090,64.54532989,34.46017858,1,Bedan School,Ghor,2,Shahrak,1,Pala Surkhak,23,Building,6,2,0,TRUE
+2306091,64.3464841,34.38595992,1,Kamanj School,Ghor,2,Shahrak,1,Kamanj Ghok,23,Village,6,2,0,TRUE
+2306093,64.61690576,34.3756719,1,Khum Mosque,Ghor,2,Shahrak,1,Qala-E-Kodak,23,Village,6,2,0,TRUE
+2306094,64.21016372,34.12161796,1,Yaka Bed School,Ghor,2,Shahrak,1,Tangai Arzo,23,Building,6,2,0,TRUE
+2306095,64.27551853,33.89619263,1,Khwaja Bor Primary School,Ghor,2,Shahrak,1,Khwaja Bor,23,Village,6,2,0,TRUE
+2306097,64.51075208,34.1088952,1,Dahn Manara Primary School,Ghor,2,Shahrak,1,Siya Khak,23,Village,6,2,0,TRUE
+2307137,66.04347148,34.459791,3,Qazal School,Ghor,4,Lal Wa Sarjangal,1,Dahan Bareeki Village,23,Building,7,4,0,TRUE
+2307138,65.94952516,34.45425827,2,Garm Aab Sufla School,Ghor,4,Lal Wa Sarjangal,2,Sare Nodah Village,23,Building,7,4,0,TRUE
+2307139,65.94435495,34.37482346,1,Qala-E-Jangal Mosque,Ghor,2,Lal Wa Sarjangal,1,Qala-E-Jangal Village,23,Building,7,2,0,TRUE
+2307140,65.99943691,34.39251319,1,Sang Shanda School,Ghor,3,Lal Wa Sarjangal,2,Qala-E-Sang Shanda Village,23,Building,7,3,3,TRUE
+2307141,66.13716941,34.47380543,2,Chashma Padshah Primary School,Ghor,3,Lal Wa Sarjangal,1,Chashma Padshah Village,23,Building,7,3,0,TRUE
+2307142,66.20454934,34.47381959,2,Dahn Chaka School,Ghor,3,Lal Wa Sarjangal,1,Dahna Chaka,23,Building,7,3,0,TRUE
+2307143,66.16168708,34.36665361,2,Joqal School,Ghor,3,Lal Wa Sarjangal,1,Peshband Bala Village,23,Village,7,3,0,TRUE
+2307144,66.23578037,34.41086544,1,Qolani School,Ghor,2,Lal Wa Sarjangal,1,Qolani Village,23,Village,7,2,0,TRUE
+2307145,66.2817481,34.50016851,3,Laal Mosque,Ghor,5,Lal Wa Sarjangal,2,Dahan Saqawa,23,Building,7,5,0,TRUE
+2307146,66.45321372,34.51870653,2,Safarak Karman School,Ghor,3,Lal Wa Sarjangal,1,Bareshtogak Village,23,Village,7,3,0,TRUE
+2307147,66.34112402,34.51949802,1,Rashk Mosque,Ghor,2,Lal Wa Sarjangal,1,Rashk Village,23,Building,7,2,0,TRUE
+2307148,66.52105273,34.46095482,2,Sray Karman School,Ghor,3,Lal Wa Sarjangal,1,Siyasang Village,23,Building,7,3,0,TRUE
+2307149,66.51379602,34.39017549,2,Sarqal Talkhak School,Ghor,3,Lal Wa Sarjangal,1,Sarqal,23,Village,7,3,0,TRUE
+2307150,66.38217596,34.33006921,2,Dahan Sarkhak School,Ghor,3,Lal Wa Sarjangal,1,Dahan Sarkhak Bala,23,Building,7,3,0,TRUE
+2307151,66.32071734,34.3142852,1,Shiniya Sabzwar School,Ghor,3,Lal Wa Sarjangal,2,Sabzwar,23,Village,7,3,0,TRUE
+2307152,66.33964343,34.67172894,2,Safid Chashma Mosque,Ghor,3,Lal Wa Sarjangal,1,Safid Chashma Pitab,23,Village,7,3,0,TRUE
+2307153,66.12465571,34.55538971,3,Bekh Sang School,Ghor,4,Lal Wa Sarjangal,1,Diwkan Village,23,Building,7,4,0,TRUE
+2307154,66.35861918,34.42040414,1,Sare Diwalak School,Ghor,2,Lal Wa Sarjangal,1,Asad Abad Village,23,Building,7,2,0,TRUE
+2307155,66.33102378,34.6567314,2,Safid Aab Mosque,Ghor,5,Lal Wa Sarjangal,3,Sar Baghandi Village,23,Building,7,5,0,TRUE
+2307156,65.9320289,34.57898409,1,Dahn Laka Sang Mosque,Ghor,2,Lal Wa Sarjangal,1,Dahan Laka Sang Village,23,Building,7,2,0,TRUE
+2307157,66.38086345,34.64460881,1,Qala Shahr Mosque,Ghor,2,Lal Wa Sarjangal,1,Shah-E-Ulya Qala,23,Village,7,2,0,TRUE
+2307158,66.04356804,34.58484828,1,Sang Zard School,Ghor,2,Lal Wa Sarjangal,1,Sang Zard,23,Building,7,2,0,TRUE
+2307159,66.34146456,34.48657423,1,Qala Shakraki Mosque,Ghor,2,Lal Wa Sarjangal,1,Qala-E-Shakarki,23,Building,7,2,0,TRUE
+2307160,65.97820665,34.59507348,2,Kham Shor School,Ghor,3,Lal Wa Sarjangal,1,Dahan Kham Shor Village,23,Building,7,3,0,TRUE
+2307161,66.02642683,34.6645587,2,Kata Chashma School,Ghor,3,Lal Wa Sarjangal,1,Kata Chashma Village,23,Building,7,3,0,TRUE
+2307162,66.50848974,34.51694569,1,Siya Khaki Karman Primary School,Ghor,2,Lal Wa Sarjangal,1,Noghala Village,23,Village,7,2,0,TRUE
+2307163,66.58148841,34.55718165,1,Shorqal School,Ghor,2,Lal Wa Sarjangal,1,Deh Mohr Ali,23,Building,7,2,0,TRUE
+2307164,66.30260182,34.64330474,1,Sare Kamran Mosque,Ghor,2,Lal Wa Sarjangal,1,Sare Kamran,23,Village,7,2,0,TRUE
+2307165,66.27675657,34.58243711,2,Qala-E-Koshk School,Ghor,3,Lal Wa Sarjangal,1,Qala-E-Koshk,23,Building,7,3,0,TRUE
+2307166,66.35229984,34.73575352,1,Qala-E-Sar Asyagak Mosque,Ghor,2,Lal Wa Sarjangal,1,Qala Sar Asyagak Village,23,Village,7,2,0,TRUE
+2307167,66.258069,34.80712706,1,Qala Dangak School,Ghor,2,Lal Wa Sarjangal,1,Qala Dangak Village,23,Village,7,2,0,TRUE
+2307168,66.59280065,34.57021543,1,Safid Aab Shinya Mosque,Ghor,2,Lal Wa Sarjangal,1,Safid Aab Shinya,23,Village,7,2,0,TRUE
+2307169,66.55703029,34.61036941,2,Tagab Sayeed Mosque,Ghor,3,Lal Wa Sarjangal,1,Tagab Sayeed,23,Village,7,3,0,TRUE
+2307170,66.64107761,34.62696733,2,Shahi School,Ghor,3,Lal Wa Sarjangal,1,Pitab Shahi Village,23,Building,7,3,0,TRUE
+2307171,66.16878754,34.63821721,2,Chahar Asyab School,Ghor,3,Lal Wa Sarjangal,1,Dahan Ghulamak Village,23,Building,7,3,0,TRUE
+2307172,66.2061091,34.7300598,1,Ghighanak School,Ghor,2,Lal Wa Sarjangal,1,Sang Polak Village,23,Village,7,2,0,TRUE
+2307173,66.21421912,34.5722086,1,Shinya Haigal Mosque,Ghor,2,Lal Wa Sarjangal,1,Shinya Haigal,23,Village,7,2,0,TRUE
+2307174,66.40961091,34.59897385,1,Shinya Chaparqul School,Ghor,2,Lal Wa Sarjangal,1,Shinya Chaparqul,23,Village,7,2,0,TRUE
+2307175,66.46968251,34.46903092,1,Talto Karman School,Ghor,2,Lal Wa Sarjangal,1,Talto Village,23,Village,7,2,0,TRUE
+2307176,66.25268874,34.64942846,1,Aab Bareek School,Ghor,2,Lal Wa Sarjangal,1,Aab Bareek Village,23,Building,7,2,0,TRUE
+2307177,66.01518937,34.51962011,1,Sar Sokhta Mosque,Ghor,2,Lal Wa Sarjangal,1,Sar Sokhta Village,23,Building,7,2,0,TRUE
+2308209,64.41814755,33.52450558,3,Pas Qala High School,Ghor,4,Taywara,1,Pas Qala,23,Village,8,4,0,TRUE
+2308211,64.26253579,33.58988278,2,Aashoqan School,Ghor,3,Taywara,1,Aashoqan,23,Building,8,3,0,TRUE
+2308212,64.15545811,33.57948062,1,Abdullah Larqa Private House,Ghor,3,Taywara,2,Larqa,23,Building,8,3,0,TRUE
+2308213,64.28481091,33.80656761,2,Abdullah Paay Hisar Private House,Ghor,3,Taywara,1,Paay Hisar,23,Village,8,3,0,TRUE
+2308215,64.41245297,33.24331259,3,Nili School,Ghor,5,Taywara,2,Darz Aab,23,Village,8,5,0,TRUE
+2308216,64.4729016,33.61982457,1,Khum Paay Hisar School,Ghor,2,Taywara,1,Khum Paay Hisar,23,Village,8,2,0,TRUE
+2308218,64.19772037,33.33694635,1,Asfor School,Ghor,2,Taywara,1,Asfor,23,Building,8,2,0,TRUE
+2308223,64.23193105,33.46522637,2,Sayed Alauddin Private House,Ghor,3,Taywara,1,Yageen,23,Building,8,3,0,TRUE
+2308224,64.29369339,33.34644545,1,Abdul Salam Private House,Ghor,3,Taywara,2,Saayen,23,Building,8,3,0,TRUE
+2308225,64.36108936,33.23244096,2,Zalragak Bazar,Ghor,3,Taywara,1,Zalargak,23,Building,8,3,0,TRUE
+2308227,64.33476514,33.17906012,1,Zarni Secondary School,Ghor,3,Taywara,2,Zarni,23,Building,8,3,0,TRUE
+2308228,64.29382097,33.47083659,2,Qoba School,Ghor,3,Taywara,1,Qoba,23,Building,8,3,0,TRUE
+2308229,64.36821208,33.51431086,2,Zahi Nawroz School,Ghor,3,Taywara,1,Zahi Nawroz,23,Building,8,3,0,TRUE
+2308232,64.22200661,33.59241815,1,Seb Talkh School,Ghor,2,Taywara,1,Seb Talkh,23,Village,8,2,0,TRUE
+2309178,63.71988353,33.97186444,3,Tolak School,Ghor,4,Tulak,1,Khwajaha Village,23,Building,9,4,0,TRUE
+2309179,63.6891388,34.12971312,2,Chahar Raah Tolak School,Ghor,4,Tulak,2,Dahan Aab Bara,23,Village,9,4,0,TRUE
+2309180,63.71176961,34.15151798,2,Dahan Paloon Mosque,Ghor,3,Tulak,1,Paloon,23,Village,9,3,0,TRUE
+2309181,63.90040867,33.99119319,1,Dahan Guldan Mosque,Ghor,2,Tulak,1,Dahan Guldan,23,Village,9,2,0,TRUE
+2309182,63.72614579,33.97656562,2,Kabotar Khan Primary School,Ghor,4,Tulak,2,Kabotar Khan,23,Building,9,0,4,FALSE
+2309183,63.71729853,33.92025724,2,Kaah Dehro Primary School,Ghor,3,Tulak,1,Kaah Dehro,23,Village,9,3,0,TRUE
+2309184,63.698247,33.806603,2,Dorody Bazar,Ghor,4,Tulak,2,Khufta Village,23,Village,9,4,0,TRUE
+2309185,63.75256255,34.13652324,2,Arbab Ghafoor Private House,Ghor,3,Tulak,1,Abshikan,23,Village,9,3,0,TRUE
+2309186,63.63185896,34.12008072,3,Tagab Ashlan Secondary School,Ghor,4,Tulak,1,Tagab Ashlan,23,Village,9,4,0,TRUE
+2309187,63.55742742,34.17968852,2,Dayee Secondary School,Ghor,3,Tulak,1,Dayee Village,23,Village,9,3,0,TRUE
+2309188,63.51807848,34.05114576,2,Kotah Mosque,Ghor,3,Tulak,1,Kotah,23,Village,9,3,0,TRUE
+2309189,63.82927902,33.82865917,2,Khameen Secondary School,Ghor,3,Tulak,1,Rabat,23,Village,9,3,0,TRUE
+2309190,63.85116644,34.14520214,2,Arbab Malek Private House,Ghor,4,Tulak,2,Gaw Gosh,23,Village,9,4,0,TRUE
+2309191,63.70859036,34.16167874,1,Naw Chara Primary School,Ghor,2,Tulak,1,Naw Chara,23,Village,9,2,0,TRUE
+2309192,63.51956725,34.15350051,1,Arbab Mir Gul Private House,Ghor,2,Tulak,1,Laraq,23,Village,9,2,0,TRUE
+2309193,63.79730451,33.94593145,2,Sang Khalq Primary School,Ghor,3,Tulak,1,Sang Khalq,23,Building,9,3,0,TRUE
+2309194,63.65145572,34.12848215,2,Gazak School,Ghor,3,Tulak,1,Gazak,23,Village,9,3,0,TRUE
+2309195,63.61372911,33.85461696,2,Arbab Rasool Private House,Ghor,3,Tulak,1,Khakchah,23,Village,9,3,0,TRUE
+2310196,63.86259882,33.69070712,3,Shekh Mohammad Saghar School,Ghor,4,Saghar,1,Taitan,23,Building,10,4,0,TRUE
+2310197,63.8569465,33.69380454,2,Saghar Girls High School,Ghor,4,Saghar,2,Taitan,23,Building,10,4,0,TRUE
+2310198,63.70327572,33.64586356,2,Deh Sheer Secondary School,Ghor,3,Saghar,1,Deh Sheer,23,Building,10,3,0,TRUE
+2310199,63.46830262,33.54298048,1,Dila Bagh,Ghor,3,Saghar,2,Dila,23,Village,10,3,0,TRUE
+2310200,63.972337786,33.853533123,1,Dahn Dotayee School,Ghor,2,Saghar,1,Dahan Dotayee,23,Village,10,2,0,TRUE
+2310201,63.89883358,33.67354458,2,Manak Sufla Secondary School,Ghor,3,Saghar,1,Manak Sufla,23,Village,10,3,0,TRUE
+2310202,63.72011326,33.42967945,2,Aspiyasang Primary School,Ghor,3,Saghar,1,Aspiyasang,23,Building,10,3,0,TRUE
+2310203,63.40607005,33.6125326,1,Sholich Mosque,Ghor,2,Saghar,1,Sholich,23,Village,10,2,0,TRUE
+2310204,63.5970147,33.64255038,2,Akheri Secondary School,Ghor,4,Saghar,2,Akheri,23,Building,10,4,0,TRUE
+2310205,63.98685635,33.78979922,1,Zer Tangi Mosque,Ghor,2,Saghar,1,Zer Tangi,23,Village,10,2,0,TRUE
+2310206,63.60020645,33.50877588,1,Zer Tangi Qarya Zaal,Ghor,2,Saghar,1,Zaal Village,23,Village,10,2,0,TRUE
+2310207,63.41744943,33.47191941,2,Masjidi Primary School,Ghor,3,Saghar,1,Masjedi,23,Village,10,3,0,TRUE
+2310208,63.84187621,33.68603174,1,Mohammad Amin Private House,Ghor,2,Saghar,1,Jarmana,23,Village,10,2,0,TRUE
+2310240,63.796220288,33.522542349,2,Naga School,Ghor,3,Saghar,1,Naga,23,Building,10,3,0,TRUE
+2401001,66.14048854,33.72200112,6,Kuhna Deh Mosque,Daykundi,10,Nili,4,"Kuhna Deh, Nili",24,Building,1,10,0,TRUE
+2401002,66.09671798,33.84807219,3,Jaraf Mosque,Daykundi,6,Nili,3,Jaraf,24,Building,1,6,0,TRUE
+2401003,66.02443966,33.84077196,2,Shish School,Daykundi,4,Nili,2,Shish,24,Building,1,4,0,TRUE
+2401004,66.16112607,33.8866269,2,Bazar Pishok Mosque,Daykundi,4,Nili,2,Pishok,24,Building,1,4,0,TRUE
+2401005,66.19996687,33.82243119,1,Bala Bagh Lazir School,Daykundi,4,Nili,3,Lazir,24,Building,1,4,0,TRUE
+2401006,66.10617947,33.7688089,1,Mesh Sufla Mosque,Daykundi,4,Nili,3,Mesh,24,Building,1,4,0,TRUE
+2401007,66.14335153,33.69642324,2,Sang Moom Mosque,Daykundi,5,Nili,3,Sang Moom,24,Building,1,5,0,TRUE
+2401008,66.15224204,33.75897298,5,Dasht Mosque,Daykundi,8,Nili,3,Dasht,24,Building,1,8,0,TRUE
+2401009,65.94606718,33.75999414,2,Siyok Haqdad Mosque,Daykundi,4,Nili,2,Siyok,24,Building,1,4,0,TRUE
+2401010,66.12862828,33.87678152,2,Qol Qadir Mosque,Daykundi,4,Nili,2,Qol Qadir,24,Building,1,4,0,TRUE
+2401011,66.1419911,33.79778875,2,Hajdi Mosque,Daykundi,4,Nili,2,Hajdi,24,Building,1,4,0,TRUE
+2401012,66.17854221,33.69695559,3,Pai Nili Mosque,Daykundi,5,Nili,2,Pai Nili,24,Building,1,5,0,TRUE
+2401169,66.0618134,33.849351249,2,Mosque,Daykundi,4,Nili,2,Jaw Qul,24,Building,1,4,0,TRUE
+2401170,66.08057521,33.747913407,2,Mosque,Daykundi,4,Nili,2,Mish Hulia,24,Building,1,4,0,TRUE
+2402013,66.43822593,33.6686245,3,Waras School,Daykundi,5,Shahristan,2,"Waras, Surkh Keji",24,Building,2,5,0,TRUE
+2402014,66.73786243,33.58614722,1,Olak Mosque,Daykundi,2,Shahristan,1,Olak,24,Building,2,2,0,TRUE
+2402015,66.32841832,33.74388019,2,Shiniya Mosque,Daykundi,4,Shahristan,2,Shiniya Haidar Beg,24,Building,2,4,0,TRUE
+2402016,66.60552723,33.67066782,1,Palich Mosque,Daykundi,2,Shahristan,1,Palich,24,Building,2,2,0,TRUE
+2402017,66.26937451,33.75127169,2,Band Barlan Mosque,Daykundi,4,Shahristan,2,Band Barlan,24,Building,2,5,0,TRUE
+2402018,66.43822547,33.79647037,1,Dahn Deh Osho Mosque,Daykundi,2,Shahristan,1,Dahn Deh Osho,24,Building,2,2,0,TRUE
+2402019,66.54928033,33.69570692,2,Olqan Mosque,Daykundi,4,Shahristan,2,Olqan,24,Building,2,4,0,TRUE
+2402020,66.39620431,33.8886167,1,Tagab Largar Mosque,Daykundi,2,Shahristan,1,Tagab Largar,24,Building,2,2,0,TRUE
+2402021,66.72049249,33.78206056,1,Chaprasak Mosque,Daykundi,3,Shahristan,2,Chaprasak,24,Building,2,3,0,TRUE
+2402022,66.47514092,33.74757647,3,Ghojgard Mosque,Daykundi,5,Shahristan,2,Ghojgard,24,Building,2,5,0,TRUE
+2402023,66.24121903,33.78331847,3,Chaharaspan Mosque,Daykundi,5,Shahristan,2,Chaharaspan,24,Building,2,5,0,TRUE
+2402024,66.26024213,33.64992188,3,Shalij Mosque,Daykundi,5,Shahristan,2,Shalij,24,Building,2,5,0,TRUE
+2402025,66.58585862,33.60942849,1,Ashkar Abad Mosque,Daykundi,2,Shahristan,1,Ashkar Abad,24,Building,2,2,0,TRUE
+2402026,66.72782011,33.54025865,1,Chochan Mosque,Daykundi,2,Shahristan,1,Chochan,24,Building,2,2,0,TRUE
+2402027,66.68482688,33.66619243,1,Jangalak Mosque,Daykundi,2,Shahristan,1,Jangalak,24,Building,2,2,0,TRUE
+2402028,66.79730199,33.5946216,1,Sayed Alam Mosque,Daykundi,2,Shahristan,1,Sayed Ahmad,24,Building,2,2,0,TRUE
+2402029,66.44950611,33.88916083,2,Plalech Mosque,Daykundi,4,Shahristan,2,Plalech Largar,24,Building,2,4,0,TRUE
+2402030,66.63039011,33.73795337,1,Tagag High School,Daykundi,2,Shahristan,1,Tagag,24,Building,2,2,0,TRUE
+2402031,66.61570275,33.80847717,1,Faiz Abad Mosque,Daykundi,2,Shahristan,1,Faiz Abad,24,Building,2,2,0,TRUE
+2402032,66.70411708,33.53156026,1,Mangor Mosque,Daykundi,2,Shahristan,1,Miyana Mangor,24,Building,2,2,0,TRUE
+2402033,66.45325846,33.75504537,1,Yama Tagablor Mosque,Daykundi,2,Shahristan,1,Yama Tagablor,24,Building,2,2,0,TRUE
+2402034,66.20959049,33.67961611,1,Azmok Mosque,Daykundi,2,Shahristan,1,Azmok,24,Building,2,2,0,TRUE
+2402035,66.61681736,33.54324787,2,Asho Gholaka Mosque,Daykundi,3,Shahristan,1,Asho Ghokala,24,Building,2,3,0,TRUE
+2402171,66.436291728,33.941932968,2,Mosque,Daykundi,3,Shahristan,1,Pitab Largar,24,Building,2,3,0,TRUE
+2402172,66.666722599,33.539880313,2,Mosque,Daykundi,3,Shahristan,1,Rakhan,24,Building,2,3,0,TRUE
+2402173,66.500231271,33.88388162,2,Mosque,Daykundi,3,Shahristan,1,Safid Pushta Largar,24,Building,2,3,0,TRUE
+2402174,66.709412969,33.806664976,2,Mosque,Daykundi,3,Shahristan,1,Ghaf,24,Building,2,3,0,TRUE
+2402175,66.265259451,33.845345012,2,School,Daykundi,3,Shahristan,1,Ghaibi,24,Building,2,3,0,TRUE
+2403106,66.03010872,33.41330023,1,Bazar Beri School,Daykundi,3,Gizab,2,Markaz Bazar Beri,24,Building,3,0,3,FALSE
+2403109,66.08165481,33.67146809,1,Sahib Zaman Wageer Mosque,Daykundi,2,Gizab,1,Wageer,24,Building,3,0,2,FALSE
+2403110,66.12831695,33.4707791,1,Chalzai Bazar School,Daykundi,2,Gizab,1,Chalzai,24,District,3,0,2,FALSE
+2403113,66.06978318,33.24524656,1,Old Governmental Building,Daykundi,2,Gizab,1,Rabat Khushk,24,Village,3,0,2,FALSE
+2403114,66.01680647,33.36589848,3,Sohoor Tagabdar Mosque,Daykundi,5,Gizab,2,Sohoor Tagabdar,24,Building,3,0,5,FALSE
+2403116,66.22287357,33.41934492,1,Nikozai Village Mosque,Daykundi,2,Gizab,1,Nikozai Village,24,Village,3,0,2,FALSE
+2403117,66.26317942,33.38038757,1,Chonai Bazar Mosque,Daykundi,2,Gizab,1,Chonai Village,24,Village,3,1,1,TRUE
+2403120,66.22920408,33.39400267,1,Bazar Kuhna Mosque,Daykundi,2,Gizab,1,Bazar Kuhna,24,Village,3,0,2,FALSE
+2404036,66.37603146,33.98332047,2,Siyah Nawar Abdi Mosque,Daykundi,4,Ishterlai,2,Siyah Nawar Abdi,24,Building,4,4,0,TRUE
+2404037,66.50461421,34.02964707,2,Safid Sang Mosque,Daykundi,3,Ishterlai,1,Pirestan,24,Building,4,3,0,TRUE
+2404038,66.45378844,34.09328464,1,Sar Tala Madrassa,Daykundi,2,Ishterlai,1,Sar Tala,24,Building,4,2,0,TRUE
+2404039,66.23761623,34.04522082,2,Dahan Deh Yak Mosque,Daykundi,3,Ishterlai,1,Shikhmeeran,24,Building,4,3,0,TRUE
+2404040,66.44070749,34.19439523,2,Khadar Bash Mosque,Daykundi,3,Ishterlai,1,"Khadar Bash, Bazar Miyana",24,Building,4,3,0,TRUE
+2404041,66.34107849,34.14484425,2,Kadaal Mosque,Daykundi,3,Ishterlai,1,"Kadaal, Dahan Gardish",24,Building,4,3,0,TRUE
+2404042,66.523270044,34.289447601,1,Gum Aab Mosque,Daykundi,2,Ishterlai,1,Gum Aab,24,Building,4,2,0,TRUE
+2404043,66.29132915,33.95999533,2,Loran Khushk Mosque,Daykundi,3,Ishterlai,1,Loran Khushk,24,Building,4,3,0,TRUE
+2404044,66.2735459,33.89804205,2,Deh Aroos Village Bazar Tent,Daykundi,4,Ishterlai,2,Deh Aroos Khushk,24,Building,4,4,0,TRUE
+2404045,66.33899811,33.93481981,1,Naglej Mosque,Daykundi,2,Ishterlai,1,Naglej Khushk,24,Building,4,2,0,TRUE
+2404046,66.30810555,34.25157577,1,Qalandaran Mosque,Daykundi,2,Ishterlai,1,Jangan Kalan,24,Building,4,2,0,TRUE
+2404047,66.34967862,34.21823835,1,Elsafi Mosque,Daykundi,3,Ishterlai,2,Jangan Khord,24,Building,4,3,0,TRUE
+2404048,66.12879669,33.97794558,2,Bareek Mosque,Daykundi,4,Ishterlai,2,Bareek Siyah Dara,24,Building,4,4,0,TRUE
+2404049,66.28076953,34.06943381,2,Qochanqi Madrassa,Daykundi,3,Ishterlai,1,Qochanqi,24,Building,4,3,0,TRUE
+2404050,66.33997162,34.05223116,1,Gurzak Sarab Mosque,Daykundi,3,Ishterlai,2,Gurzak Sarab,24,Building,4,3,0,TRUE
+2404051,66.13984857,33.90943402,4,Korga Sufla Mosque,Daykundi,6,Ishterlai,2,Korga Sufla,24,Building,4,6,0,TRUE
+2404052,66.28569855,34.1846229,1,Chaka Jankan Mosque,Daykundi,2,Ishterlai,1,Chaka Jankan,24,Building,4,2,0,TRUE
+2404053,66.27536504,34.03260385,1,Surkh Joy Mosque,Daykundi,3,Ishterlai,2,Surkh Joy,24,Building,4,3,0,TRUE
+2404176,66.305132947,33.974521469,2,Mosque,Daykundi,3,Ashtarlay,1,Taleej,24,Building,4,3,0,TRUE
+2404177,66.204876648,33.896962861,2,Mosque,Daykundi,3,Ashtarlay,1,Khar Bid Hulia,24,Building,4,3,0,TRUE
+2404178,66.428897479,34.021777824,2,Mosque,Daykundi,3,Ashtarlay,1,Maidan Ahangaran,24,Building,4,3,0,TRUE
+2404179,66.2510978,34.010662306,2,Mosque,Daykundi,3,Ashtarlay,1,Now Jok,24,Building,4,3,0,TRUE
+2405085,65.94492796,33.91461772,1,Shiniya Khadeer Ulya Mosque,Daykundi,3,Khedir,2,Khadeer Ulya,24,Building,5,3,0,TRUE
+2405086,65.91929767,34.03569733,1,Dahn Say Pasi Band School,Daykundi,2,Khedir,1,Dahn Say Pasi Band,24,Building,5,2,0,TRUE
+2405087,65.79809445,33.87193722,1,Dahn Surkh Qolak School,Daykundi,3,Khedir,2,Watma,24,Building,5,3,0,TRUE
+2405088,65.91978829,33.92720075,1,Khadeer Sufla Mosque,Daykundi,3,Khedir,2,Khadeer Sufla,24,Building,5,3,0,TRUE
+2405089,65.70597798,33.82363892,1,Shakar Dara Mosque,Daykundi,3,Khedir,2,Shakar Dara,24,Building,5,3,0,TRUE
+2405090,65.80894912,33.95387939,1,Dashtak Mosque,Daykundi,3,Khedir,2,Dashtak,24,Building,5,3,0,TRUE
+2405091,65.66240424,33.80223138,1,Dastani School,Daykundi,3,Khedir,2,Dastani,24,Building,5,3,0,TRUE
+2405092,65.68336159,33.75145633,1,Bazi Village Mosque,Daykundi,3,Khedir,2,Bazi Village,24,Building,5,3,0,TRUE
+2405093,65.72534164,33.87629224,1,Dahan Kiti Girls Primary School,Daykundi,3,Khedir,2,Dahan Kiti,24,Building,5,3,0,TRUE
+2405094,65.93746308,33.82170249,1,Siyah Band Pashtaroq School,Daykundi,3,Khedir,2,Pashtaroq,24,Building,5,3,0,TRUE
+2405095,65.76879382,33.90424922,1,Dahan Gham Qol School,Daykundi,3,Khedir,2,Gham Qol,24,Building,5,3,0,TRUE
+2405096,66.05138915,33.88531186,1,Pitabak Korga School,Daykundi,3,Khedir,2,Pitabak,24,Building,5,3,0,TRUE
+2405097,65.87576616,33.74086728,1,Weer School,Daykundi,2,Khedir,1,Weer,24,Building,5,2,0,TRUE
+2405098,65.99160789,33.95819231,1,Sarab Sang Chelak Mosque,Daykundi,2,Khedir,1,Sang Chelak,24,Building,5,2,0,TRUE
+2405099,65.77938008,33.78840612,2,Kaloh Mosque,Daykundi,3,Khedir,1,Kaloh,24,Building,5,3,0,TRUE
+2405100,65.87878633,33.7820898,2,Takht Kiyan Mosque,Daykundi,3,Khedir,1,Takht Kiyan,24,Building,5,3,0,TRUE
+2405101,65.7863709,33.9989494,2,Qorb Ali School,Daykundi,3,Khedir,1,Shalgham,24,Building,5,3,0,TRUE
+2405102,65.64106826,33.72224108,1,Khak Faqeer Mosque,Daykundi,2,Khedir,1,Khak Faqeer,24,Building,5,2,0,TRUE
+2405103,65.90498937,33.98579363,1,Shinya Jalil Pasi Band Mosque,Daykundi,2,Khedir,1,Pasi Band,24,Building,5,2,0,TRUE
+2405180,65.618818814,33.68892001,2,School,Daykundi,3,Khedir,1,Chaghan,24,Building,5,3,0,TRUE
+2405181,65.908072577,33.891592349,2,Mosque,Daykundi,3,Khedir,1,Kharbid Sar Qul,24,Building,5,3,0,TRUE
+2405182,65.716202445,33.939944208,2,Mosque,Daykundi,3,Khedir,1,Dahan Abdara,24,Village,5,3,0,TRUE
+2405183,65.840845552,33.865881244,2,School,Daykundi,3,Khedir,1,Rang Darakht,24,Building,5,3,0,TRUE
+2406124,65.80945209,33.6468554,2,Miyana Tamran Mosque,Daykundi,4,Kiti,2,Miyana Tamran,24,Building,6,4,0,TRUE
+2406125,65.856754,33.67155218,1,Sar Tamran Mosque,Daykundi,3,Kiti,2,Sar Tamran,24,Building,6,3,0,TRUE
+2406126,65.78115505,33.64543306,2,Kuhna Deh Madrassa,Daykundi,3,Kiti,1,Kuhna Deh,24,Building,6,3,0,TRUE
+2406127,65.7052117,33.63642963,2,Karwan Sarai Mosque,Daykundi,3,Kiti,1,Karwan Sarai,24,Building,6,3,0,TRUE
+2406128,65.70191881,33.41114836,2,Argan Mosque,Daykundi,3,Kiti,1,Argan,24,Building,6,3,0,TRUE
+2406129,65.7319024,33.57957573,2,Shina Kiti Mosque,Daykundi,3,Kiti,1,Shina Kiti,24,Building,6,3,0,TRUE
+2406130,65.81729232,33.71138191,2,Sanginak Mosque,Daykundi,3,Kiti,1,Sanginak,24,Building,6,3,0,TRUE
+2406131,65.78278149,33.44774715,2,Royan Mosque,Daykundi,3,Kiti,1,Royan,24,Building,6,3,0,TRUE
+2406132,65.77892404,33.68583467,2,Komi Mosque,Daykundi,3,Kiti,1,Komi,24,Building,6,3,0,TRUE
+2406133,65.66079644,33.54036601,2,Mozarmi Mosque,Daykundi,3,Kiti,1,Mozrami,24,Building,6,3,0,TRUE
+2406134,65.75762185,33.63923501,2,Shalizar Mosque,Daykundi,3,Kiti,1,Shalizar,24,Building,6,3,0,TRUE
+2406135,65.80445621,33.43086617,2,Dasht Kiso Mosque,Daykundi,3,Kiti,1,Dasht Kiso,24,Building,6,3,0,TRUE
+2406136,65.89646489,33.44652737,2,Sar Kiso Mosque,Daykundi,3,Kiti,1,Sar Kiso,24,Building,6,3,0,TRUE
+2406137,65.84716315,33.42131996,2,Ghotla Mosque,Daykundi,3,Kiti,1,Ghotla,24,Building,6,3,0,TRUE
+2406138,65.67759782,33.51401117,2,Sartaghan Mosque,Daykundi,3,Kiti,1,Sartaghan,24,Building,6,3,0,TRUE
+2406139,65.7702395,33.41126712,2,Shoro Kiso Mosque,Daykundi,3,Kiti,1,Shoro Kiso,24,Building,6,3,0,TRUE
+2406140,65.73272946,33.53448614,2,Monami Mosque,Daykundi,3,Kiti,1,Monami,24,Building,6,3,0,TRUE
+2406141,65.69672597,33.43084168,2,Soyak Mosque,Daykundi,3,Kiti,1,Soyak,24,Building,6,3,0,TRUE
+2406142,65.69505984,33.67053968,2,Panor Ulya Mosque,Daykundi,3,Kiti,1,Panor Ulya,24,Building,6,3,0,TRUE
+2406143,65.7603058,33.48991363,2,Hoshi Mosque,Daykundi,3,Kiti,1,Hoshi,24,Building,6,3,0,TRUE
+2406184,65.838021977,33.4289057,2,Mosque,Daykundi,3,Kiti,1,Sar Bagh Kisaw,24,Building,6,3,0,TRUE
+2406185,65.69132907,33.482172302,2,Mosque,Daykundi,3,Kiti,1,Tajreeb,24,Building,6,3,0,TRUE
+2406186,65.868928745,33.42558173,2,Mosque,Daykundi,3,Kiti,1,Ghola Kisaw,24,Building,6,3,0,TRUE
+2406187,65.694788847,33.561571513,2,Madrasa,Daykundi,3,Kiti,1,Korangak,24,Building,6,3,0,TRUE
+2407144,66.92274098,33.8361289,1,Orlak Mosque,Daykundi,4,Miramor,3,Teyorsal,24,Building,7,4,0,TRUE
+2407145,66.78462218,33.81171062,3,Tagab Mosque,Daykundi,4,Miramor,1,Tagab,24,Building,7,4,0,TRUE
+2407146,66.79247481,33.7296933,2,Askan Mosque,Daykundi,4,Miramor,2,Askan,24,Building,7,4,0,TRUE
+2407147,66.8711677,33.8877444,2,Surkh Joy Mosque,Daykundi,4,Miramor,2,Surkh Joy,24,Building,7,4,0,TRUE
+2407148,66.73032699,33.85931354,1,Sarsang Takhawi Mosque,Daykundi,2,Miramor,1,Deh Ghochi,24,Building,7,2,0,TRUE
+2407149,66.62556738,33.87799773,2,Darghala Charkh Mosque,Daykundi,3,Miramor,1,Darghala Charkh,24,Building,7,4,0,TRUE
+2407150,66.59453082,33.87668855,2,Bazar Joz Mosque,Daykundi,3,Miramor,1,"Siyah Dara, Bazar Joz",24,Building,7,3,0,TRUE
+2407151,66.63412268,33.85574376,1,Joy Toot School,Daykundi,2,Miramor,1,Joy Toot,24,Building,7,2,0,TRUE
+2407152,67.23338098,33.88060946,2,Nihal Boys High School,Daykundi,3,Miramor,1,Kel Joy Nihal,24,Building,7,3,0,TRUE
+2407153,67.21982837,33.89666179,1,Chahar Sad Khana Boys High School,Daykundi,3,Miramor,2,Palaas,24,Building,7,3,0,TRUE
+2407154,67.14600031,33.8516617,1,Watana Boys High School,Daykundi,2,Miramor,1,Pitap Joy,24,Building,7,2,0,TRUE
+2407155,67.29941134,33.87642714,1,Shinya Nek Mosque,Daykundi,2,Miramor,1,Shinya Nek,24,Building,7,2,0,TRUE
+2407156,67.10173487,33.81962525,1,Nar Khasi Secondary School,Daykundi,3,Miramor,2,Nar Khasi,24,Building,7,3,0,TRUE
+2407157,67.05414139,33.77585948,2,Shinya Barkar School,Daykundi,3,Miramor,1,Shinya Barkar,24,Building,7,3,0,TRUE
+2407158,66.95718975,33.70275132,1,Shina Ashto Mosque,Daykundi,2,Miramor,1,Ashto,24,Building,7,2,0,TRUE
+2407159,66.83090694,33.63682306,1,Rako Mosque,Daykundi,2,Miramor,1,Mir Ghulam,24,Building,7,2,0,TRUE
+2407160,66.78922666,33.65863479,1,Tuqman Dara Mosque,Daykundi,2,Miramor,1,Tuqman Dara,24,Building,7,2,0,TRUE
+2407161,66.91081256,33.67396683,1,Tai Jang Mosque,Daykundi,2,Miramor,1,Nadak,24,Building,7,2,0,TRUE
+2407162,66.76181876,33.94866866,1,Siyah Bomak Rabat Mosque,Daykundi,2,Miramor,1,Siyah Bomak,24,Building,7,2,0,TRUE
+2407163,66.85698672,33.65778379,1,Zaspa Tuqman Dara Mosque,Daykundi,2,Miramor,1,"Toqman Dara, Mir Ghulam",24,Building,7,2,0,TRUE
+2407164,67.01443308,33.79113795,1,Tai Barkar Mosque,Daykundi,2,Miramor,1,"Dahan Shahrak, Tai Barkar",24,Building,7,2,0,TRUE
+2407165,66.91130099,33.7724811,2,Sangan School,Daykundi,3,Miramor,1,Sangan,24,Building,7,3,0,TRUE
+2407166,66.60367713,33.97174462,1,Gargai Village Mosque,Daykundi,2,Miramor,1,Gargai,24,Building,7,2,0,TRUE
+2407167,67.05045427,33.85756736,1,Do Jahan Tikan Barkar Mosque,Daykundi,2,Miramor,1,Do Jahan,24,Building,7,2,0,TRUE
+2407188,66.598194447,33.861865892,2,Mosque,Daykundi,3,Miramor,1,Aona Bargar,24,Building,7,3,0,TRUE
+2407189,66.998718473,33.753182915,2,Mosque,Daykundi,3,Miramor,1,Bardiz Bargar,24,Building,7,3,0,TRUE
+2407190,67.050776251,33.777415031,2,School,Daykundi,3,Miramor,1,Dahan Dar Ra,24,Building,7,3,0,TRUE
+2407191,67.121170598,33.90772129,2,Mosque,Daykundi,3,Miramor,1,Shazan,24,Building,7,3,0,TRUE
+2407192,67.245977242,33.832265672,2,Mosque,Daykundi,3,Miramor,1,Ghajorak,24,Building,7,3,0,TRUE
+2408071,66.13526031,34.26387995,3,Jafaria Bazar Sang Takht Mosque,Daykundi,5,Sang-E-Takht,2,Dahan Qarghan Payeen,24,Building,8,5,0,TRUE
+2408072,66.07140697,34.28226066,3,Shinya Chaka Mosque,Daykundi,4,Sang-E-Takht,1,Shinya Chaka,24,Building,8,4,0,TRUE
+2408073,66.25366541,34.30718731,1,Talkhak School,Daykundi,2,Sang-E-Takht,1,"Bed Naw Sufla, Talkhak",24,Building,8,2,0,TRUE
+2408074,66.1804537,34.20791122,2,Shinya Qaramat School,Daykundi,3,Sang-E-Takht,1,Shinya Qaramat,24,Building,8,3,0,TRUE
+2408075,66.07943836,34.11891857,2,Qala-E-Sangi Mosque,Daykundi,3,Sang-E-Takht,1,Shekh Ali,24,Building,8,3,0,TRUE
+2408076,65.87733785,34.27275754,2,Bazar Siyah Kharak School,Daykundi,3,Sang-E-Takht,1,Siyah Kharak,24,Building,8,3,0,TRUE
+2408077,65.81678949,34.18860929,2,Bazar Salbito School,Daykundi,4,Sang-E-Takht,2,Salbito,24,Building,8,4,0,TRUE
+2408078,65.93481844,34.1784829,2,Dahan Sirak Mirasi Mosque,Daykundi,3,Sang-E-Takht,1,Sirak,24,Building,8,3,0,TRUE
+2408079,65.62905408,34.03836363,2,Siyah Chob Bazar Mosque,Daykundi,4,Sang-E-Takht,2,Siyah Chob,24,Building,8,4,0,TRUE
+2408080,65.71669634,34.10876096,1,Shinya Les Mosque,Daykundi,2,Sang-E-Takht,1,Shinya Les,24,Building,8,2,0,TRUE
+2408081,65.74558959,34.25257783,2,Aral Mosque,Daykundi,3,Sang-E-Takht,1,Aral,24,Building,8,3,0,TRUE
+2408082,65.81813199,34.13573285,2,Shinya Qala Mosque,Daykundi,3,Sang-E-Takht,1,Shinya Qala,24,Building,8,3,0,TRUE
+2408083,66.06953086,34.21380983,2,Khatim-Ul-Anbia Khulbarg Mosque,Daykundi,3,Sang-E-Takht,1,Khulbarg,24,Building,8,3,0,TRUE
+2408084,65.89361954,34.14454453,2,Asb Dawan Mosque,Daykundi,3,Sang-E-Takht,1,Mirasi,24,Building,8,3,0,TRUE
+2408193,66.25770969,34.241822819,2,Mosque,Daykundi,3,Sang-E-Takht,1,Ail Ghulam Kaligan,24,Building,8,3,0,TRUE
+2409054,65.46905046,33.20630388,2,Balaagh Mosque,Daykundi,4,Kejran,2,Balaagh,24,Building,9,4,0,TRUE
+2409055,65.52496207,33.20917796,1,Boka Sof Mosque,Daykundi,3,Kejran,2,Sof,24,Building,9,3,0,TRUE
+2409056,65.58208142,33.16311754,1,Boka Mosque,Daykundi,3,Kejran,2,Kando,24,Building,9,3,0,TRUE
+2409057,65.62422721,33.19369039,2,Zard Gulan Mosque,Daykundi,3,Kejran,1,Zard Gulan,24,Building,9,3,0,TRUE
+2409058,65.66817822,33.19352897,1,Surkh Sarak Menbar,Daykundi,2,Kejran,1,Surkh Sarak,24,Building,9,2,0,TRUE
+2409059,65.46505128,33.23277331,1,Laghar Joy School,Daykundi,2,Kejran,1,Laghar Joy,24,Building,9,2,0,TRUE
+2409060,65.69176758,33.22924569,1,Baghban Mosque,Daykundi,2,Kejran,1,Baghban,24,Building,9,2,0,TRUE
+2409061,65.726943914,33.284490898,2,Sang Shahrak Mosque,Daykundi,3,Kejran,1,Sang Shahrak,24,Building,9,3,0,TRUE
+2409062,65.76021905,33.34780243,2,Gharenj Menbar,Daykundi,3,Kejran,1,Gharenj,24,Building,9,3,0,TRUE
+2409063,65.4292675,33.17249675,1,Salmonji Menbar,Daykundi,2,Kejran,1,Salmonji,24,Building,9,2,0,TRUE
+2409064,65.455167478,33.243527785,2,Qala-E-Lash Mosque,Daykundi,3,Kejran,1,Qala-E-Lash,24,Building,9,3,0,TRUE
+2409065,65.44061748,33.22032042,1,Dahan Takha Mosque,Daykundi,2,Kejran,1,Takha,24,Building,9,2,0,TRUE
+2409066,65.445042975,33.122198066,1,Sayed Abad Mosque,Daykundi,2,Kejran,1,Sayed Abad,24,District,9,2,0,TRUE
+2409067,65.47562743,33.24408186,1,Boka Mosque,Daykundi,3,Kejran,2,Boka,24,Building,9,3,0,TRUE
+2409068,65.57451703,33.15228251,1,Bala Dasht Mosque,Daykundi,2,Kejran,1,Bala Dasht,24,Building,9,2,0,TRUE
+2409069,65.72234551,33.23751067,1,Dahan Khojo Mosque,Daykundi,2,Kejran,1,Khojo,24,Building,9,2,0,TRUE
+2409070,65.59533175,33.23698359,1,Sulaiman Abad Mosque,Daykundi,2,Kejran,1,Sulaiman Abad,24,Building,9,2,0,TRUE
+2409168,65.72167609,33.32862255,1,Haftad Nafar Mosque,Daykundi,2,Kejran,1,Haftad Nafar,24,Building,9,2,0,TRUE
+2409194,65.699426245,33.205517812,2,Mosque,Daykundi,3,Kejran,1,Qasem Abad,24,District,9,3,0,TRUE
+2501001,65.83958652,32.63252203,4,Safid Khaar Secondary School,Urozgan,7,Tirinkot,3,Safid Khaar,25,Building,1,7,0,TRUE
+2501002,65.92498508,32.6316856,4,Nachin Secondary School,Urozgan,7,Tirinkot,3,Nachin,25,Building,1,7,0,TRUE
+2501003,65.89290027,32.67907859,5,Haji Zahir Mosque,Urozgan,8,Tirinkot,3,Maktab Deh Joz Barakzai,25,Building,1,8,0,TRUE
+2501004,65.75005357,32.57981803,4,Kabeer Mosque,Urozgan,7,Tirinkot,3,Maktab Gulkhana Spin Kicha,25,Building,1,7,0,TRUE
+2501005,65.88047693,32.63210004,4,Malalai High School,Urozgan,7,Tirinkot,3,Markaz Trinkot,25,Building,1,8,0,TRUE
+2501006,65.82220318,32.61809279,4,Talani Secondary School,Urozgan,7,Tirinkot,3,Talani Village,25,Building,1,7,0,TRUE
+2501007,65.957,32.58730555,3,Garm Aab School,Urozgan,5,Tirinkot,2,Garm Aab,25,Building,1,3,2,TRUE
+2501008,65.92026561,32.65682673,4,Salam Baba High School,Urozgan,6,Tirinkot,2,Khanqa Village,25,Building,1,6,0,TRUE
+2501010,65.87387993,32.63042794,4,Saidal Khan High School,Urozgan,8,Tirinkot,4,Bazar Trinkot,25,Building,1,9,0,TRUE
+2501011,65.8830093,32.68611167,3,Pirosha Madrassa Mosque,Urozgan,5,Tirinkot,2,Pirosha,25,Building,1,1,4,TRUE
+2501012,65.90733,32.73398382,3,Shah Hussain High School,Urozgan,6,Tirinkot,3,Surkh Marghab Village,25,Building,1,6,0,TRUE
+2501013,65.88982014,32.66388402,3,Kotwal High School,Urozgan,5,Tirinkot,2,Kotwal,25,Building,1,5,0,TRUE
+2501014,65.86527136,32.64313966,3,Charamgar Secondary School,Urozgan,5,Tirinkot,2,Charamgar,25,Building,1,5,0,TRUE
+2501015,66.02546658,32.67440792,3,Mir Abad Village School,Urozgan,5,Tirinkot,2,Mir Abad Village,25,Building,1,3,2,TRUE
+2501050,65.916495568,32.776587574,3,Sajawal School,Urozgan,6,Tirinkot,3,Sajawal,25,Building,1,6,0,TRUE
+2501052,65.90339868,32.52394681,3,Mula Mir Baz Ziarat Madrassa,Urozgan,3,Tirinkot,0,Mula Mir Baz Ziarat,25,Village,1,3,0,TRUE
+2502036,65.48140709,32.65370531,6,Mula Ahmad High School,Urozgan,7,Dehraoud,1,Miyando Village,25,Building,2,7,0,TRUE
+2502037,65.45458905,32.62553872,5,Bazar Shahr-E-Naw High School,Urozgan,6,Dehraoud,1,Bazar Dehrawood,25,Building,2,6,0,TRUE
+2502038,65.51806584,32.6592562,6,Deb Sang Village High School,Urozgan,7,Dehraoud,1,Deb Sang Village,25,Building,2,7,0,TRUE
+2502039,65.56464685,32.65182205,3,Malk Khudai Dost Village School,Urozgan,4,Dehraoud,1,Anar Joy Village,25,Building,2,4,0,TRUE
+2502040,65.45593432,32.62509329,0,Girls High School,Urozgan,5,Dehraoud,5,Dehrawood Bazar,25,Building,2,5,0,TRUE
+2502042,65.4748798,32.73065928,5,Chatoo School,Urozgan,6,Dehraoud,1,Chatoo,25,Building,2,6,0,TRUE
+2502043,65.43591263,32.61592971,5,Kakhtia Ladyani Malak Zalmai Private House,Urozgan,6,Dehraoud,1,Maktab Landiyana,25,Building,2,6,0,TRUE
+2502044,65.51714621,32.63189736,5,Lebnan School,Urozgan,6,Dehraoud,1,Lebnan,25,Building,2,6,0,TRUE
+2502054,65.37293933,32.53492732,5,Mula Khudai Nazar Village School,Urozgan,6,Dehraoud,1,Sikazi Village,25,Building,2,6,0,TRUE
+2503016,66.04500672,32.86324984,5,Markazi Bazar High School,Urozgan,5,Chora,0,District Bazar,25,Building,3,5,0,TRUE
+2503017,66.04271683,32.86135687,1,Dinarkhel Girls School,Urozgan,4,Chora,3,District Womens Clinic,25,Building,3,4,0,TRUE
+2503018,66.050539928,32.846936708,3,Qala-E-Ragh School,Urozgan,4,Chora,1,Qalacha Bazar,25,Building,3,4,0,TRUE
+2503019,66.08397627,32.8523388,1,Dawlatzai High School,Urozgan,2,Chora,1,Dawlatzai Village,25,Building,3,2,0,TRUE
+2503020,66.013779994,32.920317039,2,Awiyan School,Urozgan,4,Chora,2,Qala-E-Ragh,25,Building,3,4,0,TRUE
+2503021,66.12014256,32.88017712,3,Sarab Village School,Urozgan,4,Chora,1,Sarab Village,25,Building,3,4,0,TRUE
+2503022,66.44404153,33.091449996,1,Kamisan Madrassa,Urozgan,2,Chora,1,Kamisan,25,Village,3,2,0,TRUE
+2503023,66.06768582,32.87149771,2,Haji Mohammad Akbar Khan Private House,Urozgan,3,Chora,1,Sarai Village,25,Building,3,3,0,TRUE
+2504030,65.564029,32.939945,6,Chahar Chino Bazar High School,Urozgan,6,Shahid-E-Hassas,0,Chahar Chino Bazar,25,Building,4,6,0,TRUE
+2504031,65.56377844,32.94304256,0,Chahar Chino Bazar Women'S Clinic,Urozgan,5,Shahid-E-Hassas,5,Chahar Chino Bazar,25,Building,4,5,0,TRUE
+2504032,65.48413883,32.98595602,4,Bazar Yakhdan School,Urozgan,5,Shahid-E-Hassas,1,Yakhdan Bazar,25,Building,4,4,1,TRUE
+2504033,65.56314855,32.93305461,4,Haidar Village Madrassa,Urozgan,5,Shahid-E-Hassas,1,Sper Koh,25,Village,4,5,0,TRUE
+2504034,65.5389725,32.92390702,3,Najo Shah Mashhad Mosque,Urozgan,4,Shahid-E-Hassas,1,Shah Mashhad,25,Building,4,3,1,TRUE
+2504035,65.52585451,33.02575235,4,Qala-E-Kalan School,Urozgan,5,Shahid-E-Hassas,1,Gorgeen Village,25,Village,4,0,5,FALSE
+2505024,66.64086906,32.93853948,6,Shah Zaman High School,Urozgan,8,Khas Urozgan,2,District Bazar,25,Building,5,8,0,TRUE
+2505025,66.85025775,33.11639568,4,Bazar Gandab High School,Urozgan,7,Khas Urozgan,3,Gandab Bazar,25,Building,5,0,7,FALSE
+2505026,66.81998008,33.06805708,4,Hussaini Bazar High School,Urozgan,7,Khas Urozgan,3,Hussaini Bazar,25,Building,5,0,7,FALSE
+2505027,66.72908773,32.94638287,3,Matak Khan Village High School,Urozgan,6,Khas Urozgan,3,Matak Khan Village,25,Building,5,2,4,TRUE
+2505028,66.76525269,33.0947898,4,Marghonde School,Urozgan,7,Khas Urozgan,3,Nawa Sultan Mohammad Village,25,Village,5,4,3,TRUE
+2505029,66.63163169,32.92543622,6,District Girls Primary School,Urozgan,10,Khas Urozgan,4,District Compound,25,Building,5,10,0,TRUE
+2506045,66.28065898,32.73871861,6,Maalem Faiz Mohammad High School,Urozgan,6,Chenarto,0,Bazar,25,Building,6,6,0,TRUE
+2506046,66.28177016,32.73883897,0,Womens Clinic,Urozgan,5,Chenarto,5,Chinarto,25,Building,6,5,0,TRUE
+2506048,66.267877,32.733403,5,Chinar Primary School,Urozgan,5,Chenarto,0,Chinar,25,Village,6,5,0,TRUE
+2506049,66.28783044,32.80035765,2,Siyaghar Primary School,Urozgan,2,Chenarto,0,Siyaghar,25,Building,6,2,0,TRUE
+2601001,66.90534233,32.10407297,5,Bibi Khala High School,Zabul,7,Qalat,2,Shaarwali,26,Building,1,7,0,TRUE
+2601002,66.91388327,32.10349824,6,Shekh Mati High School,Zabul,8,Qalat,2,Hawashnasi,26,Building,1,8,0,TRUE
+2601003,66.91609981,32.10699395,3,Kandak School,Zabul,5,Qalat,2,Nawai Resala,26,Building,1,5,0,TRUE
+2601004,66.8986604,32.10248597,3,Provincial Hospital,Zabul,5,Qalat,2,Qalat,26,Building,1,5,0,TRUE
+2601005,66.91530493,32.11466272,3,Sinak High School,Zabul,5,Qalat,2,Sinak,26,Building,1,6,1,TRUE
+2601006,66.89370716,32.10074875,4,Chonai School,Zabul,6,Qalat,2,Nawai Village,26,Building,1,6,0,TRUE
+2601007,66.86817808,32.16221706,3,Gagari Mosque,Zabul,5,Qalat,2,Amaki,26,Building,1,5,0,TRUE
+2601008,67.01802085,32.19259439,5,Spina Ghbarga Madrassa,Zabul,7,Qalat,2,Spina Ghbarga,26,Building,1,2,5,TRUE
+2601009,66.87705355,32.0824005,3,Haji Allah Dad Mosque,Zabul,5,Qalat,2,Kharwaryan Village,26,Building,1,4,1,TRUE
+2601045,66.891517137,32.101023309,2,Chel Dokhtaran School,Zabul,3,Qalat,1,Nawi Kali Village,26,Building,1,3,0,TRUE
+2601046,66.870527954,32.171947776,2,Kagari Mosque,Zabul,3,Qalat,1,"Kagari, Amaki",26,Building,1,2,1,TRUE
+2601047,66.985556188,32.153003897,2,Lwar Kariz Mosque,Zabul,3,Qalat,1,Miranzaie,26,Building,1,3,0,TRUE
+2601048,67.143080318,32.269475497,2,Barak Zai Check Post,Zabul,3,Qalat,1,Miranzaie Kharjoi,26,Village,1,2,1,TRUE
+2601049,66.799170743,32.091297753,2,Naw Khiz Mosque,Zabul,3,Qalat,1,Naw Khiz,26,Building,1,3,0,TRUE
+2601050,66.91446329,32.110215523,2,Resala Female School,Zabul,3,Qalat,1,Rsala,26,Building,1,3,0,TRUE
+2602026,66.32468242,31.79946917,6,Boys School,Zabul,6,Tarank Wa Jaldak,0,District Compound,26,Building,2,6,1,TRUE
+2602027,66.32492155,31.80171793,0,Girls School,Zabul,4,Tarank Wa Jaldak,4,District Compound,26,Building,2,3,1,TRUE
+2602028,66.72293797,31.97418876,4,Jaldak Hospital,Zabul,4,Tarank Wa Jaldak,0,Jaldak,26,Building,2,2,2,TRUE
+2602029,66.5227827,31.89322648,5,Ghaishi Rabat School,Zabul,5,Tarank Wa Jaldak,0,Foladgai,26,Building,2,5,0,TRUE
+2602030,66.72946306,32.05792463,5,Haji Khadi Khan Private House,Zabul,5,Tarank Wa Jaldak,0,Kheshaki Village,26,Building,2,3,2,TRUE
+2602051,66.573372539,31.906913215,2,Muhammad Jan Village Mosque,Zabul,3,Tarank Wa Jaldak,1,Muhammad Zai Village,26,Village,2,2,2,TRUE
+2602052,66.374167956,31.83222133,2,Haji Abdul Aziz Pump Station,Zabul,3,Tarank Wa Jaldak,1,Daro,26,Village,2,2,1,TRUE
+2603031,67.33683049,31.98378241,5,Shah Alam High School,Zabul,10,Shinkai,5,District Compound,26,Building,3,4,6,TRUE
+2603033,67.0379149,31.97093948,5,Syori (Shenkai) District Office,Zabul,10,Shinkai,5,Syori,26,Building,3,10,0,TRUE
+2603053,67.111875599,32.026882685,3,Ziarat Madrasa,Zabul,4,Shinkai,1,Badin,26,Village,3,3,2,TRUE
+2603056,67.004875625,31.955573634,2,Moque,Zabul,3,Shinkai,1,Omar Zai,26,Building,3,2,1,TRUE
+2604025,66.51370688,32.17622969,4,Nawa Alam Gul School,Zabul,8,Mizan,4,District Compound,26,Building,4,8,0,TRUE
+2605018,66.84615205,32.47256171,6,Shorwani Mosque,Zabul,11,Arghandab,5,Bagh Village,26,Building,5,11,0,TRUE
+2606010,67.41391912,32.51981393,7,Baba Hotak High School,Zabul,8,Shah Joi,1,Shah Joy,26,Building,6,8,0,TRUE
+2606011,67.4544659,32.55104611,4,Bazargan School,Zabul,5,Shah Joi,1,Bazargan,26,Building,6,4,2,TRUE
+2606012,67.42453162,32.61850178,2,Ghulam Rabat Maland School,Zabul,3,Shah Joi,1,Ghulam Rabat,26,Building,6,4,0,TRUE
+2606013,67.42314206,32.52065846,5,Bazar Mosque,Zabul,5,Shah Joi,0,Bazar Shah Joy,26,Building,6,5,0,TRUE
+2606014,67.3764111,32.47751681,4,Karbaghi School,Zabul,5,Shah Joi,1,Karbaghi,26,Building,6,4,2,TRUE
+2606015,67.53694734,32.51477421,3,Sherzai Haji Abdullah Khan Mosque,Zabul,4,Shah Joi,1,Jafar Mosque,26,Building,6,3,1,TRUE
+2606070,67.481234788,32.575642287,2,Qaiom Village School,Zabul,3,Shah Joi,1,"Shor Bar, Qaiom Village",26,Building,6,2,1,TRUE
+2607022,66.76633521,32.63231363,5,Daichopan Mosque,Zabul,5,Daichopan,0,Daichopan,26,Village,7,5,0,TRUE
+2607023,66.76216378,32.62985728,3,Daichopan School,Zabul,5,Daichopan,2,Daichopan,26,Village,7,2,3,TRUE
+2607024,66.763269562,32.631991429,4,District Clinic,Zabul,4,Daichopan,0,Daichopan,26,Village,7,4,0,TRUE
+2608035,67.35868447,31.73596508,3,District Clinic,Zabul,6,Atghar,3,Atghar Bazar,26,Building,8,6,0,TRUE
+2608073,67.395195735,31.784369095,2,Madrasa,Zabul,3,Atghar,1,Toragha Village,26,Building,8,3,0,TRUE
+2609042,67.4830004,32.00536025,2,Omomi School,Zabul,3,Naw Bahar,1,Lorgai,26,Building,9,3,1,TRUE
+2609043,67.63875802,32.20409758,2,District Clinic,Zabul,3,Naw Bahar,1,District Compound,26,Building,9,1,2,TRUE
+2610036,67.64568078,31.9084175,6,District Clinic,Zabul,9,Shemel Zayi,3,Shamalzai Bazar,26,Building,10,6,3,TRUE
+2610038,67.61611111,31.56277777,1,Jangi Borj Mosque,Zabul,2,Shemel Zayi,1,Dagar Jangai,26,Building,10,1,1,TRUE
+2610039,67.74406898,32.01677998,2,Seenzai School,Zabul,3,Shemel Zayi,1,Seenzai,26,Building,10,2,1,TRUE
+2610040,67.82373803,31.65092628,2,Mirwais Khan School,Zabul,2,Shemel Zayi,0,Zanzeer,26,Building,10,2,0,TRUE
+2610041,67.64584838,31.90910877,4,Maaref Mudiryat,Zabul,7,Shemel Zayi,3,Shamalzai Markaz,26,Building,10,4,3,TRUE
+2701003,65.70941515,31.62497682,10,Mohamood Tarzi High School,Kandahar,10,Kandahar,0,D09 - Nahia 9,27,Building,1,10,0,TRUE
+2701005,65.70268177,31.62244711,6,Mir Bazar School,Kandahar,6,Kandahar,0,D06 - Nahia 6,27,Building,1,6,0,TRUE
+2701006,65.72299555,31.63939867,4,Qawmi Secondary School,Kandahar,7,Kandahar,3,D10 - Nahia 10,27,Building,1,7,0,TRUE
+2701007,65.72664127,31.62453713,0,Malalai High School,Kandahar,10,Kandahar,10,D04 - Nahia 4,27,Building,1,10,0,TRUE
+2701009,65.69812825,31.60988137,1,Zarghona Ana High School,Kandahar,7,Kandahar,6,D06 - Nahia 6,27,Building,1,8,0,TRUE
+2701010,65.69651096,31.62359614,1,Aino Secondary School,Kandahar,7,Kandahar,6,D06 - Nahia 6,27,Building,1,8,0,TRUE
+2701012,65.7126059,31.6181172,7,Pakhwanai Walayat,Kandahar,7,Kandahar,0,D04 - Nahia 4,27,Building,1,7,0,TRUE
+2701014,65.69366913,31.63172577,6,Mohammadia Madrassa,Kandahar,6,Kandahar,0,D01 - Nahia 1,27,Building,1,6,0,TRUE
+2701018,65.72229627,31.61477701,8,Dar-Ul-Malemeen,Kandahar,13,Kandahar,5,D05 - Nahia 5,27,Building,1,13,0,TRUE
+2701022,65.64720464,31.61567499,4,Mirwais Mena Girls School,Kandahar,6,Kandahar,2,D06 - Nahia 6,27,Building,1,8,0,TRUE
+2701023,65.76504105,31.62114067,5,Sayed Jamaluddin High School,Kandahar,8,Kandahar,3,Aino Mena,27,Building,1,10,0,TRUE
+2701025,65.70525874,31.60977492,1,Sardar Madad School,Kandahar,7,Kandahar,6,D02 - Nahia 2,27,Building,1,8,0,TRUE
+2701029,65.71256519,31.61943703,6,Taimor Shahi High School,Kandahar,13,Kandahar,7,D04 - Nahia 4,27,Building,1,13,0,TRUE
+2701030,65.68860441,31.61355756,10,Ahmad Shah Baba High School,Kandahar,10,Kandahar,0,D02 - Nahia 2,27,Building,1,10,0,TRUE
+2701033,65.67771486,31.62036742,7,Plan Omomi Riyasat,Kandahar,7,Kandahar,0,D07 - Nahia 7,27,Building,1,7,0,TRUE
+2701034,65.68216499,31.63495628,1,Sofi Sahib Girls School,Kandahar,7,Kandahar,6,D06 - Nahia 6,27,Building,1,8,0,TRUE
+2701035,65.68551388,31.63276128,7,Sofi Sahib Boys School,Kandahar,7,Kandahar,0,D06 - Nahia 6,27,Building,1,7,0,TRUE
+2701036,65.64707705,31.61659414,5,Fazil Kandahari School,Kandahar,9,Kandahar,4,D06 - Nahia 6,27,Building,1,9,0,TRUE
+2701037,65.696603,31.623398,1,Old Education Department,Kandahar,6,Kandahar,5,D06 - Nahia 6,27,Village,1,7,0,TRUE
+2701038,65.70193146,31.61763038,6,Zahir Shahi School,Kandahar,10,Kandahar,4,D06 - Nahia 6,27,Building,1,12,0,TRUE
+2701040,65.73046173,31.621283,10,Mirwais Neeka High School,Kandahar,12,Kandahar,2,D04 - Nahia 4,27,Building,1,12,0,TRUE
+2701042,65.70153099,31.64059597,6,Shaheed Azeemullah School,Kandahar,10,Kandahar,4,D09 - Nahia 9,27,Building,1,10,0,TRUE
+2701045,65.70728651,31.60483689,7,Mashriqi High School,Kandahar,11,Kandahar,4,D03 - Nahia 3,27,Building,1,11,0,TRUE
+2701048,65.73978611,31.61753888,6,Shaheed Abdul Latif High School,Kandahar,6,Kandahar,0,D04 - Nahia 4,27,Building,1,6,0,TRUE
+2701050,65.70881386,31.61844956,0,Aino High School,Kandahar,5,Kandahar,5,D06 - Nahia 6,27,Building,1,5,0,TRUE
+2701054,65.74368116,31.61717867,6,Kadastar Riyasat,Kandahar,11,Kandahar,5,D10 - Nahia 10,27,Building,1,11,0,TRUE
+2701056,65.72532475,31.59768955,3,Sheen Ghazai Ashabi,Kandahar,12,Kandahar,9,D03 - Nahia 3,27,Building,1,12,0,TRUE
+2701058,65.74654757,31.62127597,4,Shaheed Abdul Ahad Khan Karzai High School,Kandahar,6,Kandahar,2,Karta-E-Malemeen,27,Building,1,6,0,TRUE
+2701059,65.666677616,31.604667683,4,Meena Borj,Kandahar,6,Kandahar,2,Meena Borj,27,District,1,6,0,TRUE
+2701060,65.74709059,31.63622015,3,Sayed Abad School,Kandahar,6,Kandahar,3,D10 - Nahia 10,27,Building,1,7,0,TRUE
+2701061,65.6107392,31.61771754,4,Yateemano School,Kandahar,5,Kandahar,1,Kokaran,27,Building,1,5,0,TRUE
+2701062,65.83629141,31.6183483,5,Ameer Lalee Hotel,Kandahar,8,Kandahar,3,D10 - Nahia 10,27,Building,1,8,0,TRUE
+2701063,65.676999,31.60097461,2,Abdul Hadi Dawi Secondary School,Kandahar,8,Kandahar,6,D07 - Nahia 7,27,Building,1,8,0,TRUE
+2702099,65.67305838,31.722425,1,Ghazi Mohammad Akbar Khan School,Kandahar,4,Arghandab,3,Babar,27,Building,2,4,0,TRUE
+2702100,65.6688829,31.65938236,2,Baba Sahib Dorahi - Irrigation Department,Kandahar,3,Arghandab,1,Baba Wali Sahib,27,Building,2,3,0,TRUE
+2702101,65.74943099,31.75727481,1,Khwaja Malik School,Kandahar,3,Arghandab,2,Khwaja Malik,27,Building,2,3,0,TRUE
+2702102,65.70043481,31.7398762,3,Sheen Awliya School,Kandahar,3,Arghandab,0,Sheen Awliya,27,Building,2,3,0,TRUE
+2702103,65.65458503,31.71188923,3,Jala Oar School,Kandahar,3,Arghandab,0,Doraahi,27,Building,2,3,0,TRUE
+2702104,65.63553823,31.70241891,2,Shaheed Faiz School,Kandahar,3,Arghandab,1,Chahar Gholba,27,Building,2,3,0,TRUE
+2702105,65.6123494,31.6486373,2,Kohak School,Kandahar,3,Arghandab,1,Kohak,27,Building,2,3,0,TRUE
+2702106,65.64360396,31.675564,2,Shah Ashraf School,Kandahar,3,Arghandab,1,Tabeen,27,Building,2,3,0,TRUE
+2702107,65.60953264,31.6873428,2,Manara School,Kandahar,3,Arghandab,1,Manara,27,Building,2,3,0,TRUE
+2702108,65.58540293,31.64907262,1,Khushal Khan School,Kandahar,3,Arghandab,2,Nagahan,27,Building,2,3,0,TRUE
+2702109,65.72564015,31.73407696,1,Mohammad Yaqoob Qalacha School,Kandahar,3,Arghandab,2,Mohammad Yaqoob Qalacha,27,Building,2,3,0,TRUE
+2702110,65.65779807,31.65820728,3,Baba Wali Sahib Old District Office,Kandahar,3,Arghandab,0,Baba Wali Sahib,27,Building,2,3,0,TRUE
+2702111,65.68208553,31.67427231,2,Sultan Mahmood Ghaznawi School,Kandahar,3,Arghandab,1,Mirab Khoran,27,Building,2,3,0,TRUE
+2702112,65.69524937,31.70637459,2,Mawlawi Abdul Wasi School,Kandahar,3,Arghandab,1,Gul Qalacha,27,Building,2,3,0,TRUE
+2702113,65.57770777,31.6134289,3,Bagh Pul Hotel Park,Kandahar,5,Arghandab,2,Bagh Pul,27,Building,2,5,0,TRUE
+2702114,65.7466871,31.78014096,2,Khana Gardab Madrassa,Kandahar,3,Arghandab,1,Khana Gardab,27,Building,2,3,0,TRUE
+2702115,65.64707576,31.68229891,3,Kakhta Chahar Ghalba Mosque,Kandahar,5,Arghandab,2,Kakhta Chahar Ghalba,27,Building,2,5,0,TRUE
+2703066,66.21227775,31.71452965,2,Semelzai Akhond Sahib Private House,Kandahar,4,Daman,2,Semelzai Village,27,Building,3,4,0,TRUE
+2703068,66.09070127,31.68356669,3,Mohammad Ashraf Private House,Kandahar,4,Daman,1,Manja,27,Building,3,4,0,TRUE
+2703070,65.91205328,31.44772126,3,Haji Saifullah Oil Station School,Kandahar,4,Daman,1,Dalai Village,27,Building,3,7,0,TRUE
+2703072,65.97863744,31.61645477,2,Latif Agha School,Kandahar,3,Daman,1,Najwi Village,27,Building,3,3,0,TRUE
+2703073,65.86228399,31.54949626,0,Haji Akhtar Mohamamd Private House,Kandahar,3,Daman,3,Nawe Ada,27,Village,3,3,0,TRUE
+2703074,65.9709932,31.47412105,3,Sayed Mohammad Kor,Kandahar,3,Daman,0,Nawe Ada,27,Village,3,3,0,TRUE
+2703075,66.04034782,31.572936,3,Haji Sultan Mohammad Aka Private House,Kandahar,3,Daman,0,Madzi,27,Building,3,3,0,TRUE
+2703076,65.9061707,31.59124294,3,Momand Qala School,Kandahar,3,Daman,0,Momand Qala,27,Village,3,3,0,TRUE
+2703077,65.90276807,31.59075515,0,Hayatullah Private House,Kandahar,3,Daman,3,Momand Qala,27,Village,3,3,0,TRUE
+2703078,65.854756419,31.615271088,2,Nisaji School,Kandahar,5,Daman,3,Nisaji,27,Building,3,5,0,TRUE
+2703079,65.8536799,31.54549648,4,Mandahsar School,Kandahar,5,Daman,1,Mandahsar,27,Building,3,5,0,TRUE
+2703080,65.81251955,31.50412204,3,Khosh Aab School,Kandahar,4,Daman,1,Khosh Aab,27,Building,3,4,0,TRUE
+2703081,65.81910461,31.58658409,0,Karim Shah Khan Saracha,Kandahar,3,Daman,3,Shorandam,27,Building,3,3,0,TRUE
+2703082,65.82436917,31.58290782,3,Shorandam School,Kandahar,3,Daman,0,Shorandam,27,Building,3,3,0,TRUE
+2703083,65.9473361,31.64569559,3,Azam Qala School,Kandahar,5,Daman,2,Azam Qala,27,Building,3,5,0,TRUE
+2703084,65.875274347,31.490184055,3,Faram Tarank School,Kandahar,5,Daman,2,Hakeem Jana Kalacha,27,Building,3,5,0,TRUE
+2703085,65.80766527,31.58322218,2,Haji Anfiya Kalacha/Shorandam Markaz,Kandahar,3,Daman,1,D05 - Nahia 5,27,Building,3,3,0,TRUE
+2703086,65.926926358,31.426069541,2,Tbc Clinic,Kandahar,3,Daman,1,Haji Aziz Village,27,Village,3,3,0,TRUE
+2703087,66.1570954,31.64450293,1,Haji Habib Aka Mosque,Kandahar,2,Daman,1,Sra Qala,27,Village,3,2,0,TRUE
+2703088,65.796663909,31.577241306,2,Naqileen School,Kandahar,3,Daman,1,Naqileen,27,Building,3,3,0,TRUE
+2704173,65.31554753,31.44232152,3,Mula Hassan High School,Kandahar,4,Panjwayee,1,Talgan,27,Village,4,4,0,TRUE
+2704174,65.44355817,31.48706433,2,Regwa School,Kandahar,2,Panjwayee,0,Regwa,27,Village,4,2,0,TRUE
+2704175,65.32078235,31.44977518,1,Talgaan Camp,Kandahar,2,Panjwayee,1,Talgan,27,Village,4,2,0,TRUE
+2704176,65.25783581,31.4666463,1,Shar Ali Camp,Kandahar,2,Panjwayee,1,Moshan,27,Village,4,2,0,TRUE
+2704177,65.26192373,31.46535187,2,Haji Akbar Camp,Kandahar,3,Panjwayee,1,Moshan,27,Village,4,3,0,TRUE
+2704178,65.49624739,31.54195131,3,Marghar Camp School,Kandahar,4,Panjwayee,1,Marghar Camp,27,Building,4,4,0,TRUE
+2704179,65.545838465,31.517335662,4,Salawat School,Kandahar,4,Panjwayee,0,Panjwayee,27,Building,4,4,0,TRUE
+2704180,65.45488092,31.54288046,4,Shamsuddin Kakar School,Kandahar,4,Panjwayee,0,Panjwayee Markaz,27,Building,4,4,0,TRUE
+2704181,65.32607926,31.44593925,2,Mohammad Jan Camp,Kandahar,3,Panjwayee,1,Talgan,27,Village,4,3,0,TRUE
+2704182,65.26555003,31.46236089,2,Haji Noor Mohammad Camp,Kandahar,2,Panjwayee,0,Moshan,27,Village,4,2,0,TRUE
+2704183,65.38282538,31.48568278,2,Sultan Mohammad Khan School,Kandahar,2,Panjwayee,0,Zangi Abad,27,Village,4,2,0,TRUE
+2704184,65.38240426,31.48575142,2,Sulaiman Makoo School,Kandahar,3,Panjwayee,1,Zangi Abad,27,Village,4,3,0,TRUE
+2704185,65.45551939,31.54306135,2,Girls School,Kandahar,4,Panjwayee,2,Tbc,27,Building,4,4,0,TRUE
+2704186,65.46399049,31.55029324,4,Chehl Ghor School,Kandahar,4,Panjwayee,0,Chehl Ghor,27,Building,4,4,0,TRUE
+2704187,65.42165344,31.50708093,3,Haji Abdullah Khan School,Kandahar,5,Panjwayee,2,Safid Rawan,27,Building,4,5,0,TRUE
+2704188,65.56185835,31.50436988,4,Nakhoni Village School,Kandahar,4,Panjwayee,0,Nakhoni Village,27,Village,4,4,0,TRUE
+2704189,65.31551355,31.43922059,2,Talgaan Village School,Kandahar,4,Panjwayee,2,Talgan Village,27,Village,4,4,0,TRUE
+2704190,65.27060519,31.45634205,2,Bazar Madrassa,Kandahar,2,Panjwayee,0,Moshan,27,Village,4,2,0,TRUE
+2704191,65.32941981,31.47825107,5,Mullah Atta Mohamamd Place,Kandahar,9,Panjwayee,4,Talgan,27,Village,4,8,1,TRUE
+2704192,65.26444048,31.45844168,4,Shir Ali Place,Kandahar,7,Panjwayee,3,Moshan,27,Village,4,7,0,TRUE
+2704193,65.44812416,31.36110229,4,Tranining Center Place,Kandahar,8,Panjwayee,4,Marghar,27,Village,4,8,0,TRUE
+2704194,65.53871174,31.56071513,2,Salihan Mosque,Kandahar,4,Panjwayee,2,Karez Village,27,Building,4,4,0,TRUE
+2704195,65.50494498,31.54308513,2,Mullah Abdul Rahman Darbar,Kandahar,3,Panjwayee,1,Herasi,27,Building,4,3,0,TRUE
+2705149,65.36432778,31.67057505,2,Awal Camp Tent,Kandahar,4,Zhire,2,Zharee Dasht Village,27,Building,5,4,0,TRUE
+2705150,65.50963058,31.59774157,2,Aashoqa School,Kandahar,3,Zhire,1,Aashoqa,27,Village,5,3,0,TRUE
+2705153,65.3756264,31.65774962,4,11Th Camp School,Kandahar,8,Zhire,4,Zharee Dasht,27,Building,5,8,0,TRUE
+2705154,65.37401452,31.68803368,2,8Th Camp School,Kandahar,3,Zhire,1,Zharee Dasht,27,Building,5,3,0,TRUE
+2705155,65.39819452,31.67175419,1,6Th Camp School,Kandahar,2,Zhire,1,Zharee Dasht,27,Building,5,2,0,TRUE
+2705156,65.49932066,31.62737545,1,5Th Camp School,Kandahar,2,Zhire,1,Zharee Dasht,27,Village,5,2,0,TRUE
+2705157,65.38278298,31.67717704,3,4Th Camp Mosque,Kandahar,5,Zhire,2,Zharee Dasht,27,Building,5,5,0,TRUE
+2705158,65.39043682,31.66848511,1,2Nd Camp Mosque,Kandahar,2,Zhire,1,Zharee Dasht,27,Building,5,2,0,TRUE
+2705159,65.43379528,31.58367484,2,District Building Office,Kandahar,3,Zhire,1,District Compound,27,Building,5,3,0,TRUE
+2705160,65.39318419,31.53098485,2,Amanullah School,Kandahar,2,Zhire,0,Sablaghi,27,Village,5,2,0,TRUE
+2705161,65.52713516,31.62213409,2,Haji Lala Oil Station,Kandahar,3,Zhire,1,Senzari,27,Building,5,3,0,TRUE
+2705162,65.31792579,31.49459612,1,Nalgham School,Kandahar,2,Zhire,1,Nalgham,27,Village,5,2,0,TRUE
+2705163,65.31836114,31.54902085,2,Old Clinic,Kandahar,3,Zhire,1,Hawz Madad,27,Village,5,3,0,TRUE
+2705164,65.40918084,31.55722354,1,Asad Soor School,Kandahar,2,Zhire,1,Pashmol,27,Village,5,2,0,TRUE
+2705165,65.279834075,31.511568226,1,Popal Neeka School,Kandahar,2,Zhire,1,Qolq,27,Village,5,2,0,TRUE
+2705166,65.33599358,31.5350673,1,Naadi School,Kandahar,2,Zhire,1,Sangohsar,27,Village,5,2,0,TRUE
+2705167,65.30810475,31.52971446,1,Mohammad Shah Saracha,Kandahar,2,Zhire,1,Lako Khel,27,Village,5,2,0,TRUE
+2705168,65.35700286,31.60721005,5,Near Police Station,Kandahar,8,Zhire,3,Kochiano Camp,27,Village,5,8,0,TRUE
+2705170,65.35041948,31.62946664,3,Camp School,Kandahar,6,Zhire,3,Kochiano Camp,27,Village,5,6,0,TRUE
+2705172,65.4281488,31.56211178,2,Pashmol Village School,Kandahar,4,Zhire,2,Pashmol Village,27,Village,5,4,0,TRUE
+2706089,65.96801075,31.96879479,3,Wiyan Clinic,Kandahar,6,Shah Wali Kot,3,Wiyan,27,Village,6,6,0,TRUE
+2706090,66.02687838,32.07574627,2,Haji Fayab Private House,Kandahar,2,Shah Wali Kot,0,Baghto,27,Village,6,2,0,TRUE
+2706091,66.06644177,32.02147762,2,Safullah Private House,Kandahar,2,Shah Wali Kot,0,Asakzo Sozni,27,District,6,2,0,TRUE
+2706092,66.02799602,31.94826795,2,Malak Salam Private House,Kandahar,4,Shah Wali Kot,2,Borgi,27,Village,6,4,0,TRUE
+2706094,65.77938868,31.78080534,2,Sayed Haleem School,Kandahar,4,Shah Wali Kot,2,Sayed Haleem,27,Village,6,4,0,TRUE
+2706095,66.04625696,32.16932389,2,Fazal Karam Mosque,Kandahar,2,Shah Wali Kot,0,Shah Toot,27,Village,6,2,0,TRUE
+2706097,65.91112557,32.24288461,2,Kajoor Mosque,Kandahar,2,Shah Wali Kot,0,Kajoor,27,Village,6,2,0,TRUE
+2706098,66.02638435,31.91062333,2,Zartala School,Kandahar,3,Shah Wali Kot,1,Zartala,27,Village,6,3,0,TRUE
+2707116,65.31724305,31.7691917,2,Rahmatullah Private House,Kandahar,4,Khakrez,2,Lalak,27,Village,7,0,4,FALSE
+2707118,65.60199657,31.98671283,2,Naasir School,Kandahar,2,Khakrez,0,Naasir,27,Village,7,0,2,FALSE
+2707119,65.3794553,32.16062159,2,Malak Mohammad Shah Private House,Kandahar,2,Khakrez,0,Laam,27,Village,7,0,2,FALSE
+2707121,65.49351383,31.90385895,1,Haji Qayoom Guest House,Kandahar,2,Khakrez,1,Aroq Shah Khan,27,Building,7,2,0,TRUE
+2707122,65.51520134,31.96054472,2,Haji Gul School,Kandahar,3,Khakrez,1,Haji Gul,27,Village,7,3,0,TRUE
+2707123,65.47469749,31.98267324,2,District Building Office,Kandahar,3,Khakrez,1,Khak Rez,27,Building,7,3,0,TRUE
+2707124,65.47167655,31.98600713,1,Khakrez Village Clinic,Kandahar,4,Khakrez,3,Khak Rez Village,27,Building,7,4,0,TRUE
+2707126,65.38391929,31.87417353,2,Haji Mohamamd Ayub Khan Saracha,Kandahar,2,Khakrez,0,Dokhana,27,Building,7,0,2,FALSE
+2708245,66.60354308,31.55000358,3,Bala Karzai School,Kandahar,5,Arghistan,2,Bala Karzai,27,Village,8,5,0,TRUE
+2708246,66.58508825,31.56294971,3,Mohamamd Neeka School,Kandahar,5,Arghistan,2,Khogyani,27,Village,8,5,0,TRUE
+2708247,66.7329135,31.6940352,2,Speen Agra Mosque,Kandahar,3,Arghistan,1,Speen Agra,27,Village,8,3,0,TRUE
+2708248,66.72547273,31.569464,2,Karam Khel Clinic,Kandahar,5,Arghistan,3,Karam Khel,27,Village,8,5,0,TRUE
+2708249,66.4124693,31.5965937,2,Shna Khata School,Kandahar,3,Arghistan,1,Shna Khata,27,Village,8,3,0,TRUE
+2708250,66.29995218,31.45866905,2,Guest House,Kandahar,4,Arghistan,2,Narghal,27,Village,8,4,0,TRUE
+2708251,66.35257515,31.56691943,2,Ameen Qala School,Kandahar,3,Arghistan,1,Ameen Qala,27,Village,8,3,0,TRUE
+2708252,66.54681623,31.38476271,2,Taisan Village School,Kandahar,4,Arghistan,2,Taisan Village,27,Village,8,4,0,TRUE
+2708253,66.58131426,31.33292331,2,Tesan Village School,Kandahar,3,Arghistan,1,Bala Zhara,27,Village,8,3,0,TRUE
+2709127,65.15619905,32.08420675,2,Shah Karez Clinic,Kandahar,3,Ghorak,1,Shah Karez,27,Building,9,3,0,TRUE
+2709128,65.15439764,32.08155743,1,Baran School,Kandahar,2,Ghorak,1,Shah Karez,27,Village,9,2,0,TRUE
+2709129,64.99970243,32.04967079,2,Washtan Mosque,Kandahar,2,Ghorak,0,Washtan,27,Building,9,2,0,TRUE
+2709130,65.17564375,32.07841071,2,Pir Khadim Mosque,Kandahar,2,Ghorak,0,Pir Khadim,27,Building,9,2,0,TRUE
+2709131,65.16030108,32.05788655,1,Juma Khan Private House,Kandahar,2,Ghorak,1,Ishaaqzo Village,27,District,9,2,0,TRUE
+2710135,64.96612181,31.53569812,3,Band Taimoor Clinic,Kandahar,3,Maiwand,0,Band Taimoor,27,Village,10,3,0,TRUE
+2710136,64.79349484,31.70431519,2,Muslim Abad School,Kandahar,3,Maiwand,1,Muslim Abad,27,Village,10,3,0,TRUE
+2710137,65.12994252,31.74779912,2,Shahidano School,Kandahar,2,Maiwand,0,Maiwand Chana,27,Village,10,2,0,TRUE
+2710138,65.03081805,31.63745174,3,Mohammad Yousuf Private House,Kandahar,3,Maiwand,0,Safozi Enjaran,27,Building,10,3,0,TRUE
+2710139,65.23960463,31.47263035,2,Haji Masoom Khan Private House,Kandahar,2,Maiwand,0,Do Aab,27,Village,10,2,0,TRUE
+2710140,65.02472954,31.52994509,0,Qala Khan Private House,Kandahar,2,Maiwand,2,Chashma Mohammad Khan,27,Building,10,2,0,TRUE
+2710141,64.89450719,31.54647336,2,Abdul Kareem Private House,Kandahar,2,Maiwand,0,Sufi Kareem Saracha,27,Building,10,2,0,TRUE
+2710142,65.06238844,31.61791223,2,Ghazi Mohamamd Ayub Khan High School,Kandahar,3,Maiwand,1,Zor Bazar,27,Building,10,3,0,TRUE
+2710143,64.87845909,31.77533442,2,Doctar Ismail Oil Station,Kandahar,3,Maiwand,1,Sangbar,27,Building,10,3,0,TRUE
+2710144,65.23264025,31.50780448,1,Sardar Asad Private House,Kandahar,2,Maiwand,1,Mirab Khor,27,Village,10,2,0,TRUE
+2710145,65.05610836,31.6226324,0,District Building Office,Kandahar,3,Maiwand,3,District Compound,27,Building,10,3,0,TRUE
+2710146,65.06558251,31.6146512,3,Pirzada Village Hotel,Kandahar,3,Maiwand,0,Pirzada Village,27,Building,10,3,0,TRUE
+2710147,65.22905884,31.52171943,2,Malak Ataullah Private House,Kandahar,2,Maiwand,0,Shahee Karez,27,Village,10,2,0,TRUE
+2710148,65.06197733,31.80142529,2,Balos Haji Amanullah Village,Kandahar,2,Maiwand,0,Balos Haji Amanullah Village,27,Village,10,2,0,TRUE
+2711203,66.41408787,30.99102689,6,Haji Raziq Guest House,Kandahar,7,Spin Boldak,1,Haji Raziq Village,27,Building,11,7,0,TRUE
+2711204,66.39523497,31.00704971,4,Mukhabirato Markaz,Kandahar,6,Spin Boldak,2,Awami Camp,27,Building,11,6,0,TRUE
+2711205,66.43391831,30.96608532,5,Doctar Mohammad Dawood Private House,Kandahar,6,Spin Boldak,1,Nawee Village,27,Building,11,6,0,TRUE
+2711206,66.40652244,30.95497601,5,Haji Raziq School,Kandahar,5,Spin Boldak,0,Yaqoob Wesh Market,27,Building,11,5,0,TRUE
+2711207,66.48145239,31.17736762,5,Loy Karez Clinic,Kandahar,6,Spin Boldak,1,Loy Karez,27,Building,11,6,0,TRUE
+2711208,66.41691556,30.97136213,3,Haji Ahmad Shah Market School,Kandahar,6,Spin Boldak,3,Boldak Wesh,27,Building,11,6,0,TRUE
+2711209,66.44213304,31.09279945,4,Bambol Madrassa,Kandahar,5,Spin Boldak,1,Bambol,27,Village,11,5,0,TRUE
+2711210,66.41057118,31.04105787,5,Abdul Samad Khan School,Kandahar,6,Spin Boldak,1,Rabat,27,Village,11,6,0,TRUE
+2711211,66.39489795,31.00910156,2,Unhcr Office,Kandahar,4,Spin Boldak,2,Speen Boldak,27,Building,11,4,0,TRUE
+2711212,66.39986734,31.00904248,4,Qazi Madrassa,Kandahar,6,Spin Boldak,2,Speen Boldak,27,Village,11,6,0,TRUE
+2711213,66.39174875,31.002958,2,Malyad Alizai,Kandahar,4,Spin Boldak,2,Haji Afzal Village,27,Building,11,4,0,TRUE
+2711214,66.38543885,31.02093966,4,Haji Nemat Oil Stioation,Kandahar,6,Spin Boldak,2,Speen Boldak,27,Building,11,6,0,TRUE
+2711215,66.39761449,30.99615159,4,Ahmad Shah Rooms,Kandahar,4,Spin Boldak,0,Wesh,27,Building,11,4,0,TRUE
+2711216,66.39581794,31.00978014,3,Faizo Private House,Kandahar,3,Spin Boldak,0,Speen Boldak,27,Building,11,3,0,TRUE
+2711217,66.43499425,30.96105675,3,Farmanullah Private House,Kandahar,6,Spin Boldak,3,Nawai Village,27,Building,11,6,0,TRUE
+2711218,66.38462718,31.00036284,5,Mohamamd Dawood Barakzai Private House,Kandahar,6,Spin Boldak,1,Nawai Village,27,Village,11,6,0,TRUE
+2711219,66.42550755,30.95443239,5,Aali Neeka School,Kandahar,6,Spin Boldak,1,Wesh,27,Building,11,6,0,TRUE
+2711220,66.42003013,31.04394891,4,Shaheed Abdullah Jan School,Kandahar,5,Spin Boldak,1,Rabat,27,Village,11,5,0,TRUE
+2711221,66.40273996,30.99925967,5,Geeba Neeka School,Kandahar,7,Spin Boldak,2,Khair Abad,27,Building,11,7,0,TRUE
+2711222,66.45726125,30.96913237,4,Baagul Building,Kandahar,5,Spin Boldak,1,Nawai Village,27,Building,11,5,0,TRUE
+2711223,66.42340658,31.04666388,3,Haji Mohammad Ayub School,Kandahar,4,Spin Boldak,1,Rabat,27,Village,11,4,0,TRUE
+2711224,66.41401143,31.00447902,3,Ghazi Abdullah Khan High School,Kandahar,4,Spin Boldak,1,Speen Boldak,27,Building,11,4,0,TRUE
+2711225,66.48158418,31.17742325,4,Akhtarzai Loy Village,Kandahar,5,Spin Boldak,1,Loy Karez,27,Village,11,5,0,TRUE
+2711226,66.37090884,30.93302545,4,Margha Khaima,Kandahar,6,Spin Boldak,2,Zikriya Village,27,Village,11,6,0,TRUE
+2711227,66.41453319,30.98503304,4,Haji Kamaluddin Private House,Kandahar,6,Spin Boldak,2,Bilal Abad,27,Building,11,6,0,TRUE
+2711228,66.56014324,31.14167494,5,Miranzo Village Madrassa,Kandahar,6,Spin Boldak,1,Nawai Village,27,Building,11,6,0,TRUE
+2712263,65.65759441,32.42136393,3,District Building Office,Kandahar,6,Nish,3,Niazo Khel,27,Village,12,6,0,TRUE
+2712264,65.67159114,32.41962007,3,Haji Agha Lala Private House,Kandahar,3,Nish,0,Chopani,27,Village,12,3,0,TRUE
+2712265,65.65795147,32.43690212,3,Haji Naimatullah Private House,Kandahar,3,Nish,0,Nawai Karez,27,Village,12,3,0,TRUE
+2712266,65.65051122,32.40878549,3,Rashid Khan Private House,Kandahar,3,Nish,0,Bar Kandi,27,Village,12,3,0,TRUE
+2712267,65.65213232,32.41381515,2,Haji Mirza Jamal Private House,Kandahar,3,Nish,1,Gordang,27,Village,12,3,0,TRUE
+2712268,65.75547667,32.41398586,3,Wahab Khel School,Kandahar,3,Nish,0,Kanda Village,27,Village,12,3,0,TRUE
+2713259,66.17813304,32.37174559,2,Haji Abdul Haleem Mosque,Kandahar,3,Miyanishin,1,Zamto Village,27,Village,13,3,0,TRUE
+2713261,66.372291,32.3753356,1,District Building Office,Kandahar,2,Miyanishin,1,Chalwar,27,Village,13,2,0,TRUE
+2714199,65.99435898,30.17954185,4,Wali Mohammad Khan Private House,Kandahar,6,Shorabak,2,Torzi,27,Village,14,6,0,TRUE
+2714200,66.00318497,30.13752704,3,Faiz Mohammad Private House,Kandahar,5,Shorabak,2,Abozi,27,Village,14,5,0,TRUE
+2714201,65.99451595,30.1327574,4,District Building Office,Kandahar,6,Shorabak,2,Abozi,27,Village,14,6,0,TRUE
+2714202,66.08105448,29.82859433,3,Kasamzai,Kandahar,5,Shorabak,2,Kasamzo Village,27,Village,14,5,0,TRUE
+2714269,66.17452397,30.17143391,3,Haji Rozi Khan Private House,Kandahar,5,Shorabak,2,Karez Village,27,Village,14,5,0,TRUE
+2715254,67.17797326,31.64940853,4,District Building Office,Kandahar,6,Maruf,2,District Compound,27,Village,15,6,0,TRUE
+2715255,67.32400657,31.34158915,3,Haji Manan Private House,Kandahar,5,Maruf,2,Salisoon,27,Village,15,5,0,TRUE
+2715256,67.24670421,31.61800851,3,Tbc,Kandahar,5,Maruf,2,Tbc Saratan,27,Village,15,5,0,TRUE
+2715257,67.03522199,31.48632695,3,Obto School,Kandahar,5,Maruf,2,Obto Village,27,Village,15,5,0,TRUE
+2715258,67.76578998,31.36849267,5,Aala Jirga Mosque,Kandahar,7,Maruf,2,Aala Jirga Village,27,Village,15,7,0,TRUE
+2715270,67.22807984,31.65781731,3,Chody Village Mosque,Kandahar,5,Maruf,2,Chodi Village,27,Village,15,5,0,TRUE
+2715271,67.17838996,31.64796026,3,Khogyano Village Mosque,Kandahar,5,Maruf,2,Khogyano Village,27,Village,15,5,0,TRUE
+2716196,65.64584103,29.78775459,4,Sher Shah School,Kandahar,7,Reg,3,Sher Shah,27,Village,16,7,0,TRUE
+2716197,65.07035892,29.58181044,4,Kaami School,Kandahar,6,Reg,2,Kaami,27,Village,16,6,0,TRUE
+2716198,65.71965053,29.72968321,4,District Building Office,Kandahar,6,Reg,2,Reg Manteqa,27,Village,16,6,0,TRUE
+2717001,65.69687175,31.58295337,4,Deh Bagh,Kandahar,6,Dand,2,Dand District,27,Village,17,6,0,TRUE
+2717004,65.70954999,31.57355926,3,Haji Baba Guest House,Kandahar,6,Dand,3,Dand District,27,Village,17,6,0,TRUE
+2717011,65.64597159,31.58191418,3,Rwani Secondary School,Kandahar,6,Dand,3,Dand District,27,Village,17,6,0,TRUE
+2717013,65.72264728,31.57694052,4,Karz School,Kandahar,7,Dand,3,D06 - Nahia 6,27,Village,17,7,0,TRUE
+2717015,65.709543,31.592479,3,Haji Arab School,Kandahar,6,Dand,3,D02 - Nahia 2,27,Village,17,6,0,TRUE
+2717016,65.67827019,31.57627381,4,Kulcha Abad Secondary School,Kandahar,6,Dand,2,Dand District,27,Village,17,6,0,TRUE
+2717017,65.7225373,31.57701662,4,Salo Karez School,Kandahar,6,Dand,2,Salo Karez,27,Village,17,6,0,TRUE
+2717021,65.6818364,31.58284707,3,Baldi Secondary School,Kandahar,6,Dand,3,Dand District,27,Village,17,6,0,TRUE
+2717051,65.72178756,31.54897458,4,Chaplani School,Kandahar,5,Dand,1,Chaplani,27,District,17,5,0,TRUE
+2717052,65.696402,31.591113,4,Salo Khan Chaman Mosque,Kandahar,7,Dand,3,Alkozo Koch Khana,27,Building,17,7,0,TRUE
+2717064,65.65040373,31.58133525,4,Zakir Sharif School,Kandahar,6,Dand,2,D06 - Nahia 6,27,District,17,6,0,TRUE
+2717065,65.65568891,31.55341307,2,Rambasi School,Kandahar,3,Dand,1,Rambasi,27,District,17,3,0,TRUE
+2718229,65.805477646,31.487966429,3,Sulaimanzai School,Kandahar,3,Takhta Pul,0,Zahir Village,27,Village,18,3,0,TRUE
+2718230,65.975031582,31.242384841,1,Village School,Kandahar,2,Takhta Pul,1,Haji Nazar Aka Village,27,Village,18,2,0,TRUE
+2718231,65.962931981,31.32015694,2,District Building Office,Kandahar,5,Takhta Pul,3,Shaga,27,Village,18,5,0,TRUE
+2718232,66.20142877,31.323333613,1,Madad Khan School,Kandahar,2,Takhta Pul,1,Madad Khan Village,27,Village,18,2,0,TRUE
+2718233,66.167359533,31.32856132,2,Madad Khan Village Clinic,Kandahar,2,Takhta Pul,0,Madad Khan Village,27,Village,18,2,0,TRUE
+2718234,65.979612295,31.181683036,2,Road Side School,Kandahar,4,Takhta Pul,2,Hassanzai,27,Building,18,4,0,TRUE
+2718235,66.046446971,31.113953821,3,Haji Mohammad Khan Village School,Kandahar,5,Takhta Pul,2,Haji Mohammad Khan Village,27,Village,18,5,0,TRUE
+2718236,65.97900134,31.29422926,4,Haji Mohmand Village School,Kandahar,6,Takhta Pul,2,Haji Mohmand Village,27,Village,18,6,0,TRUE
+2718237,65.836688262,31.39352192,4,Peer Mohammad Private House,Kandahar,8,Takhta Pul,4,Mirano Village,27,Village,18,8,0,TRUE
+2718238,65.712426147,31.477177611,4,Camp School,Kandahar,8,Takhta Pul,4,Tajo Khan Village,27,Village,18,8,0,TRUE
+2718239,66.01944899,31.05686727,4,Maalem Sadullah School Tent,Kandahar,8,Takhta Pul,4,Ameer Khan Village,27,Village,18,8,0,TRUE
+2718240,65.550920808,31.458441137,5,Tangai Village Tent,Kandahar,8,Takhta Pul,3,Tangai Village,27,Village,18,8,0,TRUE
+2718241,65.757257889,31.425718679,2,Haji Talib Aka Private House,Kandahar,4,Takhta Pul,2,Ishaaqzo Village,27,Village,18,4,0,TRUE
+2718242,65.603679937,31.435466284,2,Bashir Khan Private House,Kandahar,4,Takhta Pul,2,Karez Shameezi,27,Village,18,4,0,TRUE
+2718243,65.95585729,31.27722471,3,Village Secondary School,Kandahar,4,Takhta Pul,1,Sher Aka Village Shaga District,27,Village,18,4,0,TRUE
+2718244,65.978273264,31.234101583,3,Ghat School,Kandahar,4,Takhta Pul,1,Mohmand Khan Village,27,Village,18,4,0,TRUE
+2801001,65.75298216,36.66385719,7,Ibn Yameen High School,Jawzjan,11,Sheberghan,4,D01 - Nahia 1,28,Building,1,11,0,TRUE
+2801002,65.74635619,36.66351456,8,Khadija High School,Jawzjan,13,Sheberghan,5,D03 - Nahia 3,28,Building,1,13,0,TRUE
+2801003,65.75108518,36.67432792,4,Mirwais Neeka High Schoo,Jawzjan,7,Sheberghan,3,D02 - Nahia 2,28,Building,1,7,0,TRUE
+2801004,65.7747411,36.65930437,5,General Abdul Rashid Dostam High School,Jawzjan,8,Sheberghan,3,D01 - Nahia 1,28,Building,1,8,0,TRUE
+2801005,65.7574523,36.68300868,4,Zokoor Yaka Bagh Boys High School,Jawzjan,7,Sheberghan,3,D04 - Nahia 4,28,Building,1,7,0,TRUE
+2801006,65.7536323,36.64482809,5,Farzam Shaheed High School,Jawzjan,8,Sheberghan,3,D03 - Nahia 3,28,Building,1,8,0,TRUE
+2801007,65.71977971,36.67125652,5,Eid Mahalla High School,Jawzjan,8,Sheberghan,3,D02 - Nahia 2,28,Building,1,8,0,TRUE
+2801008,65.73791603,36.65706308,5,Ghulam Sarwar Shaheed High School,Jawzjan,8,Sheberghan,3,D03 - Nahia 3,28,Building,1,8,0,TRUE
+2801009,65.76646218,36.666551,5,Charamgar Khana High School,Jawzjan,8,Sheberghan,3,D04 - Nahia 4,28,Building,1,8,0,TRUE
+2801010,65.80121511,36.6937063,5,Qazanchi Baba High School,Jawzjan,8,Sheberghan,3,D04 - Nahia 4,28,Building,1,8,0,TRUE
+2801011,65.76628845,36.64339751,4,Kok Gunbad Girls High School,Jawzjan,6,Sheberghan,2,D03 - Nahia 3,28,Building,1,6,0,TRUE
+2801012,65.77724422,36.65605427,5,Arab Khana High School,Jawzjan,8,Sheberghan,3,D01 - Nahia 1,28,Building,1,8,0,TRUE
+2801013,65.74086999,36.68777054,5,Baba Ali High School,Jawzjan,8,Sheberghan,3,D02 - Nahia 2,28,Building,1,8,0,TRUE
+2801014,65.74271233,36.67014884,4,Mawlana Aznab High School,Jawzjan,6,Sheberghan,2,D02 - Nahia 2,28,Building,1,6,0,TRUE
+2801015,65.74882506,36.66410406,5,Petrolium And Gas Technical Institute,Jawzjan,9,Sheberghan,4,D03 - Nahia 3,28,Building,1,9,0,TRUE
+2801016,65.75313877,36.67715075,4,Agriculture Department,Jawzjan,6,Sheberghan,2,D04 - Nahia 4,28,Building,1,6,0,TRUE
+2801017,65.8599018,36.75015264,3,Mesr Abad High School,Jawzjan,5,Sheberghan,2,D04 - Nahia 4,28,Building,1,6,0,TRUE
+2801018,65.79689365,36.72783997,3,Yangee Areegh High School,Jawzjan,5,Sheberghan,2,D04 - Nahia 4,28,Building,1,5,0,TRUE
+2801019,65.87614636,36.76182994,4,Jalal Abad Secondary School,Jawzjan,6,Sheberghan,2,D04 - Nahia 4,28,Building,1,6,0,TRUE
+2801020,65.79870492,36.65051478,4,Aalti Khwaja High School,Jawzjan,6,Sheberghan,2,D01 - Nahia 1,28,Building,1,6,0,TRUE
+2801021,65.81236926,36.55976264,3,Qara Kent Boys High School,Jawzjan,5,Sheberghan,2,D01 - Nahia 1,28,Building,1,5,0,TRUE
+2801022,65.79604803,36.60565133,3,Tonka High School,Jawzjan,5,Sheberghan,2,D01 - Nahia 1,28,Building,1,5,0,TRUE
+2801023,65.80635048,36.49272772,2,Mangotai Afghania Mosque,Jawzjan,3,Sheberghan,1,D03 - Nahia 3,28,Building,1,3,0,TRUE
+2801024,65.8302926,36.57907546,2,Qochin Secondary School,Jawzjan,4,Sheberghan,2,D01 - Nahia 1,28,Building,1,4,0,TRUE
+2801025,65.79635831,36.53147198,4,Afghan Tapa High School,Jawzjan,6,Sheberghan,2,D01 - Nahia 1,28,Building,1,6,0,TRUE
+2801026,65.83629619,36.73310635,3,Chaharshanba Secondary School,Jawzjan,5,Sheberghan,2,D04 - Nahia 4,28,Building,1,5,0,TRUE
+2801027,65.70772241,36.66211309,2,Lab Jar Khurasan Secondary School,Jawzjan,3,Sheberghan,1,D02 - Nahia 2,28,Building,1,3,0,TRUE
+2801028,65.751975004,36.681679035,2,Chobash Kalan Secondary School,Jawzjan,3,Sheberghan,1,D04 - Nahia 4,28,Building,1,3,0,TRUE
+2801029,65.775010308,36.678397972,2,Chaghachi Secondary School,Jawzjan,3,Sheberghan,1,D04 - Nahia 4,28,Building,1,3,0,TRUE
+2801030,65.773804888,36.672280857,2,Mangotai Boys High School,Jawzjan,3,Sheberghan,1,D04 - Nahia 4,28,Building,1,3,0,TRUE
+2801031,65.75134211,36.60177472,2,Shakarak Secondary School,Jawzjan,3,Sheberghan,1,D03 - Nahia 3,28,Building,1,3,0,TRUE
+2801032,65.76944668,36.61539363,2,Hassan Tabeen High School,Jawzjan,3,Sheberghan,1,D03 - Nahia 3,28,Building,1,3,0,TRUE
+2802110,65.61475267,36.82340381,5,Khwaja Do Koh Boys High School,Jawzjan,10,Khwaja Dukoh,5,District Compound,28,Building,2,10,0,TRUE
+2802111,65.6851031,36.82723623,3,Qazal Ayaq High School,Jawzjan,4,Khwaja Dukoh,1,Qazal Ayaq,28,Building,2,4,0,TRUE
+2802112,65.63238222,36.75863461,2,Chob Bash High School,Jawzjan,3,Khwaja Dukoh,1,Chob Bash,28,Building,2,3,0,TRUE
+2802114,65.63635388,36.71717527,1,Taghan Secondary School,Jawzjan,2,Khwaja Dukoh,1,Lab Jar Taghan,28,Building,2,2,0,TRUE
+2802123,65.609950043,36.791016223,2,Haji Saleh House,Jawzjan,3,Khwaja Dukoh,1,Chob Bash Afghania,28,Village,2,3,0,TRUE
+2803115,66.10151055,36.86502639,3,Alili Boys High School,Jawzjan,4,Khanaqa,1,Khanqa,28,Building,3,4,0,TRUE
+2803116,66.13723202,36.89728457,2,Besh Kapa Watania School,Jawzjan,3,Khanaqa,1,Besh Kapa Watania,28,Building,3,3,0,TRUE
+2803117,66.07653753,36.88134721,1,Yangee Qala Arabia Girls School,Jawzjan,2,Khanaqa,1,Yangee Qala,28,Building,3,2,0,TRUE
+2803118,66.10100832,36.88280696,1,Bakawal Turkmania Mosque,Jawzjan,2,Khanaqa,1,Bakawal Turkmania,28,Building,3,2,0,TRUE
+2803119,66.10836769,36.84241831,2,Aleek Rabat Secondary School,Jawzjan,3,Khanaqa,1,Aleek Rabat,28,Building,3,3,0,TRUE
+2803120,66.16999784,36.869482016,2,Khanqah Uzbekya Girls High School,Jawzjan,3,Khanaqa,1,Khanqah Uzbekya,28,Building,3,3,0,TRUE
+2803122,66.03893202,36.87289223,1,Chobash Primary School,Jawzjan,2,Khanaqa,1,Chobash,28,Building,3,2,0,TRUE
+2804069,66.08406227,37.00583957,3,Chaar Changhoo High School,Jawzjan,5,Mingajik,2,Chaar Changhoo,28,Building,4,5,0,TRUE
+2804070,66.13708515,37.01402769,2,Mangjeek School,Jawzjan,4,Mingajik,2,Mangjeek,28,Building,4,4,0,TRUE
+2804071,66.03253412,37.06505718,2,Balja Abdul Rahman School,Jawzjan,3,Mingajik,1,Balja Abdul Rahman,28,Building,4,3,0,TRUE
+2804072,66.06001537,37.06251246,2,Safar Wali Awal School,Jawzjan,3,Mingajik,1,Safar Wali Awal,28,Building,4,3,0,TRUE
+2804073,66.08104784,36.9634398,2,Abaas Girls School,Jawzjan,4,Mingajik,2,Abaash Village,28,Building,4,4,0,TRUE
+2804074,66.18579484,37.00683033,2,Daali Muhajir School,Jawzjan,3,Mingajik,1,Daali Muhajir,28,Building,4,3,0,TRUE
+2804075,65.96813097,37.03736691,1,Qowenli Muhajir School,Jawzjan,2,Mingajik,1,Qowenli Muhajir,28,Building,4,2,0,TRUE
+2804076,66.05047808,36.91876332,2,Sultan Areegh School,Jawzjan,3,Mingajik,1,Sultan Areegh,28,Building,4,3,0,TRUE
+2804077,66.007591,37.04134478,2,Qorshangho School,Jawzjan,3,Mingajik,1,Qorshangho,28,Building,4,3,0,TRUE
+2804078,66.02146555,36.97861953,2,Qazan Naro School,Jawzjan,3,Mingajik,1,Qazan Naro,28,Building,4,3,0,TRUE
+2804079,65.9458042,37.07302692,1,Qara-E-Adeek Mosque,Jawzjan,2,Mingajik,1,Masjid Qara-E-Adeek,28,Building,4,2,0,TRUE
+2805088,65.37244852,36.06262223,4,Sher Bek School,Jawzjan,6,Qush Tepa,2,Qosh Taba,28,Building,5,6,0,TRUE
+2805089,65.39160804,36.08878129,4,Qosh Tapa High School,Jawzjan,7,Qush Tepa,3,Qosh Taba,28,Building,5,7,0,TRUE
+2805090,65.46201696,36.16901708,2,Choqma Chaqoor School,Jawzjan,4,Qush Tepa,2,Qosh Taba,28,Building,5,4,0,TRUE
+2805091,65.48422199,36.30457647,3,Jarqadoq School,Jawzjan,4,Qush Tepa,1,Qosh Taba,28,Building,5,4,0,TRUE
+2805092,65.44255043,36.14833376,1,Turkman Qadoq School,Jawzjan,2,Qush Tepa,1,Qosh Taba,28,Building,5,0,2,FALSE
+2805094,65.45593935,36.19268868,1,Taraghali School,Jawzjan,2,Qush Tepa,1,Qosh Taba,28,Building,5,0,2,FALSE
+2805125,65.368902197,36.043749479,2,Mosque,Jawzjan,3,Qush Tepa,1,Gardan,28,Village,5,3,0,TRUE
+2806084,65.73691583,37.52578696,3,Khum Aab,Jawzjan,5,Khamyab,2,Khum Aab,28,Building,6,5,0,TRUE
+2806085,65.772863971,37.505818863,2,Boz Areegh School,Jawzjan,3,Khamyab,1,Boz Areegh,28,Building,6,3,0,TRUE
+2806086,65.71695304,37.53171547,2,Qarnas School,Jawzjan,3,Khamyab,1,Qarnas,28,Building,6,3,0,TRUE
+2806087,65.80223849,37.49518735,1,Chopli Tapa,Jawzjan,2,Khamyab,1,Chopli,28,Building,6,2,0,TRUE
+2807033,66.17751589,36.90440208,6,Aaqcha Boys High School,Jawzjan,9,Aqchah,3,D01 - Nahia 1,28,Building,7,9,0,TRUE
+2807034,66.24895396,36.92456444,2,Haidar Abad Girls High School,Jawzjan,3,Aqchah,1,Haidar Abad Village,28,Building,7,3,0,TRUE
+2807035,66.1936964,36.93357155,2,Besh Areegh Mosque,Jawzjan,3,Aqchah,1,Besh Areegh Village,28,Building,7,3,0,TRUE
+2807036,66.16367507,36.9390781,2,Qum Areegh Mosque,Jawzjan,3,Aqchah,1,Qum Areegh Village,28,Building,7,3,0,TRUE
+2807037,66.207734378,36.908108093,2,Kol Baqal Ulemya School,Jawzjan,3,Aqchah,1,Kol Baqal Awalia,28,Building,7,3,0,TRUE
+2807038,66.1831244,36.91258154,2,Aaqcha Girls High School,Jawzjan,4,Aqchah,2,D01 - Nahia 1,28,Building,7,4,0,TRUE
+2807039,66.18906133,36.9065459,2,Abu Bakr Sediq Mosque,Jawzjan,4,Aqchah,2,D01 - Nahia 1,28,Building,7,5,0,TRUE
+2807040,66.1974877,36.90312732,2,Aqcha Namai Mosque,Jawzjan,4,Aqchah,2,Bati Kot Arbakia,28,Building,7,4,0,TRUE
+2807041,66.18315919,36.88507266,1,Komak Mansoor School,Jawzjan,2,Aqchah,1,Komak Mansoor,28,Building,7,2,0,TRUE
+2807042,66.22116927,36.88634069,2,Laghmani Mosque,Jawzjan,3,Aqchah,1,Laghmani Village,28,Building,7,3,0,TRUE
+2807043,66.24548547,36.84677491,1,Yandagh Areegh Mosque,Jawzjan,2,Aqchah,1,Yandagh Areegh,28,Building,7,2,0,TRUE
+2807044,66.15835072,36.91780844,3,Yangee Areegh Turkmania Boys High School,Jawzjan,5,Aqchah,2,Yangee Areegh,28,Building,7,5,0,TRUE
+2807045,66.15488049,36.88841852,3,Besh Kapa Surkh School,Jawzjan,4,Aqchah,1,Besh Kapa Surkh,28,Building,7,4,0,TRUE
+2807046,66.20989235,36.85095912,1,Qara-E-Boyeen School,Jawzjan,2,Aqchah,1,Qara-E-Boyeen,28,Building,7,2,0,TRUE
+2807047,66.27208703,36.84140641,1,Chakosh Sarband School,Jawzjan,2,Aqchah,1,Chakosh Sarband,28,Building,7,2,0,TRUE
+2807048,66.19327879,36.89345453,1,Number 1 Boys High School,Jawzjan,2,Aqchah,1,D02 - Nahia 2,28,Building,7,3,0,TRUE
+2808049,66.45631585,36.82390554,2,Shaheed Latifa Habibi Girls High School,Jawzjan,4,Faizabad,2,Sanseez Village,28,Building,8,4,0,TRUE
+2808050,66.50016999,36.79415891,1,Haidar Abad Boys Secondary School,Jawzjan,2,Faizabad,1,Haidar Abad,28,Building,8,2,0,TRUE
+2808051,66.34071723,36.80739095,2,Kokaldash School,Jawzjan,3,Faizabad,1,Kokaldash Village,28,Building,8,3,0,TRUE
+2808052,66.49247092,36.92369511,2,Bala Mardiyan Boys High School,Jawzjan,3,Faizabad,1,Bala Mardiyan Village,28,Building,8,3,0,TRUE
+2808053,66.38579856,36.82281417,1,Noor Abad Secondary School,Jawzjan,2,Faizabad,1,Noor Abad Village,28,Building,8,2,0,TRUE
+2808054,66.46061417,36.787783,2,Shisha Khana Boys High School,Jawzjan,3,Faizabad,1,Shisha Khana Arabia Village,28,Building,8,3,0,TRUE
+2808055,66.52927959,36.84811135,1,Memleek Secondary School,Jawzjan,2,Faizabad,1,Memleek Village,28,Building,8,2,0,TRUE
+2808056,66.5648053,36.80236166,1,Koshgak Girls High School,Jawzjan,2,Faizabad,1,Koshgak Village,28,Building,8,2,0,TRUE
+2808057,66.50101108,36.77338453,2,Garjak Boys Secondary School,Jawzjan,3,Faizabad,1,Garjak Village,28,Building,8,3,0,TRUE
+2808059,66.41299969,36.86140732,1,Nasrat Abad Secondary School,Jawzjan,2,Faizabad,1,Nasrat Abad Village,28,Building,8,2,0,TRUE
+2808126,66.459936302,36.855724596,2,Char Bagh High School,Jawzjan,3,Faizabad,1,Chahar Bagh,28,Building,8,3,0,TRUE
+2809060,66.3141564,36.99376348,3,Mardiyan High School,Jawzjan,5,Mardyan,2,Mardiyan Village,28,Building,9,5,0,TRUE
+2809061,66.26003749,36.94693523,3,Jangal Areegh Secondary School,Jawzjan,5,Mardyan,2,Jangal Areegh Village,28,Building,9,5,0,TRUE
+2809062,66.32245817,36.94850619,2,Fath Abad School,Jawzjan,4,Mardyan,2,Fath Abad,28,Building,9,4,0,TRUE
+2809063,66.26745896,36.89846106,2,Hindukush Primary School,Jawzjan,3,Mardyan,1,Hindukush,28,Building,9,3,0,TRUE
+2809064,66.35597865,37.02487299,1,Farok Qala Secondary School,Jawzjan,2,Mardyan,1,Farok Qala,28,Building,9,2,0,TRUE
+2809065,66.22461831,36.9569402,1,Alam Lek Secondary School,Jawzjan,2,Mardyan,1,Alam Lek Village,28,Building,9,2,0,TRUE
+2809066,66.23539951,37.0109254,1,Cheleek Ganj Secondary School,Jawzjan,2,Mardyan,1,Cheleek Ganj Village,28,Building,9,2,0,TRUE
+2809067,66.22953097,37.09176554,1,Cheleek Yaz Khan Mosque,Jawzjan,2,Mardyan,1,Cheleek Yaz Khan Village,28,Building,9,2,0,TRUE
+2809068,66.31164861,36.86096946,1,Saltaq School,Jawzjan,2,Mardyan,1,Saltaq Village,28,Building,9,2,0,TRUE
+2810080,66.03388355,37.41319326,6,Makhdoom Qali Faraghi High School,Jawzjan,9,Qarqin,3,Makhdoom Qali Faraghi,28,Building,10,9,0,TRUE
+2810081,66.06893117,37.40445102,3,Joy Sarai Secondary School,Jawzjan,4,Qarqin,1,Joy Sarai,28,Building,10,4,0,TRUE
+2810082,66.192821144,37.345530283,1,Kok Secondary School,Jawzjan,2,Qarqin,1,Shahab Village,28,Building,10,2,0,TRUE
+2810083,65.96081089,37.43089339,3,Dinar High School,Jawzjan,4,Qarqin,1,Dinar,28,Building,10,4,0,TRUE
+2811096,65.38575476,35.97807055,3,Darzaab Boys High School,Jawzjan,4,Darzab,1,District Compound,28,Building,11,4,0,TRUE
+2811097,65.39607937,35.97869227,2,Abu Zar Ghaffari School,Jawzjan,3,Darzab,1,Mafal,28,Building,11,3,0,TRUE
+2811098,65.44780484,35.9597632,2,Imam Bukhari School,Jawzjan,3,Darzab,1,Sardara Village,28,Building,11,3,0,TRUE
+2811099,65.53609168,36.05707882,1,Aaq Bolaq School,Jawzjan,2,Darzab,1,Aaq Bolaq,28,Village,11,2,0,TRUE
+2811100,65.37550769,35.9670085,2,Bito School,Jawzjan,3,Darzab,1,Bito Village,28,Building,11,3,0,TRUE
+2811101,65.36954883,35.98606408,2,Qazl Qashlaq High School,Jawzjan,3,Darzab,1,Onchi Village Darzab,28,Building,11,3,0,TRUE
+2811102,65.48009886,36.02757456,2,Tash Jawaz School,Jawzjan,3,Darzab,1,Tash Jawaz Village,28,Building,11,3,0,TRUE
+2811103,65.30285258,35.98806003,1,Badam Lek,Jawzjan,2,Darzab,1,Badamlek Darzab,28,Building,11,2,0,TRUE
+2811106,65.5214442,36.09054113,1,Aqsaay School,Jawzjan,2,Darzab,1,Aqsaay,28,Village,11,2,0,TRUE
+2811107,65.375782515,35.979389936,1,Turkman Qadoq School,Jawzjan,2,Darzab,1,Darzaab,28,Building,11,2,0,TRUE
+2811108,65.375726994,35.979447638,1,Turkman Qadoq School,Jawzjan,2,Darzab,1,Turkman Qadoq,28,Building,11,2,0,TRUE
+2811109,65.50671434,36.01326304,1,Qara Yaghach Mosque,Jawzjan,2,Darzab,1,Qara Yaghach Village,28,Village,11,2,0,TRUE
+2811127,65.197311755,35.991619553,2,Secondary School,Jawzjan,3,Darzab,1,Peer Ghaib,28,Building,11,3,0,TRUE
+2901001,64.77799058,35.92006552,5,Arab Khana High School,Faryab,8,Maimana,3,D03 - Nahia 3,29,Building,1,9,0,TRUE
+2901002,64.77713004,35.92622433,6,Khurasan High School,Faryab,8,Maimana,2,D04 - Nahia 4,29,Building,1,11,0,TRUE
+2901003,64.76273524,35.90273894,3,Sayad Rajab High School,Faryab,5,Maimana,2,D07 - Nahia 7,29,Building,1,6,0,TRUE
+2901004,64.79011901,35.91599397,0,Afghan Kot Girls High School,Faryab,5,Maimana,5,D02 - Nahia 2,29,Building,1,5,0,TRUE
+2901005,64.74708732,35.92608284,3,Tor Pakhto Boys High School,Faryab,6,Maimana,3,D07 - Nahia 7,29,Building,1,6,0,TRUE
+2901006,64.77920596,35.92360136,0,Sitara High School,Faryab,6,Maimana,6,D04 - Nahia 4,29,Building,1,6,0,TRUE
+2901007,64.78885177,35.91496338,6,Abu Ubaid Jozjani High School,Faryab,6,Maimana,0,D02 - Nahia 2,29,Building,1,7,0,TRUE
+2901008,64.73979583,35.94856963,3,Sar Balaq School,Faryab,5,Maimana,2,D09 - Nahia 9,29,Building,1,5,0,TRUE
+2901009,64.77917882,35.91522957,5,Abu Muslim Khurasani Madrassa,Faryab,5,Maimana,0,D03 - Nahia 3,29,Building,1,5,0,TRUE
+2901010,64.77659554,35.92165726,5,Jarnail Ghawsuddin Secondary School,Faryab,5,Maimana,0,D03 - Nahia 3,29,Building,1,6,0,TRUE
+2901011,64.77830134,35.90946155,0,Pasha Khani Girls School,Faryab,5,Maimana,5,D03 - Nahia 3,29,Building,1,5,0,TRUE
+2901012,64.77425628,35.9249183,0,Aziza Shaheed Number 3 Girls High School,Faryab,5,Maimana,5,D03 - Nahia 3,29,Building,1,6,0,TRUE
+2901013,64.79529736,35.91770368,3,Himmat Abad Boys School,Faryab,6,Maimana,3,D05 - Nahia 5,29,Building,1,6,0,TRUE
+2901014,64.77063459,35.92529673,5,Maimana Agriculture Vocational High School,Faryab,5,Maimana,0,D03 - Nahia 3,29,Building,1,7,0,TRUE
+2901015,64.80351784,35.90736653,3,Deh Sayedan Girls High School,Faryab,5,Maimana,2,D06 - Nahia 6,29,Building,1,5,0,TRUE
+2901016,64.80223396,35.92289977,4,Kohi Khana Maimana Girls High School,Faryab,7,Maimana,3,D01 - Nahia 1,29,Building,1,7,0,TRUE
+2901199,64.784409,35.92692398,3,Veterinary Mudiriyat,Faryab,5,Maimana,2,D04 - Nahia 4,29,Building,1,6,0,TRUE
+2901209,64.789000724,35.914897305,3,Dawlat Keptan Secondary School,Faryab,4,Maimana,1,Qatoor,29,District,1,4,0,TRUE
+2902017,64.65371434,36.10373331,2,Badqaaq School,Faryab,4,Pashtun Kot,2,Badqaaq,29,Village,2,4,0,TRUE
+2902018,64.66497137,36.03524103,3,Khwaja Namosi Boys School,Faryab,3,Pashtun Kot,0,Khwaja Namosi,29,Village,2,3,0,TRUE
+2902019,64.58240788,36.07774103,1,"Meng Darakht, Khwaja Namosi",Faryab,2,Pashtun Kot,1,Khwaja Namosi,29,Village,2,2,0,TRUE
+2902021,64.69247675,36.02271593,1,Gadai Qala Boys School,Faryab,2,Pashtun Kot,1,Gadai Qala,29,Village,2,2,0,TRUE
+2902022,64.66894311,36.17105818,1,Ghar Tapa Bazar And Mosque,Faryab,2,Pashtun Kot,1,Khwaja Namosi,29,Village,2,2,0,TRUE
+2902023,64.654321,36.04493734,0,Khwaja Namosi Girls School,Faryab,3,Pashtun Kot,3,Khwaja Namosi,29,Village,2,3,0,TRUE
+2902024,64.80595251,35.53557283,1,Telaan Mosque,Faryab,2,Pashtun Kot,1,Telaan,29,Village,2,2,0,TRUE
+2902025,64.78396793,35.59819162,1,Sar Hawz Qala Mosque,Faryab,2,Pashtun Kot,1,Sar Hawz,29,Village,2,2,0,TRUE
+2902026,64.90333511,35.69836059,1,Aaqdara Mosque,Faryab,2,Pashtun Kot,1,Aaqdara,29,Village,2,2,0,TRUE
+2902027,64.83484247,35.62631574,1,Yaka Toot Village School,Faryab,2,Pashtun Kot,1,Yaka Toot Village,29,Village,2,2,0,TRUE
+2902028,64.97846193,35.64062794,1,Mir Qasim Madrassa,Faryab,2,Pashtun Kot,1,Mir Qasim Gleem Baft,29,Village,2,2,0,TRUE
+2902029,64.93290691,35.66360644,2,Chehak Gleem Baft Mosque,Faryab,3,Pashtun Kot,1,Chehak Gleem Baft,29,Village,2,3,0,TRUE
+2902030,64.83021521,35.8975732,3,Injelad High School,Faryab,5,Pashtun Kot,2,Injelad,29,Village,2,6,0,TRUE
+2902031,64.85209583,35.86811398,2,Alaika Bala Mosque,Faryab,3,Pashtun Kot,1,Alaika Bala,29,Village,2,3,0,TRUE
+2902032,64.9329794,35.86634112,1,Bocha School,Faryab,2,Pashtun Kot,1,Bocha,29,Village,2,2,0,TRUE
+2902033,64.98581956,35.91835403,2,Hazara Qala Mosque,Faryab,3,Pashtun Kot,1,Hazara Qala,29,Village,2,3,0,TRUE
+2902034,64.761219,35.863748,2,Wali Jan Mosque,Faryab,3,Pashtun Kot,1,Wali Jan,29,Village,2,3,0,TRUE
+2902035,65.09922394,35.90640316,2,Omomi Zarshoy Mosque,Faryab,4,Pashtun Kot,2,Zar Shoy,29,Village,2,4,0,TRUE
+2902036,65.06589819,35.87509069,1,Chaqmaq Mosque,Faryab,2,Pashtun Kot,1,Chaqmaq,29,Village,2,2,0,TRUE
+2902037,64.67484055,36.03475638,3,Kata Qala High School,Faryab,4,Pashtun Kot,1,Kata Qala,29,Village,2,4,0,TRUE
+2902038,65.13858719,35.95526629,1,Tirak Lek Mosque,Faryab,2,Pashtun Kot,1,Tirak Lek,29,Village,2,2,0,TRUE
+2902039,64.80857297,35.74357546,2,Burhan Bay Mosque,Faryab,3,Pashtun Kot,1,Chekab Village,29,Village,2,3,0,TRUE
+2902040,64.82441,35.77905626,2,Awraz Bala Pogani Mosque,Faryab,3,Pashtun Kot,1,Awraz Bala Pogani,29,Village,2,3,0,TRUE
+2902041,64.74712046,35.8712354,1,Pasha Khan Mosque,Faryab,2,Pashtun Kot,1,Pasha Khan,29,Village,2,2,0,TRUE
+2902042,64.81228672,35.72541918,1,Bato Jan Mosque,Faryab,2,Pashtun Kot,1,Bato Jan,29,Village,2,2,0,TRUE
+2902043,64.62817179,35.82511105,1,Gardai Mareshkar Mosque,Faryab,2,Pashtun Kot,1,Gardai Mareshkar,29,Village,2,2,0,TRUE
+2902044,64.69984285,35.76956508,1,Taklai Hazar Sam Mosque,Faryab,2,Pashtun Kot,1,Taklai Hazar Sam,29,Village,2,2,0,TRUE
+2902045,64.67728527,35.81991917,1,Moqani Mosque,Faryab,2,Pashtun Kot,1,Moqani,29,Village,2,2,0,TRUE
+2902046,64.72278463,35.83122935,2,Sarkhab Gul Qadoq School,Faryab,3,Pashtun Kot,1,Sarkhab Gul Qadoq,29,Village,2,3,0,TRUE
+2902048,64.65290167,35.63135288,1,Halwa Khor Bala Mosque,Faryab,2,Pashtun Kot,1,Halwa Khor Bala,29,Village,2,2,0,TRUE
+2902049,64.64524039,35.9108674,1,Arab Aqsai Boys Secondary School,Faryab,2,Pashtun Kot,1,Arab Aqsai,29,Village,2,3,0,TRUE
+2902051,64.82447954,35.88823922,3,Jamshidi Secondary School,Faryab,5,Pashtun Kot,2,Jamshidi,29,Village,2,5,0,TRUE
+2902052,64.86724037,35.83350382,2,Dahendara School,Faryab,3,Pashtun Kot,1,Dahendra,29,Village,2,3,0,TRUE
+2902053,64.91973131,35.72496989,1,Qala-E-Niyaz Beg School,Faryab,2,Pashtun Kot,1,Qala-E-Niyaz Beg,29,Village,2,2,0,TRUE
+2902200,64.97507755,35.67548275,1,Dahendara Gleem Baft Mosque,Faryab,2,Pashtun Kot,1,Dahendra Gleem Baft,29,Village,2,2,0,TRUE
+2902201,64.68608003,36.01063214,1,Jar Qala Khwaja Musa Mosque,Faryab,2,Pashtun Kot,1,Khwaja Musa,29,Village,2,2,0,TRUE
+2902202,64.65976127,35.84077368,1,Arab Kawan Bashi Mosque,Faryab,2,Pashtun Kot,1,Arab Kawan Bashi,29,Village,2,2,0,TRUE
+2903054,64.8600449,36.04477305,3,Ghazari Girls High School,Faryab,6,Khwaja Sabz Posh-E-Wali,3,Ghazari Village,29,Building,3,8,0,TRUE
+2903055,64.89471381,35.99876001,2,Khwaja Qashori,Faryab,3,Khwaja Sabz Posh-E-Wali,1,Khwaja Qashori,29,Building,3,3,0,TRUE
+2903056,64.89381347,35.97181868,2,Shabakhto Girls School,Faryab,3,Khwaja Sabz Posh-E-Wali,1,Shabakhto,29,Building,3,3,0,TRUE
+2903057,64.97654448,36.03816002,2,Bolak Bacha Solidarity Council Building,Faryab,3,Khwaja Sabz Posh-E-Wali,1,Bolak Bacha,29,Building,3,3,0,TRUE
+2903058,64.8409815,36.07255767,2,Deh Naw Boys High School,Faryab,4,Khwaja Sabz Posh-E-Wali,2,Deh Naw,29,Building,3,5,0,TRUE
+2903059,64.84271403,36.10196005,3,Sahrayee Qala Boys Secondary School,Faryab,5,Khwaja Sabz Posh-E-Wali,2,Sahrayee Qala,29,Building,3,7,0,TRUE
+2903060,64.87462966,36.14620388,3,Qara-E-Shekhi Girls High School,Faryab,4,Khwaja Sabz Posh-E-Wali,1,Qara-E-Shekhi,29,Building,3,4,0,TRUE
+2903061,64.8747361,36.02986334,2,Samleek Pogani Solidarity Council Building,Faryab,4,Khwaja Sabz Posh-E-Wali,2,Samleek Pogani,29,Building,3,4,0,TRUE
+2903062,64.8487503,36.04318238,1,Badghisi Girls High School,Faryab,3,Khwaja Sabz Posh-E-Wali,2,Badghisi,29,Building,3,3,0,TRUE
+2903210,64.86351618,36.089203552,2,Yangi Qala Mosque,Faryab,3,Khwaja Sabz Posh-E-Wali,1,Yangi Qala,29,Building,3,4,0,TRUE
+2903211,64.871341562,36.022267296,2,Qezl Qshlaq Male School,Faryab,3,Khwaja Sabz Posh-E-Wali,1,Qezel Qeshlaq,29,Building,3,3,0,TRUE
+2904063,64.53369048,35.84736317,4,Almaar Boys High School,Faryab,7,Almar,3,Bazar Almaar,29,Building,4,7,0,TRUE
+2904064,64.50729834,35.81193135,2,Qara-E-Ghoyeli Mosque,Faryab,4,Almar,2,Qara-E-Ghoyeli Village,29,Building,4,0,4,FALSE
+2904065,64.5833181,35.88236367,2,Chaghatak Mosque,Faryab,4,Almar,2,Chaghatak,29,Building,4,5,0,TRUE
+2904066,64.53605587,35.7867354,2,Aiti Oroq Mosque,Faryab,3,Almar,1,Aiti Oroq,29,Building,4,3,0,TRUE
+2904067,64.50651194,35.85683636,2,Haji Sayeed Ahmad Mosque,Faryab,3,Almar,1,Bukhar Qala,29,Building,4,4,0,TRUE
+2904068,64.49378559,35.91432568,2,Badghisi Mosque,Faryab,3,Almar,1,Badghisi,29,Building,4,0,3,FALSE
+2904069,64.28125252,35.92014618,2,Khwaja Gawhar,Faryab,4,Almar,2,Khwaja Gawhar Village,29,Village,4,0,4,FALSE
+2904070,64.55492753,35.86823931,2,Khudaimat Village Mosque,Faryab,3,Almar,1,Khudaimat Village,29,Building,4,3,0,TRUE
+2904071,64.44500433,35.99449687,2,Ghalbala,Faryab,3,Almar,1,Ghalbala Village,29,Village,4,0,3,FALSE
+2904073,64.56910709,35.5638859,2,Qarayee Secondary School,Faryab,3,Almar,1,Qarayee,29,Building,4,3,0,TRUE
+2904074,64.61141655,35.57313659,2,Khwaja Baghcha Secondary School,Faryab,3,Almar,1,Khwaja Baghcha,29,Building,4,3,0,TRUE
+2904075,64.55488918,35.82242548,2,Akhond Baba Primary School,Faryab,3,Almar,1,Akhond Baba,29,Building,4,3,0,TRUE
+2904076,64.59870451,35.57594462,2,Khosh Bayee Primary School,Faryab,3,Almar,1,Khosh Bayee,29,Building,4,3,0,TRUE
+2904077,64.54981095,35.59080497,1,Aaq Masjid Primary School,Faryab,2,Almar,1,Aaq Masjid,29,Building,4,2,0,TRUE
+2904079,64.37875651,35.89945905,1,Hotaki Mosque,Faryab,2,Almar,1,Hotaki Village,29,Village,4,0,2,FALSE
+2905136,65.26823016,35.94800533,3,Kamrak Aaq Balaq Mosque,Faryab,5,Bil Chiragh,2,Kamrak Aaq Balaq,29,Village,5,5,0,TRUE
+2905137,65.16948079,35.89958892,3,Neshar Primary School,Faryab,4,Bil Chiragh,1,Neshar,29,Village,5,4,0,TRUE
+2905138,65.23171608,35.84318914,3,Balcheragh Madrassa,Faryab,5,Bil Chiragh,2,Balcheragh,29,Village,5,5,0,TRUE
+2905139,65.51587708,35.89682909,2,Tash Qala Boys School,Faryab,4,Bil Chiragh,2,Tash Qala,29,Village,5,4,0,TRUE
+2905140,65.59041327,35.90671455,3,Qorchi Secondary School,Faryab,5,Bil Chiragh,2,Qorchi,29,Village,5,5,0,TRUE
+2905141,65.40420365,35.88560058,3,Koliyan Girls School,Faryab,4,Bil Chiragh,1,Kolyan,29,Village,5,4,0,TRUE
+2905142,65.29107217,35.8569044,3,Taghalmas Boys School,Faryab,4,Bil Chiragh,1,Taghlamas,29,Village,5,4,0,TRUE
+2905143,65.52694338,35.96046123,2,Qorgh Khwaja Arab Mosque,Faryab,4,Bil Chiragh,2,Khwaja Arab Village,29,Village,5,4,0,TRUE
+2905207,65.19112297,35.94317189,2,Qerma Mosque,Faryab,3,Bil Chiragh,1,Qerma,29,Village,5,3,0,TRUE
+2906145,65.08153978,36.13588162,3,Gul Qadoq Boys School,Faryab,4,Shirin Tagab,1,Gul Qadoq,29,Building,6,4,0,TRUE
+2906146,64.85555871,36.25708984,2,Tapa Qala Mosque,Faryab,3,Shirin Tagab,1,Tapa Qala,29,Building,6,4,0,TRUE
+2906147,64.8739375,36.18750664,2,Gulzar Mosque,Faryab,3,Shirin Tagab,1,Gulzar Village,29,Building,6,3,0,TRUE
+2906148,64.86951215,36.24887404,3,Tash Qala Mosque,Faryab,4,Shirin Tagab,1,Tash Qala,29,Building,6,5,0,TRUE
+2906149,64.86398995,36.22613555,3,Islam Qala Boys School,Faryab,5,Shirin Tagab,2,Islam Qala,29,Building,6,6,0,TRUE
+2906150,64.95063004,36.15539727,3,Mahd School,Faryab,5,Shirin Tagab,2,Mahd Village,29,Building,6,5,0,TRUE
+2906151,65.09317458,36.25617174,2,Sardaba Boys Secondary School,Faryab,4,Shirin Tagab,2,Sardaba,29,Building,6,4,0,TRUE
+2906152,64.88288116,36.28124757,2,Baloch Girls High School,Faryab,4,Shirin Tagab,2,Torkol Baloch Village,29,Village,6,4,0,TRUE
+2906153,64.8585293,36.26491765,3,Koh Sayad Girls High School,Faryab,5,Shirin Tagab,2,Koh Sayad Village,29,Village,6,6,0,TRUE
+2906154,64.95232285,36.31211014,1,Shah Yousuf Boys Secondary School,Faryab,2,Shirin Tagab,1,Shah Yousuf,29,Village,6,2,0,TRUE
+2906155,64.87232578,36.29248254,2,Shamsuddin Shaheed High School,Faryab,4,Shirin Tagab,2,Faiz Abad,29,Village,6,6,0,TRUE
+2906156,64.85753478,36.26442995,2,Koh Sayad Mosque,Faryab,4,Shirin Tagab,2,Koh Sayad Village,29,Village,6,4,0,TRUE
+2906157,65.01225278,36.19097634,1,Qarghaqol Mosque,Faryab,2,Shirin Tagab,1,Qarghaqol Village,29,Village,6,2,0,TRUE
+2906208,65.01539425,36.10979108,2,Kalta Shor Mosque,Faryab,3,Shirin Tagab,1,Kalta Shor,29,Village,6,3,0,TRUE
+2907080,64.01873653,35.74828017,2,Khwaja Aspalan Mosque,Faryab,5,Qaisar,3,Chehlgazai Village,29,Village,7,0,5,FALSE
+2907081,64.02153273,35.74163197,4,Hazara Qala Chehlgazai Boys Primary School,Faryab,7,Qaisar,3,Hazara Qala,29,Building,7,7,0,TRUE
+2907082,64.09965933,35.72749714,2,Chechakto Primary School,Faryab,4,Qaisar,2,Chechakto,29,Building,7,4,0,TRUE
+2907083,64.0447562,35.67678466,2,Boland Ghor Mosque,Faryab,3,Qaisar,1,Boland Ghor,29,Building,7,3,0,TRUE
+2907084,63.96498163,35.72567221,2,Bashalmast Mosque,Faryab,3,Qaisar,1,Bashlmast,29,Building,7,3,0,TRUE
+2907085,64.02247286,35.74635888,2,Maato Mosque,Faryab,3,Qaisar,1,Chehl Gazai,29,Village,7,0,3,FALSE
+2907086,64.11842269,35.60436739,2,Shakh Mosque,Faryab,4,Qaisar,2,Bazar Kuhna Shakh,29,Building,7,4,0,TRUE
+2907088,64.03049822,35.68626537,1,Waimas School,Faryab,2,Qaisar,1,Waymas Village,29,Building,7,2,0,TRUE
+2907089,64.09299695,35.65281033,2,Yaka Bagh School,Faryab,3,Qaisar,1,Yaka Bagh,29,Building,7,3,0,TRUE
+2907090,64.23664046,35.73856738,2,Beraka Mosque,Faryab,4,Qaisar,2,Beraka,29,Building,7,4,0,TRUE
+2907091,64.28192101,35.78450669,2,Jegdalek Mosque,Faryab,3,Qaisar,1,Jegdalek Village,29,Building,7,0,3,FALSE
+2907092,64.33667387,35.72918073,1,Sawr Mosque,Faryab,2,Qaisar,1,Sawr,29,Building,7,2,0,TRUE
+2907093,64.38232478,35.79584381,1,Khwaja Tabjaq School,Faryab,2,Qaisar,1,Khwaja Tabjaq,29,Building,7,2,0,TRUE
+2907094,64.52429638,35.73668882,2,Aiti Saleeq School,Faryab,4,Qaisar,2,Aiti Saleeq,29,Building,7,4,0,TRUE
+2907095,63.910347,35.76245604,1,Karez Mosque,Faryab,2,Qaisar,1,Chehl Gazai,29,Building,7,0,2,FALSE
+2907096,63.98580072,35.75095501,1,Chaharshanba Uzbekya Mosque,Faryab,2,Qaisar,1,Chaharshanba Uzbekya Village,29,Building,7,2,0,TRUE
+2907099,63.83238126,35.74739416,1,Sar Takht Mosque,Faryab,2,Qaisar,1,Sar Takht,29,Building,7,0,2,FALSE
+2907100,64.26213791,35.6772484,2,Bori Boys Secondary School,Faryab,3,Qaisar,1,Bori,29,Building,7,3,0,TRUE
+2907101,64.2438173,35.69913375,1,Sufi Qala Boys School,Faryab,2,Qaisar,1,Sufi Qala,29,Building,7,4,0,TRUE
+2907102,64.35044185,35.65963422,1,Khwaja Hai Borghan Mosque,Faryab,3,Qaisar,2,Khwaja Hai Borghan,29,Building,7,5,0,TRUE
+2907103,64.38863063,35.61264825,2,Sayad Borghan Mosque,Faryab,3,Qaisar,1,Sayad Borghan,29,Building,7,3,0,TRUE
+2907104,64.2934343,35.68940725,3,Naadim Qaisari High School,Faryab,5,Qaisar,2,District Compound,29,Building,7,6,0,TRUE
+2907105,64.24758961,35.61560425,2,Zaafran School,Faryab,3,Qaisar,1,Zaafran,29,Building,7,3,0,TRUE
+2907106,64.30550956,35.59697223,2,Chakna Yozbegi School,Faryab,3,Qaisar,1,Yuzbegi,29,Building,7,3,0,TRUE
+2907107,64.16132919,35.59007472,2,Ghora Mosque,Faryab,3,Qaisar,1,Ghora,29,Building,7,3,0,TRUE
+2907109,64.53667042,35.67212603,2,Sayad Naqi Mosque,Faryab,3,Qaisar,1,Sayad Naqi,29,Building,7,3,0,TRUE
+2907110,64.15662982,35.72003963,2,Zori Ha Primary School,Faryab,3,Qaisar,1,Zori Ha,29,Building,7,0,3,FALSE
+2907111,64.3104714,35.70111522,2,Kohi School,Faryab,3,Qaisar,1,Kohi,29,Building,7,4,0,TRUE
+2907203,64.24116491,35.72702493,1,Yaka Pasta Afghania Mosque,Faryab,2,Qaisar,1,Yaka Pasta Afghania,29,Building,7,2,0,TRUE
+2907204,64.05980469,35.67851321,1,Khatayee Mosque,Faryab,2,Qaisar,1,Khatayee Village,29,Building,7,2,0,TRUE
+2908123,65.35578278,35.73536973,2,Gholbayan Mosque,Faryab,5,Gurziwan,3,Gholbiyan,29,Building,8,5,0,TRUE
+2908124,65.29475637,35.75271612,3,Deh Miran Boys High School,Faryab,5,Gurziwan,2,Deh Miran Village,29,Building,8,5,0,TRUE
+2908125,65.35543118,35.73428903,2,Gholbiyan Girls Secondary School,Faryab,5,Gurziwan,3,Gholbiyan Village,29,Building,8,5,0,TRUE
+2908126,65.33273774,35.70499036,2,Takhara Mosque,Faryab,4,Gurziwan,2,Takhara Village,29,Building,8,4,0,TRUE
+2908127,65.28086281,35.63678932,3,Dara-E-Zang Madrassa,Faryab,5,Gurziwan,2,Dara-E-Zang,29,Building,8,5,0,TRUE
+2908128,65.20373789,35.70794478,3,Dong Qala Girls High School,Faryab,5,Gurziwan,2,Dong Qala,29,Building,8,5,0,TRUE
+2908129,65.22545202,35.6256331,3,Dara-E-Shakh Girls School,Faryab,4,Gurziwan,1,Dara-E-Shakh,29,Building,8,4,0,TRUE
+2908130,65.22254095,35.71294251,2,Sarchakan Mosque,Faryab,4,Gurziwan,2,Sarchakan,29,Building,8,4,0,TRUE
+2908131,65.14148849,35.68213872,3,Gawaki Madrassa,Faryab,4,Gurziwan,1,Gawaki Village,29,Building,8,4,0,TRUE
+2908132,65.16467974,35.69363872,2,Jar Qala High School,Faryab,4,Gurziwan,2,Jar Qala,29,Building,8,4,0,TRUE
+2908133,65.13935272,35.67237525,2,Tagab Shan Madrassa,Faryab,4,Gurziwan,2,Tagab Shan,29,Building,8,4,0,TRUE
+2908134,65.08212451,35.6397983,1,Faresh Mosque,Faryab,3,Gurziwan,2,Faresh Village,29,Building,8,0,3,FALSE
+2908135,65.0790376,35.59361105,1,Mullah Ghulam Sakhi Dahandara House,Faryab,3,Gurziwan,2,Dahendra Village,29,Building,8,3,0,TRUE
+2908206,65.16487513,35.5334226,1,Badgah Mosque,Faryab,3,Gurziwan,2,Badgah Village,29,Building,8,3,0,TRUE
+2908212,65.260903405,35.723481607,2,Qala Tardi Female Primary School,Faryab,3,Gurziwan,1,Qala Tori,29,Building,8,3,0,TRUE
+2908213,65.276755787,35.678313952,2,Pakhal Soz Female School,Faryab,3,Gurziwan,1,Pakhlsoz,29,Building,8,2,1,TRUE
+2909158,64.88473039,36.41997614,3,Qozi Bay Qala Girls High School,Faryab,5,Dawlat Abad,2,Bay Qala Qozi,29,Building,9,5,0,TRUE
+2909159,64.90297028,36.36500584,2,Jar Qala School,Faryab,4,Dawlat Abad,2,Kokcha Qala,29,Building,9,4,0,TRUE
+2909160,64.88749001,36.37102269,2,Bazar Qala Mosque,Faryab,3,Dawlat Abad,1,Bazar Qala,29,Building,9,3,0,TRUE
+2909162,64.91360899,36.37409887,3,Topkhana Qala Girls School,Faryab,5,Dawlat Abad,2,Topkhana Qala,29,Building,9,5,0,TRUE
+2909163,64.91963509,36.43567041,3,Quraish Girls Secondary School,Faryab,4,Dawlat Abad,1,Quraish,29,Building,9,4,0,TRUE
+2909164,64.8968979,36.46464321,3,Char Shangho Secondary School,Faryab,4,Dawlat Abad,1,Char Shangho,29,Building,9,4,0,TRUE
+2909165,64.93543327,36.39175783,3,Khair Abad Primar School,Faryab,4,Dawlat Abad,1,Khair Abad,29,Building,9,4,0,TRUE
+2909166,64.91543677,36.5049397,3,Takht Palordi Primar School,Faryab,4,Dawlat Abad,1,Takht Plordi,29,Building,9,1,3,TRUE
+2909167,64.89451373,36.56076805,4,Pata Baba,Faryab,6,Dawlat Abad,2,Pata Baba Village,29,Village,9,0,6,FALSE
+2909168,64.90396288,36.33493803,2,Joq Ha Mosque,Faryab,3,Dawlat Abad,1,Joq Ha,29,Building,9,3,0,TRUE
+2910112,64.57910332,35.34949043,3,Bandar Primary School,Faryab,5,Kohistan,2,Bandar Kohistan,29,Building,10,0,5,FALSE
+2910113,64.5506633,35.26307313,1,Bar Ghar Mosque,Faryab,2,Kohistan,1,Ze Murad Village,29,Building,10,2,0,TRUE
+2910114,64.56117561,35.35334459,2,Dahendara School,Faryab,3,Kohistan,1,Dahendara,29,Building,10,0,3,FALSE
+2910115,64.63585132,35.16948038,1,Tandorak Mosque,Faryab,3,Kohistan,2,Tandorak,29,Building,10,3,0,TRUE
+2910116,64.4361626,35.33051935,1,Dasht Sahrayee Malghi Mosque,Faryab,2,Kohistan,1,Dasht Sahray Malghi,29,Village,10,0,2,FALSE
+2910117,65.26107731,35.39420904,1,Baam Surkh Mosque,Faryab,2,Kohistan,1,Baam Surkh,29,Building,10,2,0,TRUE
+2910118,65.02068942,35.44423547,1,Khwaja Hashtumeen Mosque,Faryab,2,Kohistan,1,Hashtumeen Village,29,Building,10,0,2,FALSE
+2910119,64.89247127,35.4150131,2,Gorzan Mosque,Faryab,4,Kohistan,2,Gorzan,29,Building,10,0,4,FALSE
+2910120,64.75356629,35.38386318,2,Lolash Secondary School,Faryab,4,Kohistan,2,Dor Qala,29,Building,10,4,0,TRUE
+2910121,64.73990738,35.34094386,2,Qadoghak School,Faryab,3,Kohistan,1,Qadoghak,29,Building,10,3,0,TRUE
+2910122,64.59364213,35.22983163,2,Takhta Band Lafra Mosque,Faryab,3,Kohistan,1,Takhta Band Lafra,29,Building,10,2,1,TRUE
+2910205,64.73557591,35.35517358,1,Ulyand Bandar Mosque,Faryab,2,Kohistan,1,Ulyan Bandar Village,29,Building,10,2,0,TRUE
+2910214,65.3564799,35.386369879,2,Mosque,Faryab,3,Kohistan,1,Pusht Darwaza,29,Building,10,3,0,TRUE
+2910215,65.241033911,35.305476106,2,Mosque,Faryab,3,Kohistan,1,Diwarak,29,Village,10,3,0,TRUE
+2911170,65.08320934,36.86448903,3,Qaramqol Boys High School,Faryab,4,Qaram Qul,1,Aalti Bolak Wasati Village,29,Building,11,4,0,TRUE
+2911171,65.0631623,36.86395387,2,Qaramqol District Building,Faryab,4,Qaram Qul,2,Markaz Qaramqol,29,Building,11,4,0,TRUE
+2911172,65.03144675,36.82419242,1,Sarband Secondary School,Faryab,2,Qaram Qul,1,Sarband,29,Village,11,2,0,TRUE
+2911173,65.13707114,36.83874903,2,Yousuf Mir Zayee Girls School,Faryab,4,Qaram Qul,2,Yousuf Mir Zayee,29,Building,11,4,0,TRUE
+2911174,65.08165429,36.85367332,2,Aalti Bolak Girls School,Faryab,4,Qaram Qul,2,Aalti Bolak,29,Building,11,4,0,TRUE
+2911216,64.97777472,36.791177819,2,Qepchaq Secondary School,Faryab,3,Qaram Qul,1,Qep Chap,29,District,11,3,0,TRUE
+2912190,65.09043593,36.91933932,3,Mohmmad Kawal Shaheed High School,Faryab,5,Qurghan,2,Qarghan,29,Building,12,5,0,TRUE
+2912191,65.05681037,36.98639604,1,Yaka Toot Secondary School,Faryab,2,Qurghan,1,Yaka Toot,29,Building,12,2,0,TRUE
+2912192,65.07228939,36.95829396,1,Khalifa Abdullah Mosque,Faryab,2,Qurghan,1,Bagh Bostan Payan,29,Building,12,2,0,TRUE
+2912193,65.0695866,36.91712742,2,Kuhna Qarghan Primary School,Faryab,3,Qurghan,1,Qarghan,29,Building,12,3,0,TRUE
+2912194,65.09946847,36.95328625,1,Yousuf Andkhoy High School,Faryab,3,Qurghan,2,Namazgah Kagar,29,Building,12,3,0,TRUE
+2912195,65.09404014,36.8955633,3,Mir Abad Boys High School,Faryab,5,Qurghan,2,Mir Abad,29,Building,12,5,0,TRUE
+2912196,65.08191845,36.87617979,2,Haji Laar Mosque,Faryab,3,Qurghan,1,Mir Abad,29,Building,12,3,0,TRUE
+2912197,65.09063505,36.93361912,2,Aaq Mosque,Faryab,4,Qurghan,2,Bagh Bostan,29,Village,12,4,0,TRUE
+2912198,65.09308753,36.91906982,2,Bagh Bostan High School,Faryab,4,Qurghan,2,Qarghan,29,Building,12,4,0,TRUE
+2913181,65.12328586,36.94528897,4,Yoldoz Girls High School,Faryab,7,Andkhoy,3,Shahr-E-Naw,29,Building,13,7,0,TRUE
+2913182,65.12386848,36.95284622,2,Abu Muslim High School,Faryab,5,Andkhoy,3,Bazar Andkhoy,29,Building,13,6,0,TRUE
+2913183,65.11217209,36.90594371,3,Yangee Tigarman Girls High School,Faryab,6,Andkhoy,3,Yangee Tigarman,29,Building,13,6,0,TRUE
+2913184,65.11979732,36.96312758,3,Alhendi Khana Girls School,Faryab,5,Andkhoy,2,Alhendi Khana,29,Village,13,5,0,TRUE
+2913185,65.11577455,36.95606823,3,Qazi Baba Murad High School,Faryab,5,Andkhoy,2,Kulal Khana,29,Building,13,5,0,TRUE
+2913186,65.14060093,36.95120761,3,Dawlat Geldi High School,Faryab,5,Andkhoy,2,Shahr-E-Naw,29,Building,13,5,0,TRUE
+2913187,65.13696707,36.93036091,3,Tawachi Girls High School,Faryab,5,Andkhoy,2,Tawachi,29,Building,13,5,0,TRUE
+2913188,65.11688653,36.95692677,3,Kulal Khana Girls High School,Faryab,5,Andkhoy,2,Kulal Khana,29,Building,13,5,0,TRUE
+2913189,65.12089832,36.90420687,3,Rahmatullah Shaheed Secondary School,Faryab,5,Andkhoy,2,Akhta Chi Payan,29,Building,13,5,0,TRUE
+2914175,65.22079238,37.00214166,4,Khan Chahar Bagh Boys High School,Faryab,6,Khani Charbagh,2,Khan Chaharbagh,29,Building,14,6,0,TRUE
+2914176,65.17775312,36.98423599,3,Rahman Qol Shaheed High School,Faryab,4,Khani Charbagh,1,Arab Shah Tora Khan,29,Building,14,4,0,TRUE
+2914177,65.2131962,36.94933794,3,Chakman High School,Faryab,4,Khani Charbagh,1,Chakman,29,Building,14,4,0,TRUE
+2914178,65.14938806,36.98255483,3,Aaq Mosque,Faryab,4,Khani Charbagh,1,Kuhna Qala,29,Building,14,7,0,TRUE
+2914179,65.15128066,36.96060735,1,Arab Shah Bala Mukhtalat Primary School,Faryab,2,Khani Charbagh,1,Arab Shah Bala,29,Building,14,2,0,TRUE
+2914180,65.16170332,36.99048597,1,Arab Shah Payeen Girls High School,Faryab,2,Khani Charbagh,1,Arab Shah Payeen,29,Building,14,2,0,TRUE
+3001001,64.46979044,31.61208738,3,Haji Tawos Mosque,Helmand,5,Lashkargah,2,Sarkaar,30,Village,1,5,0,TRUE
+3001002,64.36087325,31.58292566,5,Lashkargah Cinema,Helmand,5,Lashkargah,0,D02 - Nahia 2,30,Building,1,5,0,TRUE
+3001003,64.36555628,31.58645269,0,Girls High School,Helmand,6,Lashkargah,6,D02 - Nahia 2,30,Building,1,6,0,TRUE
+3001004,64.36560981,31.58533434,6,Boys Secondary School,Helmand,6,Lashkargah,0,D02 - Nahia 2,30,Building,1,6,0,TRUE
+3001005,64.36500611,31.58421339,7,Boys High School,Helmand,7,Lashkargah,0,D02 - Nahia 2,30,Building,1,7,0,TRUE
+3001006,64.35624179,31.62303349,0,Hashim Khan Mosque,Helmand,5,Lashkargah,5,Lashkar Bazar Shamal Village,30,Building,1,5,0,TRUE
+3001007,64.41074655,31.58991077,6,Lashkar Bazar Sharqi Primary School,Helmand,6,Lashkargah,0,Lashkar Bazar Sharqi,30,Village,1,6,0,TRUE
+3001008,64.37700007,31.59892591,3,Malalai High School,Helmand,5,Lashkargah,2,Karta-E-Lagan Nahia 2,30,Building,1,6,0,TRUE
+3001010,64.37544581,31.59188774,8,Karta-E-Lagan High School,Helmand,8,Lashkargah,0,Karta-E-Lagan Nahia 2,30,Building,1,8,0,TRUE
+3001011,64.38353023,31.5952492,2,Hindwano School,Helmand,8,Lashkargah,6,Karta-E-Lagan Nahia 2,30,Building,1,8,0,TRUE
+3001012,64.37508093,31.60734659,5,Numarat C1 School,Helmand,5,Lashkargah,0,C1 Numarat,30,Building,1,5,0,TRUE
+3001013,64.36132045,31.59794416,9,Tor Tank Boys School,Helmand,10,Lashkargah,1,Tor Tank,30,Building,1,10,0,TRUE
+3001014,64.36239023,31.5983275,0,Tor Tank Girls School,Helmand,6,Lashkargah,6,Tor Tank,30,Building,1,6,0,TRUE
+3001015,64.35386127,31.5725259,4,Kala Kuhna Boys School,Helmand,8,Lashkargah,4,Kala Kuhna,30,Building,1,10,0,TRUE
+3001016,64.37751059,31.57951682,4,Kharoto Mosque,Helmand,7,Lashkargah,3,Safiyan,30,Building,1,7,0,TRUE
+3001017,64.35808303,31.5316039,4,Nek Mohammad Private House,Helmand,5,Lashkargah,1,Loy Karez,30,Building,1,5,0,TRUE
+3001018,64.35897241,31.54488931,0,Mira Jaan Private House,Helmand,5,Lashkargah,5,Karez,30,Building,1,5,0,TRUE
+3001019,64.3673263,31.50202868,5,Haji Kareem Dad Village School,Helmand,5,Lashkargah,0,Haji Kareem Dad Village,30,Building,1,5,0,TRUE
+3001020,64.36082777,31.49057222,3,Mohammad Ibrahim Private House,Helmand,6,Lashkargah,3,Qala-E-Bost,30,Building,1,6,0,TRUE
+3001021,64.37726162,31.47142406,4,Sayed Nabi Private House,Helmand,6,Lashkargah,2,Qala-E-Bost,30,Building,1,6,0,TRUE
+3001022,64.32911487,31.57508091,5,Farm Tameer Bolan,Helmand,8,Lashkargah,3,Farm Building Bolan,30,Building,1,8,0,TRUE
+3001024,64.3242793,31.59989054,3,Bolan Kala School,Helmand,5,Lashkargah,2,Bolan Kala,30,Building,1,5,0,TRUE
+3001025,64.3283326,31.65605412,3,Bushran School,Helmand,5,Lashkargah,2,Bushran Village,30,Building,1,5,0,TRUE
+3001026,64.35548614,31.67251732,2,Sayedano School Babaji,Helmand,4,Lashkargah,2,Sayedano Village,30,Building,1,4,0,TRUE
+3001027,64.33441815,31.66683361,2,Zor School Babaji,Helmand,4,Lashkargah,2,Dolizo Village,30,Building,1,4,0,TRUE
+3001028,64.385827,31.71294678,2,Ibrahim Khan Private House,Helmand,4,Lashkargah,2,Babaji,30,Building,1,4,0,TRUE
+3001029,64.41792956,31.72487052,2,Korghojat School Babaji,Helmand,4,Lashkargah,2,Raheemkhelo Village,30,Building,1,4,0,TRUE
+3001030,64.35756952,31.63788901,3,Khan Mohammad Mosque,Helmand,6,Lashkargah,3,Muhajereeno Camp,30,Building,1,6,0,TRUE
+3001031,64.36564816,31.64147399,4,Haji Abdullah Mosque,Helmand,7,Lashkargah,3,Muhajereeno Village,30,Building,1,7,0,TRUE
+3001033,64.40595542,31.68591587,2,Kochi Center Mosque,Helmand,4,Lashkargah,2,Punjab Village,30,Building,1,4,0,TRUE
+3002062,64.31818332,31.72661414,7,Dahna 31 Gharbi Primary School,Helmand,7,Nad Ali,0,Dahna 31 Gharbi,30,Village,2,7,0,TRUE
+3002065,64.27105755,31.6954167,4,Naqil Abad School,Helmand,4,Nad Ali,0,Naqil Abad,30,Village,2,4,0,TRUE
+3002066,64.23829517,31.64038277,3,Nad Ali District Clinic,Helmand,4,Nad Ali,1,District Compound,30,Building,2,4,0,TRUE
+3002067,64.23841822,31.64437885,4,Central High School,Helmand,8,Nad Ali,4,District Compound,30,Building,2,8,0,TRUE
+3002068,63.90230227,31.79664078,4,Primary School,Helmand,4,Nad Ali,0,Loy Maanda,30,Village,2,4,0,TRUE
+3002069,64.23800793,31.64478338,3,District Center School,Helmand,4,Nad Ali,1,District Compound,30,Village,2,4,0,TRUE
+3002070,64.26293447,31.6301187,3,Loy Bagh School,Helmand,4,Nad Ali,1,Loy Bagh,30,Building,2,4,0,TRUE
+3002071,64.31261712,31.68146524,2,Chah Enjeer High School,Helmand,4,Nad Ali,2,Chah Enjeer,30,Building,2,4,0,TRUE
+3002078,64.26023752,31.65434484,3,Zarghoon Village School,Helmand,8,Nad Ali,5,Zarghoon Village,30,Village,2,8,0,TRUE
+3002079,64.22718006,31.64143061,2,Sayed Abad School,Helmand,4,Nad Ali,2,Sayed Abad,30,Village,2,4,0,TRUE
+3002080,64.21993969,31.64180542,3,Sheen Village School,Helmand,4,Nad Ali,1,Sheen Village,30,Building,2,4,0,TRUE
+3002081,64.12606307,31.71616869,3,Noor Mohammad Village School,Helmand,4,Nad Ali,1,Jonobi Ja Enjeer Maktab,30,Village,2,4,0,TRUE
+3002084,64.23489396,31.6787835,4,Chah Mirza Mosque,Helmand,4,Nad Ali,0,Chah Mirza,30,Village,2,4,0,TRUE
+3002223,64.306228446,31.673991265,2,Cha Anjeer,Helmand,3,Nad Ali,1,Cha Angeer,30,Building,2,3,0,TRUE
+3002224,64.266509008,31.573349103,2,Dorahi,Helmand,3,Nad Ali,1,Zabur Abad,30,Building,2,3,0,TRUE
+3003089,64.33267896,31.54296002,4,Ahmad Shah Mosque,Helmand,4,Nawa-E-Barakzayi,0,Ainak,30,Village,3,4,0,TRUE
+3003090,64.30519911,31.47958662,3,Haji Ghulam Ali Mosque,Helmand,4,Nawa-E-Barakzayi,1,Treekh Zabar,30,Building,3,4,0,TRUE
+3003091,64.30030771,31.35011418,3,Surkh Doz School,Helmand,4,Nawa-E-Barakzayi,1,Surkh Doz,30,Building,3,4,0,TRUE
+3003092,64.3611019,31.42490408,3,Mangal Zai School,Helmand,4,Nawa-E-Barakzayi,1,Mangal Zai,30,Building,3,4,0,TRUE
+3003093,64.28208466,31.37779026,4,Khalj High School,Helmand,4,Nawa-E-Barakzayi,0,Khalj,30,Building,3,4,0,TRUE
+3003094,64.3007102,31.39068715,4,Nabi Khan Mosque,Helmand,5,Nawa-E-Barakzayi,1,Khalj,30,Village,3,5,0,TRUE
+3003095,64.30438101,31.37844933,4,Abdul Hakeem Mosque,Helmand,4,Nawa-E-Barakzayi,0,Khalj,30,Building,3,4,0,TRUE
+3003096,64.27870941,31.36023144,3,Wakil Manan Private House,Helmand,4,Nawa-E-Barakzayi,1,Sra Kala,30,District,3,4,0,TRUE
+3003097,64.24363602,31.30591347,3,Asadullah Mosque,Helmand,4,Nawa-E-Barakzayi,1,Hazar Asp,30,Building,3,4,0,TRUE
+3003098,64.27892082,31.32464206,3,Hazar Asp School,Helmand,4,Nawa-E-Barakzayi,1,Hazar Asp,30,Building,3,4,0,TRUE
+3003099,64.28395156,31.34541965,3,Nek Mohammad Mosque,Helmand,4,Nawa-E-Barakzayi,1,Hazar Asp,30,Building,3,3,1,TRUE
+3003100,64.31851693,31.39309635,3,Clinic Block 1,Helmand,4,Nawa-E-Barakzayi,1,Block 1,30,Building,3,4,0,TRUE
+3003101,64.220983652,31.237535677,3,Loy Village School,Helmand,3,Nawa-E-Barakzayi,0,Loy Village,30,Building,3,3,0,TRUE
+3003102,64.20852781,31.33494676,2,Dopala School,Helmand,3,Nawa-E-Barakzayi,1,Dopala,30,Building,3,3,0,TRUE
+3003103,64.34492724,31.407990661,5,Kharaba Clinic,Helmand,5,Nawa-E-Barakzayi,0,Kharaba,30,Building,3,5,0,TRUE
+3003104,64.29419262,31.35453314,5,Baslan Clinic,Helmand,5,Nawa-E-Barakzayi,0,Baslan,30,Building,3,5,0,TRUE
+3003105,64.29172275,31.4020634,4,Khusr Abad Gharbi Mosque,Helmand,4,Nawa-E-Barakzayi,0,Khusr Abad Gharbi,30,Village,3,4,0,TRUE
+3003106,64.324783291,31.426721857,2,Khusr Abad School,Helmand,4,Nawa-E-Barakzayi,2,Khusr Abad Sharqi,30,Building,3,4,0,TRUE
+3003107,64.33702285,31.4607026,3,Gorgeen Sufla School,Helmand,4,Nawa-E-Barakzayi,1,Gorgeen Sufla,30,Building,3,4,0,TRUE
+3003108,64.32043605,31.36278231,3,Gorgeen Ulya School,Helmand,4,Nawa-E-Barakzayi,1,Gorgeen Ulya,30,Building,3,4,0,TRUE
+3004034,64.50905045,31.79131213,3,Wazir Fateh Khan School,Helmand,5,Nahr-E-Saraj,2,Malgeer,30,Village,4,5,0,TRUE
+3004035,64.57414666,31.81599127,5,Abul Fath Basti High School,Helmand,7,Nahr-E-Saraj,2,Gereshk,30,Building,4,7,0,TRUE
+3004036,64.56752571,31.79401968,4,Abazan School,Helmand,6,Nahr-E-Saraj,2,Maktab Abazan,30,Building,4,6,0,TRUE
+3004038,64.56035125,31.8209806,3,Gereshk Haji Fabrika,Helmand,5,Nahr-E-Saraj,2,Gereshk,30,Building,4,5,0,TRUE
+3004039,64.57012669,31.82000645,0,Girls High School,Helmand,4,Nahr-E-Saraj,4,Gereshk,30,Building,4,4,0,TRUE
+3004040,64.5734966,31.81753183,0,Gereshk Hospital,Helmand,4,Nahr-E-Saraj,4,Gereshk,30,Building,4,4,0,TRUE
+3004041,64.56650888,31.8257707,5,Rawoof Khan Shila Mosque,Helmand,6,Nahr-E-Saraj,1,Gereshk,30,Building,4,6,0,TRUE
+3004043,64.50377865,31.78075183,4,Chahar Kocha School,Helmand,5,Nahr-E-Saraj,1,Chahar Kocha,30,Village,4,5,0,TRUE
+3004049,64.64441319,31.72934886,3,Alauddin Private House,Helmand,4,Nahr-E-Saraj,1,Nahr Siraj Area,30,Village,4,4,0,TRUE
+3004051,64.68440342,31.79376966,2,Yakhchal School,Helmand,4,Nahr-E-Saraj,2,Yakhchal,30,Village,4,4,0,TRUE
+3004052,64.59012291,31.82972279,4,Mirza Khan Building,Helmand,4,Nahr-E-Saraj,0,Deh Adam Khan,30,Village,4,4,0,TRUE
+3004053,64.76907032,31.92301528,2,Haidar Abad School,Helmand,4,Nahr-E-Saraj,2,Haidar Abad,30,Village,4,4,0,TRUE
+3004054,64.63426712,31.83783204,3,Mustafa Building,Helmand,4,Nahr-E-Saraj,1,Sarband,30,Village,4,4,0,TRUE
+3004055,64.62951415,31.83815922,3,Haji Saleem Private House,Helmand,4,Nahr-E-Saraj,1,Sarband,30,Village,4,4,0,TRUE
+3004056,64.61425797,31.80873392,3,Noorzi Lal Mohammad Private House,Helmand,4,Nahr-E-Saraj,1,Dagiyan,30,Village,4,4,0,TRUE
+3004057,64.56460585,31.79050925,3,Bowzai School,Helmand,4,Nahr-E-Saraj,1,Bawzai,30,Village,4,4,0,TRUE
+3004058,64.69389591,31.79544103,4,Haji Ali Mohammad Private House,Helmand,4,Nahr-E-Saraj,0,Pasaw,30,District,4,4,0,TRUE
+3004059,64.70895845,31.85387832,2,Zambali School,Helmand,4,Nahr-E-Saraj,2,Zambali,30,Village,4,4,0,TRUE
+3005211,63.86615182,32.24515782,4,District Clinic,Helmand,6,Washer,2,Na Konbira (Kochi Center),30,Building,5,11,0,TRUE
+3006109,64.01316707,30.60806296,3,Banadar Sufla School,Helmand,3,Garm Ser,0,Banadar Sufla,30,Village,6,3,0,TRUE
+3006110,64.11807337,30.76864985,2,Katorai School,Helmand,3,Garm Ser,1,Maktab Kochnai Darweshan,30,Building,6,3,0,TRUE
+3006111,64.19173933,31.13010354,3,Hazar Joft School,Helmand,3,Garm Ser,0,Mira Khan New Village,30,Building,6,3,0,TRUE
+3006112,64.12583796,30.94357135,2,Mustafa Mosque,Helmand,3,Garm Ser,1,Bir Taka,30,Village,6,3,0,TRUE
+3006113,64.23186293,31.09331567,5,Deh Zekriya School,Helmand,5,Garm Ser,0,Deh Zekria,30,Village,6,5,0,TRUE
+3006114,64.2012155,31.04606188,4,Haji Hazrat Ali Khan Village School,Helmand,5,Garm Ser,1,Haji Hazar Ali Village,30,Building,6,5,0,TRUE
+3006115,64.18516786,31.01789557,3,Kodalee School,Helmand,3,Garm Ser,0,Haji Bari Dad Village,30,Building,6,3,0,TRUE
+3006116,64.12321085,30.81136257,4,Lakee School,Helmand,4,Garm Ser,0,Amer Shah Wali Khan Village,30,Building,6,4,0,TRUE
+3006117,64.13927193,30.91423873,2,Haji Nadir Village School,Helmand,2,Garm Ser,0,Haji Nadir Village,30,Building,6,2,0,TRUE
+3006118,64.1402429,30.8709754,3,Lakree School,Helmand,3,Garm Ser,0,Haji Abdul Zahir Village,30,Building,6,3,0,TRUE
+3006119,64.1925544,31.13029878,4,Hazar Joft School,Helmand,5,Garm Ser,1,Haji Sayed Mir Khan,30,Building,6,5,0,TRUE
+3006120,64.05237458,30.63460793,2,Haji Ali Ahmad Private House,Helmand,3,Garm Ser,1,Banadar,30,Village,6,3,0,TRUE
+3006121,64.17099487,31.07603693,3,Hassan Abad Barjawi School,Helmand,3,Garm Ser,0,Haji Dawood Khan Village,30,Building,6,3,0,TRUE
+3006123,64.34758512,30.85168265,3,Government Building,Helmand,5,Garm Ser,2,Bibi Jana,30,District,6,5,0,TRUE
+3006124,64.35718514,30.59568189,2,Abbas Abad School,Helmand,4,Garm Ser,2,Abbas Abad,30,District,6,4,0,TRUE
+3006125,64.19846171,31.13096019,2,Hazar Joft Village School,Helmand,4,Garm Ser,2,Hazar Joft Village,30,Village,6,4,0,TRUE
+3006126,64.19869144,31.13079509,2,District Center School,Helmand,3,Garm Ser,1,Haji Mohammad Lal Village,30,Building,6,3,0,TRUE
+3006225,64.239549264,30.155836467,2,School,Helmand,3,Garm Ser,1,Kochinai Darwishian,30,Building,6,3,0,TRUE
+3007192,64.52308388,32.35162117,5,Haji Mohammad Qasim Khan Mosque,Helmand,7,Nawzad,2,Dahna,30,Building,7,7,0,TRUE
+3007196,64.47085691,32.404516,6,Asad Suri High School,Helmand,7,Nawzad,1,Nawzad Kalan,30,Village,7,7,0,TRUE
+3007204,64.47094564,32.40445721,6,District Center School,Helmand,7,Nawzad,1,District Compound,30,Building,7,7,0,TRUE
+3008127,64.95952358,32.15146455,6,Nasozi Ulya School,Helmand,6,Sangin Qala,0,Nasozi Ulya,30,Village,8,6,0,TRUE
+3008129,64.84086052,32.05761836,3,Central Hospital,Helmand,5,Sangin Qala,2,Nawai Maktab Bazar,30,Building,8,5,0,TRUE
+3008130,64.83753068,32.07193746,5,Central Mosque,Helmand,5,Sangin Qala,0,District Bazar,30,Building,8,5,0,TRUE
+3008131,65.00198861,32.23253233,3,Agha Noor Khan Mosque,Helmand,5,Sangin Qala,2,Bostanzai,30,Village,8,5,0,TRUE
+3008132,65.00841077,32.23390528,5,Bostanzai School,Helmand,5,Sangin Qala,0,Bostanzai,30,Village,8,5,0,TRUE
+3008133,64.96361935,32.15928941,3,Sher Ali Mosque,Helmand,4,Sangin Qala,1,Nasozi Sufla,30,Village,8,4,0,TRUE
+3008134,64.96966258,32.17163802,5,Nasozi School,Helmand,5,Sangin Qala,0,Nasozi,30,Village,8,5,0,TRUE
+3008135,64.83882306,32.07365474,7,Hashim Sarwani School,Helmand,7,Sangin Qala,0,District Compound,30,Building,8,7,0,TRUE
+3008226,64.837401346,32.071870008,3,New School,Helmand,4,Sangin Qala,1,Nawi Maktab,30,Building,8,4,0,TRUE
+3009178,64.79306407,32.2998484,5,Yatamchi Madrassa,Helmand,6,Musa Qala,1,Yatamchi,30,Village,9,6,0,TRUE
+3009180,64.77292558,32.35121228,4,Akhtar Jan Market,Helmand,6,Musa Qala,2,District Compound,30,Building,9,6,0,TRUE
+3009184,64.6983095,32.23240214,3,Noor Mohammad Private House,Helmand,5,Musa Qala,2,Sher Ghazai,30,Village,9,5,0,TRUE
+3009185,64.74522454,32.26020614,3,Khan Mohammad Mosque,Helmand,5,Musa Qala,2,Kaani Manda,30,Village,9,5,0,TRUE
+3009186,64.77107502,32.34868298,4,Central High School,Helmand,5,Musa Qala,1,Takhta Pol,30,Building,9,5,0,TRUE
+3009187,64.81106227,32.28022017,3,Cheek Aab School,Helmand,5,Musa Qala,2,Cheek Aab,30,Village,9,5,0,TRUE
+3009189,64.77329545,32.3401042,4,Lal Jan Market,Helmand,7,Musa Qala,3,Chena Sufla,30,Building,9,7,0,TRUE
+3010147,65.06407084,32.27225909,4,Kajaki Sufla School,Helmand,5,Kajaki,1,Kajaki Sufla,30,Village,10,5,0,TRUE
+3010149,65.07612937,32.28190709,4,District Building Office,Helmand,4,Kajaki,0,District Compound,30,Village,10,4,0,TRUE
+3010157,65.10380405,32.32713994,7,District Center School,Helmand,13,Kajaki,6,District Compound,30,Village,10,13,0,TRUE
+3010158,65.08205743,32.34946005,3,Kajaki Wasat Mosque,Helmand,4,Kajaki,1,Kajaki Wasat,30,Village,10,4,0,TRUE
+3011212,63.45453481,30.68545996,4,Dost Mohammad Mosque,Helmand,4,Reg-E-Khan Nishin,0,Qala-E-Golo Maktab,30,District,11,4,0,TRUE
+3011213,63.385833,30.491388,3,Malkhan Mosque,Helmand,3,Reg-E-Khan Nishin,0,Haji Salam Village,30,Village,11,3,0,TRUE
+3011214,63.23372083,30.66386636,2,Karam Khan Mosque,Helmand,3,Reg-E-Khan Nishin,1,Haji Hassan Village,30,District,11,3,0,TRUE
+3011215,63.9261468,30.55341571,2,Aalem Khan Private House,Helmand,3,Reg-E-Khan Nishin,1,Dewalak Village Masjid,30,Village,11,3,0,TRUE
+3011216,63.79733539,30.55467807,2,District Center School,Helmand,3,Reg-E-Khan Nishin,1,Khanesheen,30,Building,11,3,0,TRUE
+3011217,63.7856295,30.55137466,2,District Building Office,Helmand,3,Reg-E-Khan Nishin,1,District Compound,30,Building,11,3,0,TRUE
+3011218,63.48447149,30.5434244,2,Shahbaz Private House (Kochi Center),Helmand,3,Reg-E-Khan Nishin,1,Taayez,30,Village,11,3,0,TRUE
+3011227,63.946843745,30.560501037,2,Mosque,Helmand,3,Reg-E-Khan Nishin,1,Diwarak,30,Building,11,3,0,TRUE
+3014063,64.1382668,31.52818399,3,Karez Sadi School,Helmand,4,Marja,1,Karez Sadi,30,Village,14,4,0,TRUE
+3014064,64.12317991,31.52388623,2,Wakeel Mohammad Ikhlas School,Helmand,3,Marja,1,Marja,30,Village,14,3,0,TRUE
+3014072,64.12232147,31.53702959,3,Marja High School,Helmand,4,Marja,1,Block 25,30,Village,14,4,0,TRUE
+3014073,64.12952013,31.48834532,2,Marja Block 10 - D School,Helmand,3,Marja,1,Marja Block 10 - D,30,Village,14,3,0,TRUE
+3014074,64.07228957,31.3890808,2,Marja Block 9 School,Helmand,3,Marja,1,Marja Block 9,30,Village,14,3,0,TRUE
+3014075,64.0460482,31.47104147,6,Malak Private House,Helmand,8,Marja,2,Sistani,30,Village,14,8,0,TRUE
+3014076,64.11870035,31.37875878,3,Miraab Private House,Helmand,3,Marja,0,Block 11 Kalan,30,Village,14,3,0,TRUE
+3014077,64.1023444,31.50189439,3,Marja Block 1 - A Mosque,Helmand,4,Marja,1,Marja Block 1 - A,30,Village,14,4,0,TRUE
+3014082,64.23181885,31.56273649,2,Amr Boland Marja Private House,Helmand,3,Marja,1,Zabar Abad Dorahi,30,Village,14,3,0,TRUE
+3014083,64.10199132,31.37106128,2,Marja Block 11 Khord School,Helmand,3,Marja,1,Marja Block 11 Khord,30,Village,14,3,0,TRUE
+3014085,64.23193331,31.52828678,2,Mir Hamza Private House,Helmand,3,Marja,1,Treekh Zabar,30,Village,14,3,0,TRUE
+3014086,64.0665271,31.5145591,2,Block 4 - F Building,Helmand,3,Marja,1,Block 4 - F,30,Village,14,3,0,TRUE
+3014087,64.23042719,31.52914498,2,Faizullah Private House (Kochi Center),Helmand,3,Marja,1,Treekh Zabar,30,Village,14,3,0,TRUE
+3014088,64.055082928,31.292807341,1,Sheen Ghazak Buliding (Kochi Center),Helmand,2,Marja,1,Sheen Ghazak,30,Village,14,2,0,TRUE
+3101001,63.12984584,34.98600334,7,Hanzala School Qala- E- Naw,Badghis,14,Qala-E-Now,7,Hanzala,31,Building,1,14,0,TRUE
+3101002,63.13066694,34.98415035,4,Shahr-E-Qala-E-Now Girls School,Badghis,9,Qala-E-Now,5,Qala-E-Now,31,Building,1,9,0,TRUE
+3101003,63.13296691,35.01573396,4,Ferestan School,Badghis,7,Qala-E-Now,3,Faristan,31,Building,1,7,0,TRUE
+3101004,63.11039665,35.06309443,3,Khum Abasi School,Badghis,5,Qala-E-Now,2,Khum Abasi,31,Building,1,5,0,TRUE
+3101005,63.08896853,35.08936474,3,Chashma-E-Dozdak School,Badghis,5,Qala-E-Now,2,Chashma-E-Dozdak,31,Building,1,5,0,TRUE
+3101006,63.15277011,34.97513016,4,Qarqeito School,Badghis,6,Qala-E-Now,2,Qarqeito,31,Building,1,6,0,TRUE
+3101007,63.21159651,34.94759966,3,Khareesan School,Badghis,5,Qala-E-Now,2,Kharestan,31,Building,1,5,0,TRUE
+3101008,63.24,34.80361111,4,Social Center Building Najakzad Sarhang Village,Badghis,5,Qala-E-Now,1,Nechak Village,31,Building,1,5,0,TRUE
+3101009,63.13965545,34.95469535,4,Baghak School,Badghis,6,Qala-E-Now,2,Baghak,31,Building,1,6,0,TRUE
+3101010,63.12660135,34.93161479,3,Kandalan Village School,Badghis,5,Qala-E-Now,2,Kandalan Sar Cheshma Village,31,Building,1,5,0,TRUE
+3101011,63.17503305,34.80786493,4,Chushma-E- Senjid Bazar,Badghis,6,Qala-E-Now,2,Chashma-E- Sanjid Bazar,31,Building,1,6,0,TRUE
+3101012,63.20769556,34.7266644,3,Malmanji Mosque,Badghis,5,Qala-E-Now,2,Malmanji,31,Building,1,5,0,TRUE
+3101013,63.09848979,34.96876345,3,Tagab Esmaeel School,Badghis,5,Qala-E-Now,2,Takab Esmaeel,31,Building,1,5,0,TRUE
+3101014,63.07865566,34.86929475,4,Mir Mirak Village,Badghis,5,Qala-E-Now,1,Sahn-E-Aab Dool Village,31,Village,1,5,0,TRUE
+3101015,63.116316,34.82343495,3,Nadami School,Badghis,4,Qala-E-Now,1,Nadami,31,Building,1,4,0,TRUE
+3101016,63.10254201,34.76318093,3,Laman School,Badghis,5,Qala-E-Now,2,Laman,31,Building,1,5,0,TRUE
+3101017,63.02480598,34.81887234,2,Aalam Chob Bazar,Badghis,4,Qala-E-Now,2,Aalam,31,Village,1,4,0,TRUE
+3101018,63.05213752,34.76937338,2,Chakab Clinic,Badghis,4,Qala-E-Now,2,Chakab,31,Building,1,4,0,TRUE
+3101019,63.00997816,34.76284342,2,Khan Aqa Secondary School,Badghis,4,Qala-E-Now,2,Khan Aqa Village,31,Building,1,4,0,TRUE
+3102028,63.01769924,35.21470479,3,Jafari High School,Badghis,4,Ab Kamari,1,Jafari Village,31,Village,2,4,0,TRUE
+3102035,63.05915068,35.15100816,2,Hichkah High School,Badghis,3,Ab Kamari,1,Hichkah,31,Village,2,3,0,TRUE
+3102036,63.05279613,34.97364965,4,Aabkamari Village School,Badghis,5,Ab Kamari,1,Aabkamari School,31,Building,2,5,0,TRUE
+3102037,63.04927878,35.04875657,1,Mobarak Shah Secondary School,Badghis,2,Ab Kamari,1,Mobarak Shah,31,Building,2,2,0,TRUE
+3102038,63.0637632,35.08477015,1,Sang-E- Khars School,Badghis,2,Ab Kamari,1,Sang-E- Khers Village,31,Building,2,2,0,TRUE
+3102039,63.04089596,34.92215943,2,Aaghak School,Badghis,4,Ab Kamari,2,Aaghak,31,Building,2,4,0,TRUE
+3102040,62.94188233,34.84714613,2,Zard Koja High School,Badghis,3,Ab Kamari,1,Zard Koja,31,Building,2,3,0,TRUE
+3102041,62.98214325,34.81712194,1,Gulkhana Village Mosque,Badghis,2,Ab Kamari,1,Gulkhana,31,Building,2,2,0,TRUE
+3102042,62.87969996,34.83430446,1,Tashbolaq High School,Badghis,2,Ab Kamari,1,Tashbolaq,31,Building,2,2,0,TRUE
+3102043,62.89362415,34.80191009,2,Gandah Aab School,Badghis,3,Ab Kamari,1,Gandah Aab,31,Village,2,3,0,TRUE
+3102044,62.92748173,34.69171038,2,Dehistan Village Mosque,Badghis,3,Ab Kamari,1,Dehistan,31,Village,2,3,0,TRUE
+3102045,62.81974061,34.70562328,2,Sina Urdo Mosque,Badghis,3,Ab Kamari,1,Seena Urdo Bazar,31,Building,2,3,0,TRUE
+3102046,62.9048612,34.8921869,2,Padeh Laghari School,Badghis,3,Ab Kamari,1,Padeh Laghari,31,Building,2,3,0,TRUE
+3102047,62.88337379,34.88514983,2,Padeh Dehzangi High School,Badghis,3,Ab Kamari,1,Padeh Dehzangi,31,Building,2,3,0,TRUE
+3102048,62.82235,34.86830278,2,Kokjail Village School,Badghis,3,Ab Kamari,1,Kokjail Village,31,Building,2,3,0,TRUE
+3102049,62.71967653,34.8995323,2,Aab Barik School,Badghis,3,Ab Kamari,1,Aab Barik,31,Building,2,3,0,TRUE
+3102175,62.85200133,34.87189866,2,Takh-E-Dara Kockchail School,Badghis,3,Ab Kamari,1,Kockchail Dara,31,Building,2,3,0,TRUE
+3102176,62.97188121,34.78142015,1,Serzarak Village School,Badghis,2,Ab Kamari,1,Sir Zarak Village,31,Building,2,2,0,TRUE
+3102190,62.825735711,34.813605257,2,Safidlak School,Badghis,3,Ab Kamari,1,Safid Lak,31,Building,2,3,0,TRUE
+3102191,62.908794764,34.74858958,2,Chalanak School,Badghis,3,Ab Kamari,1,Chalanak,31,Building,2,3,0,TRUE
+3102192,62.875309156,34.708394648,2,Sang Lawh Mosque,Badghis,3,Ab Kamari,1,Sang Lawh,31,Building,2,3,0,TRUE
+3103020,63.27010217,35.07939017,3,District Building And Rubat Clinic,Badghis,4,Muqur,1,Rubat,31,Building,3,4,0,TRUE
+3103021,63.17350147,35.08402911,2,Kamari Clinic,Badghis,3,Muqur,1,Kamari,31,Building,3,3,0,TRUE
+3103022,63.20090663,35.10643408,2,Khwaja Pesta Village Mosque,Badghis,3,Muqur,1,Khwaja Pesta,31,Building,3,3,0,TRUE
+3103023,63.23614283,35.09738581,1,Jaknah Primary School,Badghis,2,Muqur,1,Jaknah Village,31,Building,3,2,0,TRUE
+3103024,63.29345123,35.05673726,1,Meeranzai Mosque,Badghis,2,Muqur,1,Meeranzai,31,Village,3,2,0,TRUE
+3103025,63.29137085,35.03065829,2,Zad Ali High School,Badghis,3,Muqur,1,Zad Ali,31,Building,3,3,0,TRUE
+3103026,63.29095889,34.99557061,1,Andari School,Badghis,2,Muqur,1,Andari,31,Building,3,1,1,TRUE
+3103027,63.2445897,34.98126084,1,Sanjitak Village School,Badghis,2,Muqur,1,Sanjitak,31,Building,3,2,0,TRUE
+3104054,63.44161237,34.80225719,3,Jamiat High School,Badghis,4,Qadis,1,District Center,31,Building,4,4,0,TRUE
+3104055,63.41243758,34.82167272,2,Arbab Sarwar School,Badghis,3,Qadis,1,Arbab Sarwar,31,Building,4,3,0,TRUE
+3104056,63.27189017,34.87165065,1,Aab Bakhsh School,Badghis,2,Qadis,1,Aab Bakhsh,31,Building,4,2,0,TRUE
+3104057,63.26299203,34.75726426,3,Deh Berenj School,Badghis,4,Qadis,1,Deh Berenj,31,Building,4,4,0,TRUE
+3104058,63.37324508,34.70423301,2,Joleeq School,Badghis,3,Qadis,1,Joleeq,31,Building,4,3,0,TRUE
+3104059,63.45402344,34.72685645,1,Boyaha Village,Badghis,2,Qadis,1,Boyaha,31,Building,4,2,0,TRUE
+3104060,63.51699531,34.68149811,1,Boya Kadank School,Badghis,2,Qadis,1,Boya Kadank,31,Building,4,2,0,TRUE
+3104061,63.49697119,34.75106535,1,Khwaja Ha-E- Shur Aab Village,Badghis,2,Qadis,1,Khwaja Ha-E-Shue Aab,31,Building,4,2,0,TRUE
+3104062,63.50922407,34.78803294,1,Zeyarat Village,Badghis,2,Qadis,1,Ziarat,31,Building,4,2,0,TRUE
+3104063,63.52531426,34.75456762,2,Qades Khordak School,Badghis,3,Qadis,1,Qades Khordak Village,31,Building,4,3,0,TRUE
+3104064,63.56934357,34.71529787,1,Arbab Mohammad Village,Badghis,2,Qadis,1,Arbab Mohammad Village,31,District,4,2,0,TRUE
+3104065,63.59922382,34.65220352,1,Deh Aabi Village,Badghis,2,Qadis,1,Deh Aabi,31,Village,4,2,0,TRUE
+3104066,63.33777998,34.88288644,1,Malayan Village,Badghis,2,Qadis,1,Mullahyan,31,Building,4,2,0,TRUE
+3104067,63.31429801,34.90736397,2,Qarchighai Clinic,Badghis,3,Qadis,1,Qarchi Ghai Clinic,31,Building,4,3,0,TRUE
+3104068,63.30396062,34.96075228,1,Bab-E- Doosti Village,Badghis,2,Qadis,1,Bab-E- Doosti,31,Building,4,2,0,TRUE
+3104069,63.51209802,34.82147749,1,Takak School,Badghis,2,Qadis,1,Takak School,31,Building,4,2,0,TRUE
+3104070,63.46193666,34.86982249,2,Langari Sharif High School,Badghis,3,Qadis,1,Langar-E- Sharif,31,Building,4,3,0,TRUE
+3104071,63.390032,34.936695,2,Karez School,Badghis,3,Qadis,1,Karez School,31,Village,4,0,3,FALSE
+3104072,63.44267507,34.92266384,1,Shuraab-E- Balla Village Mosque,Badghis,2,Qadis,1,Shuraab-E- Balla,31,Building,4,0,2,FALSE
+3104073,63.56711546,34.88552954,2,Mir Gheyas School,Badghis,3,Qadis,1,Mir Gheyas,31,Building,4,3,0,TRUE
+3104075,63.70694444,34.67777777,1,Gunbad Mosque,Badghis,2,Qadis,1,Gunbad Village,31,Building,4,2,0,TRUE
+3104076,63.72138888,34.85333333,1,Gunbad Shekh Ghiasuddin Madrassa,Badghis,2,Qadis,1,Gunbad Shekh Gheyasuddin Village,31,District,4,2,0,TRUE
+3104077,63.713642,34.76677104,1,Nayek Mosque,Badghis,2,Qadis,1,Nayek Village,31,Village,4,2,0,TRUE
+3104078,63.77093986,34.74644973,2,Burj Mosque,Badghis,3,Qadis,1,Burj Village,31,Building,4,3,0,TRUE
+3104079,63.78179114,34.60710221,1,Bargul Village Madrassa,Badghis,2,Qadis,1,Bargul Village,31,Building,4,2,0,TRUE
+3104080,63.863211312,34.715314415,1,Nawa Mullah Gadah Mosque,Badghis,2,Qadis,1,Nawa Mullah Gadah,31,Building,4,2,0,TRUE
+3104081,63.64411055,34.86784781,2,Gulchin Clinic,Badghis,3,Qadis,1,Gulchin,31,Building,4,3,0,TRUE
+3104082,63.62597071,34.9646667,1,Khair Khana Mosque,Badghis,2,Qadis,1,Khair Khana Village,31,Village,4,2,0,TRUE
+3104084,63.46398471,35.08734778,2,Darra-E-Bom District Building,Badghis,3,Qadis,1,Darra-E- Bom,31,Village,4,3,0,TRUE
+3104088,63.63861256,34.96273294,2,Dahan-E- Khushk -E- Khair Khana,Badghis,3,Qadis,1,Dahan- E- Khushk- E- Khair Khana Village,31,Village,4,3,0,TRUE
+3104177,63.3180144,34.71822919,1,Mosque,Badghis,2,Qadis,1,Darra-E-Tabar Afghan,31,Village,4,2,0,TRUE
+3104178,63.56061441,34.72020701,1,Jar-E- Durosht Mosque,Badghis,2,Qadis,1,Jar-E- Durosht,31,Village,4,2,0,TRUE
+3104193,63.861761112,34.712594328,2,Shorak Mosque,Badghis,3,Qadis,1,Shorak,31,Building,4,3,0,TRUE
+3105147,63.333115512,35.581933035,4,Markaz Murghab School,Badghis,4,Bala Murghab,0,Markaz Murghab,31,Building,5,4,0,TRUE
+3105148,63.32725784,35.58339253,0,Murghab Clinic,Badghis,3,Bala Murghab,3,Murghab,31,Building,5,3,0,TRUE
+3105149,63.33346585,35.55271308,2,Joy-E-Khwaja School,Badghis,3,Bala Murghab,1,Joy-E-Khwaja,31,Village,5,3,0,TRUE
+3105150,63.366289,35.458522,1,Buz Baye Mosque,Badghis,2,Bala Murghab,1,Buz Baye,31,Village,5,2,0,TRUE
+3105153,63.31073532,35.61373847,2,Akazi School,Badghis,3,Bala Murghab,1,Akaziha,31,Building,5,3,0,TRUE
+3105158,63.37038205,35.52160345,2,Joy-E- Kar School,Badghis,3,Bala Murghab,1,Joy-E-Kar,31,Building,5,3,0,TRUE
+3105168,63.64135239,35.32536504,3,Mahalla-E- Paheen  School,Badghis,5,Bala Murghab,2,Mahalla-E- Paheen,31,Village,5,5,0,TRUE
+3105188,63.32484536,35.61215435,2,Sarkhlang Joy-E-Ganj Mosque,Badghis,3,Bala Murghab,1,Sarkhlang Joy-E-Ganj,31,Village,5,3,0,TRUE
+3105189,63.35322119,35.56169168,1,Qabchaq Kapa Baba School,Badghis,2,Bala Murghab,1,Qabchaq Kapa Baba,31,Building,5,2,0,TRUE
+3105194,63.355167128,35.55351431,2,Kapa Baba Village,Badghis,3,Bala Murghab,1,Kapa Baba,31,Village,5,3,0,TRUE
+3106089,64.15292252,35.06259953,3,Char Taq School,Badghis,4,Jawand,1,Char Taq,31,Building,6,4,0,TRUE
+3106091,63.79857886,34.84852773,2,Rigee Village Mosque,Badghis,3,Jawand,1,Rigee,31,Village,6,3,0,TRUE
+3106092,63.90145851,34.81794182,2,Gashk Mosque,Badghis,3,Jawand,1,Gashk,31,Village,6,3,0,TRUE
+3106093,63.97969871,34.75172043,2,Meel Naw Mosque,Badghis,3,Jawand,1,Meel Naw,31,Village,6,3,0,TRUE
+3106094,64.06824153,34.81455451,2,Aab Khor School,Badghis,3,Jawand,1,Aab Khor,31,Building,6,3,0,TRUE
+3106095,64.13570005,34.9165167,2,Jeeghani School,Badghis,3,Jawand,1,Jeejani,31,Building,6,3,0,TRUE
+3106096,64.16370071,34.80179619,2,Khameen School,Badghis,3,Jawand,1,Khameen,31,Building,6,3,0,TRUE
+3106097,64.23017242,34.62355905,2,Kalan Mosque,Badghis,3,Jawand,1,Marghzar,31,Village,6,3,0,TRUE
+3106101,64.34224311,35.08293245,1,Kazak Village Mosque,Badghis,2,Jawand,1,Kazak,31,Village,6,2,0,TRUE
+3106102,64.38803388,34.91397267,1,Tagab Beest Village,Badghis,2,Jawand,1,Tagab Beest,31,Building,6,2,0,TRUE
+3106103,64.50331454,34.92420693,1,Kadian Village Mosque,Badghis,2,Jawand,1,Kadian Village,31,Village,6,2,0,TRUE
+3106104,64.62952652,34.94636473,1,Chushm Bed Mosque,Badghis,2,Jawand,1,Chushmah Bid,31,Building,6,2,0,TRUE
+3106105,64.60054476,34.89102118,1,Chushma Char Village Mosque,Badghis,2,Jawand,1,Chushmah Char,31,Building,6,2,0,TRUE
+3106106,64.70884462,35.03856703,1,Qaz Village Mosque,Badghis,2,Jawand,1,Qaz,31,Building,6,2,0,TRUE
+3106107,64.56988042,35.09613528,1,Sartawah Mosque,Badghis,2,Jawand,1,Sartawah,31,Building,6,2,0,TRUE
+3106108,64.52417346,35.07816444,1,Orgo Village Mosque,Badghis,2,Jawand,1,Orgo,31,Village,6,2,0,TRUE
+3106109,64.42954599,35.15901048,1,Takht-E- Zard Village Mosque,Badghis,2,Jawand,1,Takht-E- Zard,31,Village,6,2,0,TRUE
+3106110,64.23015565,34.97329413,1,Ghow Kalan Village Mosque,Badghis,2,Jawand,1,Ghow Kalan,31,Village,6,2,0,TRUE
+3106111,64.28527777,34.92944444,2,Dahan-E- Do Aabi Village,Badghis,3,Jawand,1,Dahan-E- Do Aabi,31,Village,6,3,0,TRUE
+3106112,64.35858413,34.89742855,1,Rubat Mosque,Badghis,2,Jawand,1,Rubat,31,Village,6,2,0,TRUE
+3106113,64.35868406,34.89765779,1,Rubatak Mosque,Badghis,2,Jawand,1,Rubatak,31,Village,6,2,0,TRUE
+3106114,64.39488717,34.73186335,1,Shur Aabak Mosque,Badghis,2,Jawand,1,Shur Aabak,31,Village,6,2,0,TRUE
+3106115,64.141763,35.17171239,1,Yak Mirawk Mosque,Badghis,2,Jawand,1,Yak Mirawk,31,Village,6,0,2,FALSE
+3106116,64.27017166,35.28084933,1,Mawladad Mosque,Badghis,2,Jawand,1,Koj-E- Lalbai Village,31,Village,6,0,2,FALSE
+3106120,64.0691541,35.38943605,1,Dahan-E- Khesi Village Mosque,Badghis,2,Jawand,1,Dahan-E- Khesi Village,31,Village,6,0,2,FALSE
+3106122,64.04718085,35.18390847,1,Qarye Petow Village Mosque,Badghis,3,Jawand,2,Petow,31,Building,6,0,3,FALSE
+3106179,64.66544381,34.78842486,1,Dahan Daramullah Yar Mosque,Badghis,2,Jawand,1,Dahan Daramullah Yar,31,Building,6,2,0,TRUE
+3106180,64.42561535,35.09296075,1,Samba Keech Mosque,Badghis,2,Jawand,1,Samba Keech,31,Village,6,2,0,TRUE
+3106195,64.514058057,35.136136187,2,Open Field,Badghis,3,Jawand,1,Sar Khas,31,Building,6,3,0,TRUE
+3106196,64.385974044,35.055456753,2,Gosala Danak Mosque,Badghis,3,Jawand,1,Gosala Danak,31,Building,6,3,0,TRUE
+3106197,64.11693485,34.859308839,2,Gul Zirai Paien Mosque,Badghis,3,Jawand,1,Gul Zirai Pahien,31,Building,6,3,0,TRUE
+3106198,63.874135958,34.8362794,2,Kaftar Khan Mosque,Badghis,3,Jawand,1,Kaftar Khan,31,Building,6,3,0,TRUE
+3106199,64.391080097,34.780398745,2,Pai Chang Mosque,Badghis,3,Jawand,1,Pai Chang,31,Building,6,3,0,TRUE
+3106200,64.362597811,34.871768763,2,Hazrat Mullah Mosque,Badghis,3,Jawand,1,Hazrat Mulah,31,Building,6,3,0,TRUE
+3106201,64.336964134,34.917922464,2,Takhlanga Mosque,Badghis,3,Jawand,1,Takhlanga,31,Building,6,3,0,TRUE
+3107124,63.78017896,35.73948356,5,Center School,Badghis,5,Ghormach,0,Ghormach,31,Building,7,5,0,TRUE
+3107125,63.82468762,35.73742073,2,Abgarmak Village,Badghis,3,Ghormach,1,Abgarmak Village,31,Building,7,3,0,TRUE
+3107140,63.81851307,35.74067646,3,Petow Village Mosque,Badghis,4,Ghormach,1,Petow,31,Building,7,4,0,TRUE
+3107141,63.76847285,35.57098147,1,Sharshar Village,Badghis,2,Ghormach,1,Sharshar Village,31,Village,7,0,2,FALSE
+3107142,63.86578698,35.7291258,2,Nagharah Khan Village,Badghis,3,Ghormach,1,Nagharah Khan Village,31,Village,7,0,3,FALSE
+3107143,63.83131111,35.73696666,2,Aabgarmak,Badghis,3,Ghormach,1,Aabgarmak,31,Village,7,0,3,FALSE
+3107144,63.71336467,35.79333761,1,Kabulzai,Badghis,2,Ghormach,1,Kabulzai,31,Village,7,0,2,FALSE
+3107146,63.96380193,35.57798667,1,Tarnawe,Badghis,2,Ghormach,1,Tarnawe,31,Village,7,0,2,FALSE
+3201001,62.21449519,34.34992754,6,Sultan High School,Herat,12,Herat,6,D01 - Nahia 1,32,Building,1,12,0,TRUE
+3201002,62.2200872,34.3500935,6,Gauhar Shad High School,Herat,10,Herat,4,D01 - Nahia 1,32,Building,1,10,0,TRUE
+3201003,62.19261223,34.34369486,0,Malika Jalali High School,Herat,6,Herat,6,D02 - Nahia 2,32,Building,1,6,0,TRUE
+3201004,62.19565546,34.34311007,14,Hirat City Big Mosque,Herat,14,Herat,0,D02 - Nahia 2,32,Building,1,14,0,TRUE
+3201005,62.20011509,34.3441926,4,Jami High School,Herat,9,Herat,5,D03 - Nahia 3,32,Building,1,9,0,TRUE
+3201006,62.19971935,34.34000201,5,Khwaja Mohammad Taki High School,Herat,11,Herat,6,D03 - Nahia 3,32,Building,1,11,1,TRUE
+3201007,62.21653594,34.33087512,6,Hatefi High School,Herat,11,Herat,5,D04 - Nahia 4,32,Building,1,11,0,TRUE
+3201008,62.21013623,34.34277034,3,Balian Boys School,Herat,7,Herat,4,D04 - Nahia 4,32,Building,1,7,0,TRUE
+3201009,62.19608942,34.360024,4,Mehdeiah Ghur -E- Darwaz,Herat,9,Herat,5,D05 - Nahia 5,32,Village,1,9,0,TRUE
+3201010,62.18965406,34.35120526,6,Mehri High School,Herat,13,Herat,7,D05 - Nahia 5,32,Building,1,13,0,TRUE
+3201011,62.2059547,34.35962063,5,Experimental School,Herat,11,Herat,6,D05 - Nahia 5,32,Building,1,12,0,TRUE
+3201012,62.19771218,34.36034601,4,Merman Hayati Bagh- E- Dasht High School,Herat,8,Herat,4,D05 - Nahia 5,32,Building,1,8,0,TRUE
+3201013,62.1979117,34.34997992,5,Inqelab High School,Herat,8,Herat,3,D05 - Nahia 5,32,Building,1,8,0,TRUE
+3201014,62.22943855,34.33707662,4,Pul -E- Rageena High School,Herat,9,Herat,5,D06 - Nahia 6,32,Building,1,9,0,TRUE
+3201015,62.22106265,34.34321133,4,Pul -E -Rageena Mosque,Herat,8,Herat,4,D06 - Nahia 6,32,Building,1,9,0,TRUE
+3201016,62.21739317,34.33336559,5,Osman-E- Ghani Mosque,Herat,9,Herat,4,D06 - Nahia 6,32,Building,1,9,0,TRUE
+3201017,62.25883597,34.35066971,7,Fath Now Abad High School,Herat,13,Herat,6,D11 - Nahia 11,32,Building,1,13,1,TRUE
+3201018,62.17829069,34.34711757,4,Kabeer Buraman Mosque,Herat,9,Herat,5,D07 - Nahia 7,32,Building,1,10,1,TRUE
+3201019,62.17270754,34.3318888,3,Paeen Aab School,Herat,7,Herat,4,D07 - Nahia 7,32,Building,1,7,2,TRUE
+3201020,62.19044354,34.34718061,0,Mojtameh Khwaharan,Herat,6,Herat,6,D10 - Nahia 10,32,Village,1,6,0,TRUE
+3201021,62.18939018,34.3440825,7,Ekhtiarudden Mosque,Herat,7,Herat,0,D07 - Nahia 7,32,Building,1,7,0,TRUE
+3201022,62.2171719,34.35959036,5,Amir Ali Shir Nawayee School,Herat,10,Herat,5,D09 - Nahia 9,32,Building,1,10,0,TRUE
+3201023,62.23603389,34.3531527,6,Fekri Saljooqi High School,Herat,11,Herat,5,D08 - Nahia 8,32,Building,1,11,0,TRUE
+3201024,62.24052711,34.37425,5,Guzarga  Mosque,Herat,9,Herat,4,D08 - Nahia 8,32,Building,1,9,0,TRUE
+3201025,62.18497683,34.35585042,4,Fakhrul Madares,Herat,9,Herat,5,D09 - Nahia 9,32,Building,1,10,1,TRUE
+3201026,62.16838743,34.38415583,3,Salahuddin Saljoqi School,Herat,7,Herat,4,D09 - Nahia 9,32,Village,1,8,1,TRUE
+3201027,62.18432351,34.36460191,6,Abdul Ali Shah Tokhi School,Herat,11,Herat,5,D12 - Nahia 12,32,Building,1,11,0,TRUE
+3201028,62.17915587,34.35854785,4,Baba Zangi Ata School,Herat,9,Herat,5,D09 - Nahia 9,32,Village,1,10,0,TRUE
+3201029,62.19016225,34.33518541,3,Hareewa Secondary School,Herat,7,Herat,4,D10 - Nahia 10,32,Building,1,7,0,TRUE
+3201030,62.17621147,34.33314363,4,Hazrat -E- Belal Mosque,Herat,9,Herat,5,D10 - Nahia 10,32,Building,1,9,1,TRUE
+3201031,62.18701823,34.33015841,6,Seefi High School,Herat,13,Herat,7,D10 - Nahia 10,32,Building,1,13,0,TRUE
+3201424,62.203846,34.33816955,4,Alreza Mosque,Herat,9,Herat,5,D03 - Nahia 3,32,Village,1,10,0,TRUE
+3201425,62.20068488,34.36764847,3,Bagh-E-Dasht Mosque,Herat,8,Herat,5,D05 - Nahia 5,32,Building,1,8,0,TRUE
+3201426,62.26830597,34.34839744,3,Now Abad Mosque,Herat,6,Herat,3,D11 - Nahia 11,32,Building,1,6,0,TRUE
+3201427,62.24057928,34.3439817,4,Karti-E-Amin Secondary School,Herat,8,Herat,4,D06 - Nahia 6,32,Building,1,8,0,TRUE
+3201428,62.16966199,34.33524334,4,Hazrat-E- Umar Faroq School,Herat,10,Herat,6,D07 - Nahia 7,32,Building,1,12,0,TRUE
+3201429,62.21089875,34.36696393,5,New Univrsity,Herat,10,Herat,5,D05 - Nahia 5,32,Building,1,10,0,TRUE
+3201430,62.150743891,34.378943026,5,Imigration Department,Herat,9,Herat,4,D12 - Nahia 12,32,Building,1,9,0,TRUE
+3201431,62.135527585,34.381693547,7,Jebrail Girls School,Herat,16,Herat,9,D12 - Nahia 12,32,Building,1,18,0,TRUE
+3201432,62.21555959,34.35364074,3,Herat Prison,Herat,6,Herat,3,Municipality First Nahia,32,Building,1,2,4,TRUE
+3201433,62.21926535,34.2115979,6,Shahrak-E-Sanhati,Herat,6,Herat,0,Guzara District Inside Of Airport,32,Building,1,6,0,TRUE
+3201471,62.144621353,34.373829924,2,Jebariel Mosque,Herat,4,District_12,2,Jebraiel Mosque,32,Building,1,6,0,TRUE
+3201472,62.224014381,34.363025242,2,Ustad Kamaludin Behzad High School,Herat,4,District_08,2,Ustad Kamaludin Behzad Highschool,32,Building,1,4,0,TRUE
+3201473,62.199480756,34.375449718,2,Bagh Dasht Esteqlal High School,Herat,4,District_05,2,Esteqlal Bagh Dashd High School,32,Building,1,4,0,TRUE
+3201474,62.161099311,34.364726459,2,Sayed Qanad Secondary School,Herat,4,District_12,2,Said Qunad Secondary School,32,Building,1,5,0,TRUE
+3201475,62.18022871,34.373389482,2,Mawlana Jame,Herat,4,Herat,2,9Th District,32,Building,1,5,0,TRUE
+3202032,62.20479398,34.30318025,4,Shaikh Mohammad Umar Mosque,Herat,4,Enjil,0,First Cheghara,32,Building,2,4,0,TRUE
+3202033,62.20864076,34.29685683,0,Paienda Mosque,Herat,4,Enjil,4,Second Cheghra,32,Building,2,4,0,TRUE
+3202034,62.191161677,34.313302855,4,Qafaslan Mosque,Herat,7,Enjil,3,Qafaslan,32,Building,2,7,0,TRUE
+3202035,62.21080912,34.32261513,4,Karti-E-Shohada Mosque,Herat,9,Enjil,5,Karta,32,Building,2,9,0,TRUE
+3202036,62.16772764,34.31922393,2,Sheman Mosque,Herat,3,Enjil,1,Sheman Village,32,Building,2,5,0,TRUE
+3202037,62.15695217,34.30224649,2,Jaghratan High School,Herat,3,Enjil,1,Jaghratan,32,Village,2,4,0,TRUE
+3202038,62.14796166,34.36007106,3,Abul Waleed Mosque,Herat,6,Enjil,3,Abul Waleed,32,Building,2,6,0,TRUE
+3202039,62.135461035,34.344170547,3,Gow Butan High School,Herat,5,Enjil,2,Gow Butan,32,Building,2,7,0,TRUE
+3202041,62.13356463,34.37791381,2,Safid Rawan Gilrs Secondary School,Herat,3,Enjil,1,Safid Rawan Village,32,Building,2,3,0,TRUE
+3202042,62.28154581,34.26539543,2,Taryak School,Herat,3,Enjil,1,Taryak Village,32,Village,2,3,0,TRUE
+3202043,62.32614424,34.27691883,2,Emam Shash Noor School,Herat,4,Enjil,2,Khesht Pashan Village,32,Building,2,4,0,TRUE
+3202044,62.2602705,34.28796115,2,Khalifa Saheb Nawin,Herat,3,Enjil,1,Naween Ulya Village,32,Building,2,3,0,TRUE
+3202045,62.25273816,34.29398737,2,Baland Aab Mosque,Herat,3,Enjil,1,Baland Aab Village,32,Building,2,3,0,TRUE
+3202046,62.22803676,34.29699064,2,Naween Sufla School,Herat,3,Enjil,1,Naween Sufla Village,32,Building,2,3,0,TRUE
+3202047,62.30775505,34.34828307,2,Kahedastan School,Herat,3,Enjil,1,Kahedastan Village,32,Building,2,5,0,TRUE
+3202048,62.28728758,34.34072798,1,Safiudeen High School,Herat,2,Enjil,1,Qabul Daraz,32,Building,2,3,0,TRUE
+3202049,62.28188621,34.3303577,1,Nang Abad Mosque,Herat,2,Enjil,1,Nang Abad,32,Building,2,2,0,TRUE
+3202050,62.26625593,34.26721333,2,Adran Mosque,Herat,3,Enjil,1,Adran,32,Building,2,3,0,TRUE
+3202051,62.185822205,34.309844782,2,Bozdang Enjil School,Herat,3,Enjil,1,Bozdang Alanjan,32,Building,2,3,0,TRUE
+3202052,62.08016484,34.32117474,2,Tallab Mosque,Herat,3,Enjil,1,Tallab Village,32,Building,2,3,0,TRUE
+3202053,62.05746076,34.34422162,2,Rawashan High School,Herat,3,Enjil,1,Khirdozan Village,32,Building,2,3,0,TRUE
+3202054,62.08929963,34.33616043,2,Sofiyan Primary School,Herat,3,Enjil,1,Sofiyan Village,32,Building,2,3,0,TRUE
+3202055,62.20890174,34.50441929,2,Parwana Secondary School,Herat,3,Enjil,1,Parwana Village,32,Building,2,3,0,TRUE
+3202056,62.0806916,34.53126869,2,Chahak School And Mosque,Herat,3,Enjil,1,Chahak Village,32,Village,2,3,0,TRUE
+3202057,62.23636988,34.31847386,2,Kababeyan Secondary School,Herat,3,Enjil,1,Oqab-E-Kababeyan Village,32,Building,2,3,0,TRUE
+3202058,62.22545969,34.32373761,2,Ghizan Sangar Mosque,Herat,3,Enjil,1,Qeeizan Sangar Village,32,Building,2,3,0,TRUE
+3202059,62.24940446,34.30745922,1,Gerdaab School,Herat,2,Enjil,1,Gerdaab Village,32,Building,2,2,0,TRUE
+3202060,62.14152104,34.33336805,2,Poran Secondary School,Herat,3,Enjil,1,Poran Village,32,Building,2,3,0,TRUE
+3202061,62.36410114,34.271179748,3,Sar Asiab School,Herat,3,Enjil,0,Sar Asiab Village,32,Building,2,3,0,TRUE
+3202062,62.363835,34.27125241,0,Sar Asiab Scondary School,Herat,3,Enjil,3,Sar Asiab Village,32,Building,2,3,0,TRUE
+3202063,62.23085794,34.28297904,2,Aboraihan-E- Alberoni Primary School,Herat,3,Enjil,1,Garazan Village,32,Building,2,3,0,TRUE
+3202064,62.31656241,34.29534328,2,Naw Badam High School,Herat,3,Enjil,1,Naw Badam Village,32,Building,2,3,0,TRUE
+3202065,62.2263712,34.31100327,3,Srorestan Secondary School,Herat,5,Enjil,2,Srorestan Village,32,Building,2,5,0,TRUE
+3202066,62.28860059,34.32679584,1,Ghazali Badloo Scondary School,Herat,2,Enjil,1,Badloo Village,32,Building,2,2,0,TRUE
+3202067,62.24452484,34.3309318,1,Shaheed-E-Dashti High School,Herat,2,Enjil,1,Zaman Abad Village,32,Building,2,2,0,TRUE
+3202068,62.32493688,34.32899342,2,Tawah Beryan School,Herat,3,Enjil,1,Tawah Beryan Village,32,Building,2,4,1,TRUE
+3202069,61.96583211,34.36978379,2,Kashak Bad-E- Saba Mosque,Herat,3,Enjil,1,Kashak Bad-E-Saba Village,32,Building,2,3,0,TRUE
+3202070,62.03522137,34.35975468,2,Ab Jalil Mosque And School,Herat,3,Enjil,1,Aab Jalil Village,32,Village,2,3,0,TRUE
+3202071,62.15970892,34.34882105,3,Hauz Karbas Girls School,Herat,6,Enjil,3,Hauz Karbas Village,32,Building,2,8,0,TRUE
+3202072,62.05383911,34.42177409,1,Immigrants Office,Herat,2,Enjil,1,Maslakh Awal,32,Building,2,3,0,TRUE
+3202073,62.12937741,34.40209106,2,Eshaq Suliman High School,Herat,5,Enjil,3,Eshaq Suliman Village,32,Building,2,5,0,TRUE
+3202074,62.122491,34.38327766,2,Khwaja Mohammad Kohee Secondary School,Herat,3,Enjil,1,Shadi-E- Bara Ulya,32,Building,2,5,0,TRUE
+3202075,62.11305711,34.31517715,2,Mahal-E- Najoha School,Herat,3,Enjil,1,Maldan Village,32,Building,2,3,0,TRUE
+3202076,62.17819071,34.30095219,2,Marghaz Mosque,Herat,3,Enjil,1,Marghaz Village,32,Building,2,3,0,TRUE
+3202077,62.17282629,34.3075111,1,Khwaja Abdullah Ahrar Secondary School,Herat,2,Enjil,1,Bazdank Hasan Khan,32,Village,2,2,0,TRUE
+3202078,62.39698059,34.27960544,2,Shohada Secondary School,Herat,2,Enjil,0,Sar Hasan Khwaja Village,32,Building,2,2,0,TRUE
+3202079,62.39591845,34.27605539,0,Sar Hasan Khwaja Mosque,Herat,2,Enjil,2,Sar Hasan Khwaja Village,32,Building,2,2,0,TRUE
+3202080,62.12345029,34.29754944,2,Kabrzan School,Herat,3,Enjil,1,Kabrzan Village,32,Building,2,3,0,TRUE
+3202081,62.0389011,34.42035929,3,Maslakh Duowm School,Herat,6,Enjil,3,Maslakh Duwom,32,Building,2,6,0,TRUE
+3202434,62.12204893,34.30480207,2,Rubat-E-Srosetan Mosque,Herat,3,Enjil,1,Rubat-E-Srosetan Village,32,Building,2,3,0,TRUE
+3202435,62.17393135,34.37824217,3,Babaji High School,Herat,4,Enjil,1,Muhala Babaji 12Th Nahia Heart City,32,Building,2,5,0,TRUE
+3202436,62.09182335,34.35106025,2,Sofiyan High School (Amir Esmaeel High School,Herat,3,Enjil,1,Jalal Abad Village,32,Building,2,4,0,TRUE
+3202476,62.268337102,34.303141153,2,Chongar High School,Herat,3,Enjil,1,Chongar,32,Building,2,3,0,TRUE
+3203082,62.18267166,34.03400308,3,Primary School Deh Now,Herat,4,Guzara,1,Chashma Khani,32,Building,3,4,0,TRUE
+3203083,62.02258221,34.25198695,1,Deh Now Secondary School,Herat,2,Guzara,1,New Deh,32,Building,3,2,0,TRUE
+3203084,62.22867083,34.26192618,2,Khatamul Anbeya Madrassa,Herat,3,Guzara,1,Shahrak-E- Khatamul Anbeya,32,Building,3,4,1,TRUE
+3203085,62.2503928,34.24237372,1,Khwaja Shahab High School,Herat,2,Guzara,1,Feroz Abad Village,32,Building,3,4,0,TRUE
+3203086,62.22188498,34.25750354,5,Nasaji,Herat,5,Guzara,0,Gawashan Village (Markaz Guzara Awal),32,Building,3,5,0,TRUE
+3203087,62.21986274,34.24629746,0,Girls School,Herat,3,Guzara,3,Shokor Khani Village (Markazguzara Duwom),32,Building,3,3,0,TRUE
+3203088,62.31641613,34.23155671,3,Kort-E-Sufla Mosque,Herat,4,Guzara,1,Kort Sufla Village,32,Village,3,4,0,TRUE
+3203089,62.28791748,34.24109712,1,Char Kabotar Khan Mosque,Herat,2,Guzara,1,Char Kabotar Khan Village,32,Village,3,2,0,TRUE
+3203090,62.2789127,34.23385281,2,Khwaja Mohammad Kanjani High School,Herat,3,Guzara,1,Seyawshan Village,32,Building,3,3,0,TRUE
+3203091,62.18977716,34.2726788,2,Nagahan High School,Herat,3,Guzara,1,Nagahan Village,32,Building,3,4,1,TRUE
+3203092,62.1587102,34.26827944,2,Shamsudeen-E-Kort High School,Herat,3,Guzara,1,Goshmeer Village,32,Building,3,3,0,TRUE
+3203093,62.37684784,34.23288667,1,Neshin Bala School,Herat,2,Guzara,1,Neshin Bala Village,32,Building,3,2,0,TRUE
+3203094,62.33038142,34.2281095,2,Wahdat High School,Herat,3,Guzara,1,Kort Ulya Village,32,Building,3,3,0,TRUE
+3203095,62.15089527,34.21547677,2,Malan High School,Herat,3,Guzara,1,Malan Village,32,Building,3,3,0,TRUE
+3203096,62.13889395,34.19723143,3,Zeyarat Ja High School,Herat,4,Guzara,1,Zeyarat Ja,32,Building,3,5,0,TRUE
+3203097,62.41599342,34.25808601,3,Rubat Meerak Primary School,Herat,5,Guzara,2,Rubat Meerak Tufchi  Village,32,Building,3,5,0,TRUE
+3203098,62.43541147,34.24038359,2,Dadshan High School,Herat,3,Guzara,1,Dadshan Village,32,Building,3,3,0,TRUE
+3203099,62.10583545,34.21406119,1,Kofan High School,Herat,2,Guzara,1,Kofan Village,32,Building,3,3,1,TRUE
+3203100,62.09816097,34.24891859,1,Zangan Secondary School,Herat,2,Guzara,1,Zangan Village,32,Building,3,2,0,TRUE
+3203101,62.39859892,34.24203299,1,Kool Mosque,Herat,2,Guzara,1,Kool Village,32,Building,3,2,0,TRUE
+3203102,62.31667926,34.1267306,1,Rubat Safchi Primary School,Herat,2,Guzara,1,Rubat Safchi Village,32,Building,3,2,0,TRUE
+3203103,62.12261904,34.25041119,1,Tangharshan Scondary School,Herat,2,Guzara,1,Tangharshan Village,32,Building,3,2,0,TRUE
+3203104,62.0875,34.18621678,1,Kalata Khalil High School,Herat,2,Guzara,1,Kalata Khalil Village,32,Building,3,2,0,TRUE
+3203105,62.42061249,34.24089457,1,Bechqi Mosque,Herat,2,Guzara,1,Bechqi Village,32,Building,3,2,0,TRUE
+3203106,62.2199725,34.22814309,4,Wazir Fath Khan High School,Herat,6,Guzara,2,Mahalla-E- Baghaban Ha,32,Building,3,6,0,TRUE
+3203107,62.17602944,34.22583443,2,Amir Shahi High School,Herat,3,Guzara,1,Sar Asyab,32,Building,3,3,0,TRUE
+3203108,62.19339613,34.23725293,1,Murghaab Boys High School,Herat,2,Guzara,1,Murghaab,32,Building,3,2,0,TRUE
+3203109,62.04455404,34.22380087,1,Tezan Secondary School,Herat,2,Guzara,1,Tezan Village,32,Building,3,2,0,TRUE
+3203110,62.04265119,34.28207419,1,Farjai Primary School,Herat,2,Guzara,1,Farjai Village,32,Building,3,2,0,TRUE
+3203111,62.35865145,34.2509103,1,Kol Khurma Primary School,Herat,2,Guzara,1,Kal Khurma Village,32,Building,3,2,0,TRUE
+3203113,62.13933216,33.93282804,3,Gul Hazar  Primary School,Herat,4,Guzara,1,Gul Hazar,32,Village,3,4,0,TRUE
+3203114,62.13458523,34.09822959,1,Pusht-E- Koh Mullah Yasin Secondary School,Herat,2,Guzara,1,Pusht-E- Koh Mulla Yasin,32,Building,3,2,0,TRUE
+3203115,62.11716825,34.05696554,1,Kochis Location,Herat,2,Guzara,1,Khum Ziarat,32,District,3,0,2,FALSE
+3203116,61.654794549,34.025313986,2,Kochis Location,Herat,4,Guzara,2,Chah-E-Bulbul Village,32,Village,3,4,0,TRUE
+3203117,62.37629026,34.06038433,1,Kochis Location,Herat,2,Guzara,1,Gumbadi Village,32,Village,3,2,0,TRUE
+3203118,62.07791887,34.03959817,1,Kochis Location,Herat,2,Guzara,1,Sharb-E-Paeen Village,32,District,3,2,0,TRUE
+3203437,62.06482329,34.27707687,1,Kalata Mazreha Mosque,Herat,2,Guzara,1,Kalata Mazreha,32,Building,3,2,0,TRUE
+3203438,62.12360673,33.94678239,1,Nahistan School,Herat,2,Guzara,1,Nahistan,32,Village,3,2,0,TRUE
+3204148,62.58207601,34.49229039,5,Karrokh Primary School,Herat,7,Karrukh,2,Karrukh Center,32,Building,4,7,0,TRUE
+3204149,62.58693511,34.47670069,3,Sabz Posh Mosque,Herat,4,Karrukh,1,Paeen Muhala Karrukh,32,Building,4,4,0,TRUE
+3204150,62.63823804,34.51458666,2,Qala-E -Sharbat School,Herat,3,Karrukh,1,Qala-E- Sharbat Village,32,Building,4,3,0,TRUE
+3204151,62.55279255,34.45712157,2,Dahan Ghar School,Herat,3,Karrukh,1,Dahan Ghar,32,Building,4,3,0,TRUE
+3204152,62.48675251,34.45380215,2,Mujqandak School,Herat,3,Karrukh,1,Mujqandak Village,32,Building,4,3,0,TRUE
+3204153,62.48116607,34.50352369,2,Ali Abad School,Herat,3,Karrukh,1,Ali Abad,32,Building,4,3,0,TRUE
+3204154,62.69197092,34.43246173,1,Sanjoor School,Herat,2,Karrukh,1,Sanjoor Village,32,Building,4,2,0,TRUE
+3204155,62.41782183,34.49784458,1,Faliz Kar School,Herat,2,Karrukh,1,Nahistan Village,32,Building,4,2,0,TRUE
+3204156,62.71569897,34.48132639,1,Maluma School,Herat,2,Karrukh,1,Maluma Village,32,Building,4,2,0,TRUE
+3204157,62.444431,34.32182461,2,Janda Khan School,Herat,3,Karrukh,1,Janda Khan Village,32,Building,4,3,0,TRUE
+3204158,62.444844685,34.376802157,1,Islam Abad School,Herat,2,Karrukh,1,Islam Abad Village,32,Building,4,2,0,TRUE
+3204159,62.39578671,34.35810732,1,Pahlawan Peri Scondary School,Herat,2,Karrukh,1,Pahlawan Peri Village,32,Building,4,2,0,TRUE
+3204160,62.84089135,34.51827273,3,Mirzabahar School,Herat,5,Karrukh,2,Mirzabahar Villag,32,Building,4,5,0,TRUE
+3204161,62.92677726,34.51910858,2,Badamto School,Herat,4,Karrukh,2,Badamto Village,32,Building,4,4,0,TRUE
+3204162,62.68638225,34.4662848,1,Darakht-E-Toot School,Herat,2,Karrukh,1,Darakht-E- Toot Village,32,Village,4,2,0,TRUE
+3204163,62.3171772,34.54668731,1,Korpa School,Herat,3,Karrukh,2,Korpa Village,32,Building,4,3,0,TRUE
+3204164,63.0914111,34.57343081,2,Kochis Location,Herat,3,Karrukh,1,Mjid Chobi,32,Village,4,3,0,TRUE
+3204442,62.82926128,34.55537827,1,Armalaq School,Herat,2,Karrukh,1,Armalaq,32,Building,4,2,0,TRUE
+3205261,61.78434134,34.39056339,3,Abu Mansoor Shikeban School,Herat,4,Zendajan,1,Shikeban Marvi Awal,32,Building,5,4,0,TRUE
+3205262,61.77499319,34.37349386,2,Chardarah School,Herat,3,Zendajan,1,Shikeban Tajeki,32,Building,5,3,0,TRUE
+3205263,61.66592908,34.40498802,1,Jadah-E- Shadah School,Herat,3,Zendajan,2,Shadah Village,32,Building,5,3,0,TRUE
+3205264,61.68392987,34.39386062,2,Shaikh Abu Lais School,Herat,3,Zendajan,1,Ogha Village,32,Building,5,3,0,TRUE
+3205265,61.91125049,34.39240304,2,Deh Sorkh Primary School,Herat,3,Zendajan,1,Deh Sorkh,32,Building,5,3,0,TRUE
+3205266,61.98716513,34.28853284,2,Kabotar Khan School,Herat,3,Zendajan,1,Kabotar Khan,32,Building,5,3,0,TRUE
+3205267,61.94247169,34.4958157,1,Chashma-E- Ghori New Buiding,Herat,2,Zendajan,1,Chashma-E- Ghori,32,Village,5,2,0,TRUE
+3205268,62.02087019,34.56229856,2,Next To Clinic Building,Herat,4,Zendajan,2,Deh Karnail,32,Village,5,4,0,TRUE
+3205269,61.92164462,34.15200792,2,Pehrah School,Herat,3,Zendajan,1,Pehrah,32,Building,5,3,0,TRUE
+3205270,61.74732555,34.34258734,1,Fushanj  School,Herat,2,Zendajan,1,District Center,32,Village,5,2,0,TRUE
+3205271,61.75984896,34.33732772,2,Farm-E- Pelawari,Herat,2,Zendajan,0,Qala-E- Rig,32,Village,5,2,0,TRUE
+3205272,61.76787065,34.33691066,0,Amir Maawia Primary School,Herat,3,Zendajan,3,Qala-E Rig,32,Building,5,3,0,TRUE
+3205273,61.73351925,34.34640806,2,Qalae Now Mosque,Herat,3,Zendajan,1,Qala-E- Now Sar Mazar,32,Village,5,3,0,TRUE
+3205274,61.71669398,34.33497548,2,Mulkiha New School,Herat,3,Zendajan,1,Mulkiha,32,Building,5,3,0,TRUE
+3205457,61.88833484,34.03088628,1,Kariz Pada Clinic,Herat,2,Zendajan,1,Kariz Pada Village,32,Building,5,0,2,FALSE
+3205458,61.73714254,34.3294849,1,Mahala-E- Khwajaha School,Herat,3,Zendajan,2,Mahala-E- Khwaja Ha-E-Dasht,32,Building,5,3,0,TRUE
+3205477,61.782366723,34.200256061,2,Cultural Asosiation,Herat,3,Zendajan,1,Sang Tarqida,32,Building,5,0,3,FALSE
+3205478,61.953641118,34.352589685,2,Qala Yadgar School,Herat,3,Zendajan,1,Yadgar,32,Building,5,3,0,TRUE
+3206119,62.69141857,34.22748282,4,Gim Central High School,Herat,6,Pashtun Zarghun,2,Gim Village,32,Building,6,6,0,TRUE
+3206120,62.66974257,34.23370899,2,Dogh Abad Mosque,Herat,3,Pashtun Zarghun,1,Dogh Abad Village,32,Building,6,3,0,TRUE
+3206121,62.72396592,34.2390319,2,Band Abad Secodary School,Herat,3,Pashtun Zarghun,1,Band Abad Village,32,Village,6,3,0,TRUE
+3206122,62.7517183,34.24187398,2,Bazyan Mosque,Herat,2,Pashtun Zarghun,0,Bazyan Village,32,Village,6,2,0,TRUE
+3206123,62.75211458,34.24002335,0,Bazyan School,Herat,2,Pashtun Zarghun,2,Bazyan Village,32,Village,6,2,0,TRUE
+3206124,62.78365503,34.23709108,2,Pushkan Awal School,Herat,3,Pashtun Zarghun,1,Pushkan Awal,32,Village,6,3,0,TRUE
+3206125,62.80726072,34.23853407,1,Pushkan Duowm School,Herat,2,Pashtun Zarghun,1,Pushkan Duowm,32,Village,6,2,0,TRUE
+3206126,62.62744268,34.24840463,3,Mamora Mosque,Herat,4,Pashtun Zarghun,1,Mahmura Village,32,Building,6,4,0,TRUE
+3206128,62.62732016,34.22481174,3,Shah Abad School,Herat,5,Pashtun Zarghun,2,Shad Abad Village,32,Building,6,5,0,TRUE
+3206129,62.59203992,34.2180142,2,Gul Meer High School,Herat,3,Pashtun Zarghun,1,Gul Meer Village,32,Village,6,3,0,TRUE
+3206130,62.51480744,34.2663252,1,Saraab School,Herat,2,Pashtun Zarghun,1,Saraab Village,32,Building,6,2,0,TRUE
+3206131,62.49891464,34.25698644,1,Salimi School,Herat,2,Pashtun Zarghun,1,Salimi Village,32,Building,6,2,0,TRUE
+3206132,62.46315438,34.25318802,2,Buka School,Herat,3,Pashtun Zarghun,1,Buka Village,32,Building,6,3,0,TRUE
+3206133,62.86732867,34.22681341,2,Cheorshi Mosque,Herat,2,Pashtun Zarghun,0,Cheorshi Village,32,Village,6,2,0,TRUE
+3206134,62.86712427,34.22586619,0,Cheorshi School,Herat,2,Pashtun Zarghun,2,Cheorshi Village,32,Village,6,2,0,TRUE
+3206135,62.95633057,34.24369612,1,Dasht-E- Naizan School,Herat,3,Pashtun Zarghun,2,Dasht-E- Naizan Village,32,Village,6,3,0,TRUE
+3206136,62.54995797,34.24653797,2,Manzil School,Herat,3,Pashtun Zarghun,1,Manzel Vilage,32,Building,6,3,0,TRUE
+3206137,62.46391743,34.29302796,1,Ghooran School,Herat,2,Pashtun Zarghun,1,Ghooran,32,Building,6,2,0,TRUE
+3206138,62.88819884,34.25613486,3,Mar Abad Secondary School,Herat,5,Pashtun Zarghun,2,Mar Abad Village,32,Building,6,5,0,TRUE
+3206140,62.56182236,34.30932494,1,Turan School,Herat,2,Pashtun Zarghun,1,Turan Village,32,Building,6,2,0,TRUE
+3206141,62.66137791,34.29268952,1,Gushak Mosque,Herat,2,Pashtun Zarghun,1,Goshak Village,32,Building,6,2,0,TRUE
+3206142,62.94805859,34.08819902,1,Taqcha School,Herat,2,Pashtun Zarghun,1,Taqcha Village,32,Village,6,2,0,TRUE
+3206143,62.51803115,34.30594526,1,Tunion School,Herat,2,Pashtun Zarghun,1,Tunion Village,32,Building,6,2,0,TRUE
+3206144,62.86863498,34.24660603,1,Boreya Baf School,Herat,2,Pashtun Zarghun,1,Boreya Baf Village,32,Village,6,2,0,TRUE
+3206145,62.73815808,34.1489341,1,Karo Mosque,Herat,2,Pashtun Zarghun,1,Karo Village,32,Building,6,2,0,TRUE
+3206146,62.63639957,34.15064701,1,Khesrow Mosque,Herat,2,Pashtun Zarghun,1,Khesrow Village,32,Building,6,2,0,TRUE
+3206147,62.60527304,33.98149631,2,Clinic And Mosque,Herat,3,Pashtun Zarghun,1,Aabgarmi Village,32,Village,6,3,0,TRUE
+3206439,62.82146431,34.30713044,1,Khwaja Mohammad Ustad School,Herat,2,Pashtun Zarghun,1,Khwaja Mohammad Ustad Village,32,Building,6,0,2,FALSE
+3206440,62.67946927,34.24700866,1,Kashak Sairwan Primary School,Herat,2,Pashtun Zarghun,1,Sairawan,32,Building,6,2,0,TRUE
+3206441,62.54797853,34.22174142,1,Deh Shaikh Mosque,Herat,2,Pashtun Zarghun,1,Deh Shaikh,32,Village,6,2,0,TRUE
+3207165,62.13663075,34.79866203,3,Kashak Rubat Sangi Awal  Center Mosque,Herat,4,Kushk (Rubat-E-Sangi),1,Markaz-E-Kashak Rubat Sang Awal,32,Building,7,4,0,TRUE
+3207166,62.13610507,34.79716161,1,Kashak Rubat Sangi Duowm Girls High School,Herat,4,Kushk (Rubat-E-Sangi),3,Markaz-E-Kashak Rubat  Sang Duowm,32,Building,7,4,0,TRUE
+3207167,62.19283314,34.77177716,1,Khwaja Malal School,Herat,2,Kushk (Rubat-E-Sangi),1,Khwaja Malal Village,32,Building,7,2,0,TRUE
+3207168,62.05546492,34.72348396,2,Chahar Aolang School,Herat,3,Kushk (Rubat-E-Sangi),1,Chahar Aolang Village,32,Building,7,3,0,TRUE
+3207169,62.331693675,34.885918317,1,Oqabi School,Herat,2,Kushk (Rubat-E-Sangi),1,Oqabi Village,32,Building,7,2,0,TRUE
+3207170,62.23070706,34.77713982,1,Baghcha School,Herat,2,Kushk (Rubat-E-Sangi),1,Baghcha Village,32,Village,7,2,0,TRUE
+3207171,62.2375655,34.8722725,2,Yaka Darakht School And Mosque,Herat,3,Kushk (Rubat-E-Sangi),1,Yaka Darakht Village,32,Building,7,3,0,TRUE
+3207172,62.09193639,34.90016819,3,Hafto School,Herat,4,Kushk (Rubat-E-Sangi),1,Hafto Sofla Village,32,Building,7,4,0,TRUE
+3207173,62.1622113,34.9121292,2,Doghi Mosque,Herat,2,Kushk (Rubat-E-Sangi),0,Deh Zuri Awal Village,32,Building,7,2,0,TRUE
+3207174,62.16356194,34.89908789,0,Doghi School,Herat,2,Kushk (Rubat-E-Sangi),2,Deh Zuri Duowm Village,32,Building,7,2,0,TRUE
+3207176,62.38909444,34.83901944,1,Lak Lak Khana School,Herat,2,Kushk (Rubat-E-Sangi),1,Lak Lak Khana,32,Building,7,2,0,TRUE
+3207177,62.19177671,34.97750289,2,Doghi Qanat Wakil School,Herat,3,Kushk (Rubat-E-Sangi),1,Doghi Qanat Wakil Village,32,Building,7,3,0,TRUE
+3207178,62.11325449,34.99851617,2,Kariz Now School,Herat,3,Kushk (Rubat-E-Sangi),1,Kariz Now,32,Building,7,3,0,TRUE
+3207179,62.29075891,34.76533317,2,Khaleefa Rahmat School,Herat,3,Kushk (Rubat-E-Sangi),1,Khaleefa Rahmat Village,32,Building,7,3,0,TRUE
+3207181,62.04515476,34.83357339,1,Qala-E- Safed Ayoubi Mosque,Herat,2,Kushk (Rubat-E-Sangi),1,Qala -E- Safid Ayoubi,32,Building,7,2,0,TRUE
+3207182,62.19792452,35.09871169,2,Chapqal School,Herat,4,Kushk (Rubat-E-Sangi),2,Chapqal,32,Village,7,4,0,TRUE
+3207183,62.32819272,34.7301008,2,Jafar Big Kawdani School,Herat,3,Kushk (Rubat-E-Sangi),1,Jafar Big Kawdani  Village,32,Building,7,3,0,TRUE
+3207184,62.23636111,35.04583333,2,Khalawakha School,Herat,3,Kushk (Rubat-E-Sangi),1,Khalawakha-E-Ulya And Sufla Village,32,Building,7,3,0,TRUE
+3207186,62.08256024,34.80783749,2,Khwaja Qasem School,Herat,3,Kushk (Rubat-E-Sangi),1,Khwaja Qasem Village,32,Building,7,3,0,TRUE
+3207187,62.387827591,34.722380235,2,Khwaja Noor School,Herat,4,Kushk (Rubat-E-Sangi),2,Khwaja Noor Village,32,Village,7,4,0,TRUE
+3207188,62.23642445,34.92929974,2,Shirwayee School,Herat,2,Kushk (Rubat-E-Sangi),0,Shirwani Village,32,Building,7,2,0,TRUE
+3207189,62.28310942,35.24395437,4,Torghandi Awal School,Herat,4,Kushk (Rubat-E-Sangi),0,Shahrak Torghondi,32,Building,7,4,0,TRUE
+3207190,62.28299744,35.24395188,0,Girls High School,Herat,4,Kushk (Rubat-E-Sangi),4,Shahrak Torghondi,32,Building,7,4,0,TRUE
+3207191,62.19081016,35.18631321,2,Barjenak School,Herat,3,Kushk (Rubat-E-Sangi),1,Barjenak Village,32,Building,7,3,0,TRUE
+3207192,62.32312078,35.09574112,2,Yakatoot School,Herat,3,Kushk (Rubat-E-Sangi),1,Yakatoot Village,32,Village,7,3,0,TRUE
+3207193,62.30364166,35.12015833,5,Tamer Hamam Chel Dukhtar Awal,Herat,5,Kushk (Rubat-E-Sangi),0,Chehl Dokhtar Ulya,32,Building,7,5,0,TRUE
+3207194,62.30583333,35.11873888,0,Chel Dukhtar Duowm Mosque,Herat,2,Kushk (Rubat-E-Sangi),2,Chel Dukhtar Duowm,32,Building,7,2,0,TRUE
+3207445,62.39863982,34.81519912,2,Haqaba Asadi School,Herat,3,Kushk (Rubat-E-Sangi),1,Huqaba Asadi,32,Village,7,3,0,TRUE
+3207446,62.10002979,35.07578682,1,Muqoor Mosque,Herat,2,Kushk (Rubat-E-Sangi),1,Sar Chushma Muqoor,32,Village,7,2,0,TRUE
+3207479,62.332258871,34.775884096,2,School,Herat,3,Kushk (Rubat-E-Sangi),1,Jafar Big Khurasani,32,Building,7,3,0,TRUE
+3208196,61.77532915,34.93841678,5,Qarabagh Primary School,Herat,6,Gulran,1,Bazar Qarabagh,32,Building,8,6,0,TRUE
+3208197,61.68641929,34.92568582,2,Asyab Deu Mosque,Herat,3,Gulran,1,Asyab Deu Village,32,Village,8,3,0,TRUE
+3208198,61.68544184,35.09788233,3,Gulran Khawgiani Clinic,Herat,5,Gulran,2,Gulran Khawgiani,32,Village,8,0,5,FALSE
+3208199,61.5225971,35.10507208,2,Nehrab Mosque,Herat,3,Gulran,1,Nehrab,32,Building,8,0,3,FALSE
+3208200,61.9703842,34.84567131,2,Qashawari Primari School,Herat,3,Gulran,1,Qashawari Ulya,32,Building,8,3,0,TRUE
+3208202,61.48849991,35.27982619,2,Seya Kamarak Primary School,Herat,3,Gulran,1,Seya Kamarak,32,Village,8,3,0,TRUE
+3208203,61.33979838,35.25461542,1,Kariz-E- Sam Mosque,Herat,3,Gulran,2,Kariz Sam,32,Village,8,3,0,TRUE
+3208204,61.37021172,35.34657003,2,Kalatah Mosque,Herat,3,Gulran,1,Kalata Village,32,Village,8,3,0,TRUE
+3208205,61.34292269,35.42386406,2,Kariz-E- Elyas Clinic,Herat,4,Gulran,2,Kariz Elyas,32,Village,8,4,0,TRUE
+3208209,61.5790027,35.33027556,2,Chah-E- Kehsani Mosque,Herat,3,Gulran,1,Chah-E-Kasani,32,Village,8,3,0,TRUE
+3208210,61.9294413,34.99570652,2,Tootchi Primary School,Herat,5,Gulran,3,Tootechi,32,Village,8,5,0,TRUE
+3208211,61.81413403,34.87129645,1,Buzan Ulya Mosque,Herat,2,Gulran,1,Bazan,32,Building,8,2,0,TRUE
+3208212,61.29799102,35.38715946,2,Dashak Mosque,Herat,3,Gulran,1,Dashak,32,Village,8,3,0,TRUE
+3208213,61.34897533,35.36781529,1,Karez E Kuhna Mosque,Herat,2,Gulran,1,Karez E Kuhna,32,Village,8,2,0,TRUE
+3208214,61.38956866,35.24570597,2,Darakht-E- Toot  Mosque,Herat,3,Gulran,1,Darakht-E- Tot,32,Village,8,3,0,TRUE
+3208215,61.45840079,35.33466233,1,Lahrab Clinic,Herat,2,Gulran,1,Lahrab,32,Village,8,2,0,TRUE
+3208217,61.72258666,34.90709158,2,Maishmast School,Herat,3,Gulran,1,Maishmast,32,Building,8,3,0,TRUE
+3208220,61.75611832,34.89393911,2,Zeeragee Kalan School,Herat,3,Gulran,1,Zeeragee Kalan,32,Building,8,3,0,TRUE
+3208221,61.8546362,34.80795039,2,Shakar Aab Mosque,Herat,3,Gulran,1,Shakar Aab,32,Building,8,3,0,TRUE
+3208222,61.91605518,34.7839303,2,Sang-E -Kotal-E- Afzal Mosque,Herat,3,Gulran,1,Sang-E- Kotal-E- Afzal Village,32,Village,8,3,0,TRUE
+3208223,61.84031364,34.72381552,2,Khwaja Mohammad Shorab Mosque,Herat,3,Gulran,1,Khwaja Mohammad Shorab,32,Village,8,3,0,TRUE
+3208224,61.63138501,35.06939589,1,Rig Abad Mosque,Herat,2,Gulran,1,Rig Aab Village,32,Village,8,2,0,TRUE
+3208225,61.6082023,34.9660933,2,Aab -E -Safed Mosque,Herat,3,Gulran,1,Aab -E- Safed Village,32,Village,8,3,0,TRUE
+3208227,61.38591346,35.49255176,1,Chah Galgal Mosque,Herat,2,Gulran,1,Chah Galgal Village,32,Village,8,2,0,TRUE
+3208228,61.87407255,34.85103498,1,Kochis Location,Herat,2,Gulran,1,Rubat Sargaradan,32,Village,8,2,0,TRUE
+3209275,62.2668806,33.64391049,3,District Center High School,Herat,5,Adraskan,2,Adreskan District Center,32,Building,9,5,0,TRUE
+3209276,62.24857563,33.62144011,2,Deh Sabz Primary School,Herat,3,Adraskan,1,Deh Sabz Village,32,Building,9,3,0,TRUE
+3209277,62.51505994,33.65592073,2,Ghori Mosque,Herat,3,Adraskan,1,Ghori Village,32,Village,9,3,0,TRUE
+3209278,62.25050693,33.77120547,2,Mir Ali Scondary School,Herat,3,Adraskan,1,Mir Ali Village,32,Building,9,3,0,TRUE
+3209279,62.15869027,33.5590239,2,Zulm Abad Secondary School,Herat,3,Adraskan,1,Zulm Abad Village,32,Building,9,3,0,TRUE
+3209280,61.83983392,33.63642169,2,Tirgerd Primary School,Herat,4,Adraskan,2,Tirgerd Village,32,Building,9,4,0,TRUE
+3209281,62.63028358,33.80692753,1,Kartoon Mosque,Herat,2,Adraskan,1,Kartoon,32,Building,9,0,2,FALSE
+3209282,62.72726228,33.50333541,1,Hamsh Afghani Mosque,Herat,2,Adraskan,1,Hamsh Village,32,Village,9,2,0,TRUE
+3209284,62.34963224,33.82777758,1,Jahan Khan Mosque,Herat,2,Adraskan,1,Jahan Khan,32,Building,9,2,0,TRUE
+3209285,62.66633807,33.62056893,2,Kharbed-E- Mir Abad School,Herat,3,Adraskan,1,Mir Abad,32,Building,9,3,0,TRUE
+3209286,62.40014251,33.50753696,1,Nigl Mosque,Herat,2,Adraskan,1,Nigl,32,Building,9,2,0,TRUE
+3209287,62.86699649,33.6023543,1,Shirzad Mosque,Herat,2,Adraskan,1,Shirzad Village,32,Building,9,2,0,TRUE
+3209288,62.89822923,33.663515,1,Takhab Mosque,Herat,2,Adraskan,1,Takhab,32,Building,9,2,0,TRUE
+3209289,62.51752147,33.67438807,1,Zuhrak Mosque,Herat,3,Adraskan,2,Zuhrak Village,32,Building,9,3,0,TRUE
+3209290,62.65135043,33.6871374,1,Tazrbed Secondary School,Herat,2,Adraskan,1,Tazrbed Villag,32,Building,9,2,0,TRUE
+3209291,62.74181846,33.73254257,1,Karocha Scondary School,Herat,2,Adraskan,1,Karocha,32,Building,9,0,2,FALSE
+3209292,62.275976,33.73633634,1,Chahar Sang Mosque,Herat,3,Adraskan,2,Chahar Sang,32,Building,9,0,3,FALSE
+3209293,61.71048228,33.68685623,1,Tanoora Mosque,Herat,2,Adraskan,1,Tanoorah,32,Building,9,2,0,TRUE
+3209294,62.02672584,33.6352428,1,Chahe Surkhak Mosque,Herat,2,Adraskan,1,Chahe Surkhak,32,Building,9,2,0,TRUE
+3209295,62.5514087,33.58425811,1,Chenar Mosque,Herat,2,Adraskan,1,Chenar Village,32,Building,9,0,2,FALSE
+3209297,63.05150017,33.8195329,1,Gallah-E- Chashmah Tent,Herat,2,Adraskan,1,Gallah Chashmah Village,32,Building,9,0,2,FALSE
+3209459,62.28830146,33.63256596,1,Kharchan Qala Primary School,Herat,2,Adraskan,1,Kharchan Qalaa,32,Building,9,2,0,TRUE
+3209460,62.65230587,33.54018763,2,Deh Khar Mosque,Herat,3,Adraskan,1,Deh Khar,32,Village,9,3,0,TRUE
+3209461,62.96949323,33.62232652,1,Qala-E- Mullah Ata Mosque,Herat,2,Adraskan,1,Qala-E- Mullah Ata,32,Building,9,2,0,TRUE
+3209462,62.40139748,33.88895627,1,Zard Alogak Mosque,Herat,2,Adraskan,1,Zard Alogak,32,Village,9,2,0,TRUE
+3209463,61.37585892,33.78645091,1,Kaftari Mosque,Herat,2,Adraskan,1,Kaftari,32,Village,9,0,2,FALSE
+3209480,62.747193388,33.562436311,2,Dara Bast Mosque,Herat,3,Adraskan,1,Dara Bast,32,Building,9,0,3,FALSE
+3209481,62.279589632,33.700584273,2,Kal Yak Paia Promary School,Herat,3,Adraskan,1,Kal Yak Paia,32,Building,9,3,0,TRUE
+3209482,61.920265068,33.625524775,2,Ghulam Kushta Mosque,Herat,3,Adraskan,1,Ghulam Kushta,32,Building,9,3,0,TRUE
+3210405,62.50819404,34.87151377,6,Bazar-E- Kuhna Mosque,Herat,7,Kushk-E-Kuhna,1,Bazar-E- Kuhna,32,Building,10,7,0,TRUE
+3210406,62.56035514,34.85037823,3,Kaklam Awal Scondary School,Herat,3,Kushk-E-Kuhna,0,District Center,32,Building,10,3,0,TRUE
+3210407,62.56135058,34.85056564,0,Kakalam Duowm Girls Secondary School,Herat,2,Kushk-E-Kuhna,2,Second Kaklam,32,Building,10,2,0,TRUE
+3210409,62.48242571,34.8177978,3,Kariz-E- Zaman /Mardana Mosque,Herat,3,Kushk-E-Kuhna,0,Kariz-E-Zaman Village,32,Village,10,3,0,TRUE
+3210410,62.47632614,34.80938536,0,Kariz-E- Zaman /Zanana Paheen Mosque,Herat,2,Kushk-E-Kuhna,2,Kariz-E-Zaman Village,32,Village,10,2,0,TRUE
+3210412,62.53364526,34.7946285,2,Joy-E-Sultani Secondary School,Herat,3,Kushk-E-Kuhna,1,Joy-E- Sultani Village,32,Building,10,3,0,TRUE
+3210414,62.64943497,34.88183403,2,Muhammad Abad Cheshma Khafi Mosque(Male),Herat,2,Kushk-E-Kuhna,0,Chashma-E- Khafi Village,32,Building,10,2,0,TRUE
+3210415,62.6489525,34.83097213,0,Muhammad Abad Cheshma Khafi Mosque(Female),Herat,2,Kushk-E-Kuhna,2,Chashma-E- Khafi Village,32,Village,10,2,0,TRUE
+3210417,62.65692785,34.78444798,2,Khwaja Qalandar School,Herat,3,Kushk-E-Kuhna,1,Khwaja Qalandar,32,Building,10,3,0,TRUE
+3210418,62.70055048,34.81017164,2,Zenda Hashm School,Herat,3,Kushk-E-Kuhna,1,Zenda Hashm Village,32,Building,10,3,0,TRUE
+3210419,62.60132598,34.75132006,3,Khwaja Shahab Mosque,Herat,5,Kushk-E-Kuhna,2,Khwaja Shahab,32,Building,10,5,0,TRUE
+3210421,62.77996648,34.74756592,2,Galla Chaghar Mardana- Mosque,Herat,2,Kushk-E-Kuhna,0,Galla Chaghar Village,32,Building,10,2,0,TRUE
+3210422,62.77784887,34.74678328,0,Galla Chaghar Paheen Zananah- Mosque,Herat,2,Kushk-E-Kuhna,2,Galla Chaghar Village,32,Building,10,2,0,TRUE
+3210423,62.75171565,34.85568178,3,Nazdik-E- Chah  Khwaja Alkhand School,Herat,5,Kushk-E-Kuhna,2,Khwaja Alkhand,32,Building,10,5,0,TRUE
+3211245,61.49113729,34.34719746,4,Girls School,Herat,5,Ghoryan,1,District Center Hospitol Road,32,Building,11,5,0,TRUE
+3211246,61.47523589,34.34113633,2,Ghanjan Mosque,Herat,3,Ghoryan,1,Ghanjan Center,32,Building,11,3,0,TRUE
+3211247,61.47061381,34.37816799,2,Astanan Primary School,Herat,4,Ghoryan,2,Astanan Village Near Main Road,32,Building,11,4,0,TRUE
+3211248,61.53156568,34.35347529,2,Gandummna Mosque,Herat,3,Ghoryan,1,Gandummna,32,Building,11,3,0,TRUE
+3211249,61.59431424,34.38533176,0,Barna Abad Zanana Girls School,Herat,3,Ghoryan,3,Barnabad Village,32,Building,11,3,0,TRUE
+3211250,61.58965297,34.38162321,2,Barna Abad Mardana Mosque,Herat,2,Ghoryan,0,Barnabad Village,32,Building,11,2,0,TRUE
+3211251,61.56776872,34.41044127,2,Rooj  Mosque,Herat,3,Ghoryan,1,Rooj Village,32,Building,11,3,0,TRUE
+3211252,61.52789287,34.41739583,2,Sabool  Mosque,Herat,3,Ghoryan,1,Sabool Village,32,Building,11,3,0,TRUE
+3211253,61.45716032,34.4204852,2,Roshnan  Mosque,Herat,3,Ghoryan,1,Roshnan Village,32,Building,11,3,0,TRUE
+3211254,61.44119407,34.43327241,2,Zangi Sabah Mosque,Herat,4,Ghoryan,2,Zangi Sabah Village,32,Village,11,4,0,TRUE
+3211255,61.39102211,34.49565368,2,Shabesh School,Herat,3,Ghoryan,1,Shabesh Village,32,Building,11,3,0,TRUE
+3211256,61.49499258,34.34615218,3,Wazir Akbar Khan School,Herat,6,Ghoryan,3,Scond District Center,32,Building,11,6,0,TRUE
+3211257,61.50355861,34.34598678,3,Qaisan Mosque,Herat,4,Ghoryan,1,Mahal-E- Faqedan,32,Building,11,4,0,TRUE
+3211259,60.91623646,34.50762557,2,Chahe Rig Mosque,Herat,4,Ghoryan,2,Markaz-E-Chahe Rig Village,32,Village,11,4,0,TRUE
+3211451,61.06019189,34.2797211,2,Chashma-E- Dam Tent,Herat,3,Ghoryan,1,Chushma-E -Dam,32,Building,11,3,0,TRUE
+3211452,61.46092686,34.32651616,2,Balochs Tent,Herat,3,Ghoryan,1,Balochs Village,32,Village,11,3,0,TRUE
+3211453,61.59068994,34.36766928,1,Now Abad School,Herat,2,Ghoryan,1,Barna Bad,32,Village,11,2,0,TRUE
+3211454,61.48741122,34.33160095,1,Mawlawe Seraj Mosque,Herat,2,Ghoryan,1,Mahal-E- Taheryan,32,Village,11,2,0,TRUE
+3211455,61.515257945,34.338407961,1,Abdullah Khan Mosque,Herat,2,Ghoryan,1,Yakhdan,32,Building,11,2,0,TRUE
+3211456,61.47871013,34.3447002,1,Sar Asia Mosque,Herat,3,Ghoryan,2,Markaz-E-Sar Asia,32,Building,11,3,0,TRUE
+3212365,63.17585974,34.36984989,4,Markaz-E-Oba High School,Herat,6,Obe,2,Markaz-E-Oba Char Mahal,32,Village,12,6,0,TRUE
+3212366,63.20500292,34.37681999,2,Band-E- Benafsh School,Herat,2,Obe,0,Band-E- Benafsh Village,32,Village,12,2,0,TRUE
+3212367,63.2047082,34.37569006,0,Band-E-Benafsh Girls School,Herat,2,Obe,2,Band-E-Benafsh Village,32,Village,12,2,0,TRUE
+3212368,63.06754243,34.32299458,1,Saberah School,Herat,2,Obe,1,Sabera Dasht Village,32,Building,12,2,0,TRUE
+3212369,63.14852707,34.34272248,2,Musafran Mosque,Herat,3,Obe,1,Musafran,32,Village,12,3,0,TRUE
+3212370,63.35765172,34.37474205,2,Kar Ghawz Mosque,Herat,3,Obe,1,Kar Ghawz,32,Building,12,3,0,TRUE
+3212371,63.42095555,34.38457777,2,Jenowa Boys School,Herat,2,Obe,0,Jenowa Village,32,Building,12,2,0,TRUE
+3212372,63.42060021,34.38374217,0,Jenowa Jaded Girls School,Herat,2,Obe,2,Jenowa Village,32,Village,12,2,0,TRUE
+3212374,63.17450726,34.37623516,2,Markaz-E-Obe Duowm Girls School,Herat,3,Obe,1,Markaz-E- Obah Duowm,32,Building,12,3,0,TRUE
+3212376,63.24147262,34.27624227,3,Posht-E- Paji Mosque,Herat,5,Obe,2,Posht-E- Paji,32,Village,12,5,0,TRUE
+3212377,63.05783067,34.28907849,3,Sarwan School,Herat,5,Obe,2,Sarwan Village,32,Building,12,5,0,TRUE
+3212378,63.020466,34.26332354,2,Karshak Mardanah Mosque,Herat,2,Obe,0,Karshak Village,32,Building,12,2,0,TRUE
+3212379,63.02070843,34.26386569,0,Karshak Zanana Mosque,Herat,2,Obe,2,Karshak Zananah,32,Building,12,2,0,TRUE
+3212380,62.965517072,34.27236718,2,Rubat-E- Akhuod Boys School,Herat,2,Obe,0,Rubat-E- Akhond Village,32,Village,12,2,0,TRUE
+3212381,62.960740355,34.269616904,0,Rubat-E-Akhond Zanana Girls School,Herat,2,Obe,2,Rubat-E- Akhond Village,32,Village,12,2,0,TRUE
+3212382,62.99349364,34.27262512,3,Chenaran Boys School,Herat,3,Obe,0,Chenaran Village,32,Building,12,3,0,TRUE
+3212383,62.99099269,34.26087903,0,Chenarana Girls School,Herat,3,Obe,3,Chenaran Village,32,Building,12,3,0,TRUE
+3212384,63.2523041,34.36589527,2,Nab Boys School,Herat,3,Obe,1,Nab,32,Village,12,3,0,TRUE
+3212385,63.27873144,34.46521454,2,Tagab Mahi Mosque,Herat,3,Obe,1,Takab Mahi,32,Village,12,3,0,TRUE
+3212386,63.47561507,34.50332398,2,Deh Gahee Mosque,Herat,2,Obe,0,Deh Gahee Mardanah,32,Village,12,2,0,TRUE
+3212387,63.48067713,34.50224467,0,Dawawm Mosque,Herat,2,Obe,2,Deh Gahee Zananah,32,Village,12,2,0,TRUE
+3212388,63.26867601,34.36447389,1,Sara Pardah School,Herat,2,Obe,1,Sara Pardah,32,Village,12,2,0,TRUE
+3212468,63.12044992,34.3239103,1,Abdulrahim Khan Mosque,Herat,2,Obe,1,Gunah Abad,32,Village,12,2,0,TRUE
+3213230,61.19986264,34.65804204,5,Kahsan High School,Herat,8,Kohsan,3,Markaz-E-Kahsan,32,Building,13,8,0,TRUE
+3213231,61.11366572,34.66191207,2,Qodoos Abad Mosque,Herat,4,Kohsan,2,Qodoos Abad-E- Awal,32,Building,13,4,0,TRUE
+3213232,61.09388579,34.79808168,2,Qazal Islam Scondary School,Herat,3,Kohsan,1,Qazal Islam,32,Building,13,3,0,TRUE
+3213233,61.11466064,34.65673672,2,Qodos Abad-E- Dowom School,Herat,4,Kohsan,2,Qodoos Abad-E-Duowm,32,Building,13,4,0,TRUE
+3213234,61.09543778,34.71262033,2,Kalata Qazi Primary School,Herat,3,Kohsan,1,Kalat-E- Qazi,32,Building,13,3,0,TRUE
+3213235,61.31135433,34.80504769,1,Bay Mohammad Primary School,Herat,3,Kohsan,2,Bay Mohammad,32,Building,13,3,0,TRUE
+3213236,61.0886774,34.67090116,4,Islam Qala Secondary School,Herat,7,Kohsan,3,Islam Qala,32,Building,13,7,0,TRUE
+3213237,61.32219273,34.56594084,1,Ahmad Abad Primary School,Herat,3,Kohsan,2,Ahmad Abad,32,Building,13,3,0,TRUE
+3213238,61.09678222,34.7127424,2,Bunyad Primary School,Herat,4,Kohsan,2,Bunyad Village,32,Village,13,4,0,TRUE
+3213239,61.134080919,35.049221143,1,Kamana Primary School,Herat,3,Kohsan,2,Kamana,32,Building,13,3,0,TRUE
+3213240,61.15635637,34.66653289,2,Tukhum Village Mosque,Herat,3,Kohsan,1,Takhum Village,32,Building,13,3,0,TRUE
+3213242,61.22437925,34.63873188,1,Qala-E- Sardar Primary School,Herat,2,Kohsan,1,Qala-E-Sardar,32,Village,13,2,0,TRUE
+3213243,61.11542084,34.74304996,1,Mustafa Big Primary School,Herat,3,Kohsan,2,Mustafa Big,32,Village,13,3,0,TRUE
+3213244,61.19644426,34.58210455,1,Kochis Location,Herat,2,Kohsan,1,Chah-E-Zaiedi,32,District,13,2,0,TRUE
+3213447,61.07770633,34.76693763,2,Naeeb Ghafoor Mosqu,Herat,3,Kohsan,1,Naeeb Ghafoor,32,Village,13,3,0,TRUE
+3213449,61.57604615,34.88376837,1,Naiyak Tent,Herat,2,Kohsan,1,Naiyak,32,Village,13,0,2,FALSE
+3214298,62.15668277,33.30415102,6,Markaz-E-Sharwaly,Herat,6,Shindand,0,Takht-E- Bazar,32,Building,14,6,0,TRUE
+3214299,62.16068026,33.30745547,0,Public Health,Herat,5,Shindand,5,Takht-E-Bazar,32,Building,14,5,0,TRUE
+3214300,62.21054,33.228891,3,Mir Sadat Girls School,Herat,5,Shindand,2,Mir Sadat,32,Building,14,5,0,TRUE
+3214301,62.14273845,33.30640805,4,Qandiz Qademi Mosque,Herat,5,Shindand,1,Qandiz,32,Building,14,5,0,TRUE
+3214302,62.13769509,33.30987171,2,Qandiz Qademi Duowm Mosque,Herat,3,Shindand,1,Qandiz Duowm,32,Building,14,3,0,TRUE
+3214303,62.14227703,33.29982387,2,Khatib Naseer Abadi Mosque,Herat,4,Shindand,2,Naseer Abad,32,Building,14,4,0,TRUE
+3214304,62.15973369,33.34520026,4,Shur Abad School,Herat,5,Shindand,1,Shur Abad,32,Building,14,5,0,TRUE
+3214305,62.15030587,33.3457396,1,Ibrahim Khan Mosque,Herat,2,Shindand,1,Posht-E-Shahr,32,Building,14,2,0,TRUE
+3214306,62.16508415,33.29814327,1,Kuhna Sang School,Herat,2,Shindand,1,Kuhna Sang,32,Building,14,2,0,TRUE
+3214307,62.17218845,33.3056415,1,Haji Ibrahim Mosque,Herat,2,Shindand,1,Khwaja Nowh Village,32,Building,14,2,0,TRUE
+3214308,62.15212498,33.29381348,2,Haji Allahudeen Khan Mosque,Herat,3,Shindand,1,Pa Kashak,32,Building,14,3,0,TRUE
+3214309,62.11055951,33.27459786,1,Haji Nazir Mosque,Herat,2,Shindand,1,Khaifan Awal,32,Building,14,0,2,FALSE
+3214310,62.1415658,33.27652779,1,Shir Abad Mosque,Herat,2,Shindand,1,Khaifan Duowm,32,Building,14,0,2,FALSE
+3214311,62.19989236,33.29015061,2,Abdullah Khan Mosque,Herat,3,Shindand,1,Deh Mirza Qasem,32,Building,14,0,3,FALSE
+3214320,61.98628435,33.39957058,2,Deh Alaika Mosque,Herat,3,Shindand,1,Deh Alaika,32,Village,14,0,3,FALSE
+3214321,62.05145618,33.45788104,1,Sangbar Mosque,Herat,3,Shindand,2,Sangbar,32,Building,14,0,3,FALSE
+3214322,62.3063314,33.38188029,2,Qala-E- Mirza Haji Akram Mosque,Herat,3,Shindand,1,Qala-E-Mirza,32,Building,14,3,0,TRUE
+3214323,62.32066825,33.34173507,2,Deh Abdul Aziz School,Herat,3,Shindand,1,Deh Abdul Aziz,32,Building,14,3,0,TRUE
+3214324,62.32015453,33.33863905,3,Madressa Aziz Abad,Herat,4,Shindand,1,Aziz Abad,32,Building,14,2,2,TRUE
+3214325,62.2396184,33.37275404,1,Bazar Qanadi Mosque,Herat,2,Shindand,1,Bazar Qanadi,32,Building,14,2,0,TRUE
+3214326,62.28838682,33.35426936,1,Haji Sultan Khan Mosque,Herat,2,Shindand,1,Deh Pahlawan,32,Village,14,2,0,TRUE
+3214327,62.24986873,33.3659923,1,Mughelan-E-Kuhna Mosque,Herat,2,Shindand,1,Mughelan Village,32,Village,14,2,0,TRUE
+3214328,62.22851468,33.34882861,2,Changan Mosque,Herat,3,Shindand,1,Changan,32,Building,14,3,0,TRUE
+3214329,62.27279413,33.32467051,2,Kohdan Madrassa,Herat,3,Shindand,1,Kohdan,32,Village,14,3,0,TRUE
+3214330,62.25994487,33.30988587,1,Nanisik School,Herat,2,Shindand,1,Nanisik Village,32,Building,14,2,0,TRUE
+3214331,62.24995799,33.29720147,1,Chalosak Mosque,Herat,2,Shindand,1,Chalosak,32,Building,14,0,2,FALSE
+3214332,62.22187356,33.25892481,2,Shahr Abad School,Herat,4,Shindand,2,Shahr Abad-E-Awal,32,Building,14,0,4,FALSE
+3214333,62.17735029,33.22023386,1,Sano Ghan Mosque,Herat,2,Shindand,1,Shahr Abad-E-Duowm,32,Village,14,1,1,TRUE
+3214334,62.17039827,33.21344493,2,Bakht Abad Mosque,Herat,3,Shindand,1,Shahr Abad Seowm,32,Village,14,0,3,FALSE
+3214335,62.20091705,33.22629835,1,Chahar Qala-E-Awal School,Herat,2,Shindand,1,Chahar Qala-E-Awal,32,Village,14,2,0,TRUE
+3214336,62.1931337,33.2060007,1,Chahar Qala-E-Dowom Clinic,Herat,2,Shindand,1,Chahar Qala-E-Duowm,32,Building,14,1,1,TRUE
+3214337,62.17600852,33.19163725,1,Farmakan Mosque,Herat,2,Shindand,1,Farmakan,32,Building,14,1,1,TRUE
+3214344,62.05037739,33.35492412,1,Fajer Mosque,Herat,2,Shindand,1,Fajer Ulya Village,32,Building,14,2,0,TRUE
+3214345,61.96099769,33.29781028,2,Kalata Nazar Khan Mosque,Herat,3,Shindand,1,Kalata Nazar Khan,32,Building,14,3,0,TRUE
+3214346,63.03977999,33.24138871,2,Koh-E- Zoor Qabre Mir Mosque,Herat,3,Shindand,1,Qabre Mir,32,Village,14,3,0,TRUE
+3214347,60.74937186,33.1174875,1,Karizk  Mosque,Herat,2,Shindand,1,Karizk Awal,32,Building,14,2,0,TRUE
+3214349,62.60009551,33.13150753,1,Khair Abad Clinic,Herat,2,Shindand,1,Khair Abad,32,Village,14,2,0,TRUE
+3214350,62.6611117,33.41992411,1,Wakhal Koh-E- Zoor Mosque,Herat,2,Shindand,1,Wakhal,32,Building,14,2,0,TRUE
+3214351,62.98337649,33.50912207,2,Dahan-E-Osha-Koh Zoor Mosque,Herat,3,Shindand,1,Dahan-E- Oshah,32,Building,14,3,0,TRUE
+3214464,62.12684206,33.29699668,1,Sangistan School,Herat,2,Shindand,1,Sangistan,32,Village,14,2,0,TRUE
+3214465,62.22737626,33.29342672,1,Joy-E-Now Mosque,Herat,2,Shindand,1,Jak Village,32,Building,14,0,2,FALSE
+3214466,62.32780741,33.38559719,1,Kashak Mosque,Herat,2,Shindand,1,Kashak,32,Village,14,2,0,TRUE
+3214467,62.18547395,33.23695064,1,Maruf Khel Mosque,Herat,2,Shindand,1,Maruf Khel,32,Village,14,2,0,TRUE
+3215352,63.14177667,33.73400175,4,Kashak Khak Mosque,Herat,5,Fersi,1,Shelah,32,Village,15,5,0,TRUE
+3215353,63.44447472,33.8482119,2,Tik Secondary School,Herat,3,Fersi,1,Tik Village,32,Village,15,3,0,TRUE
+3215354,63.273457143,33.787654374,2,Girls School,Herat,4,Fersi,2,District Center,32,Village,15,4,0,TRUE
+3215355,63.37220099,33.84270495,2,Aab-E- Mahi Mosque,Herat,3,Fersi,1,Aab-E- Mahi,32,Village,15,3,0,TRUE
+3215356,63.20338267,33.89640402,2,Shura-E- Ankishafi Building,Herat,3,Fersi,1,Pay-E- Hesar,32,Village,15,3,0,TRUE
+3215357,63.32277579,33.90478055,1,Shura-E- Ankishafi Building,Herat,3,Fersi,2,Safidan Village,32,Village,15,3,0,TRUE
+3215358,63.36158304,33.95614077,2,Dahan-E-Jar Mosque,Herat,3,Fersi,1,Dahan Jar-E-Bar Pul,32,Village,15,3,0,TRUE
+3215359,63.53460957,33.87827191,2,Haji Aagha Mosque,Herat,3,Fersi,1,Chap Rod,32,Village,15,3,0,TRUE
+3215360,63.14260077,33.87512985,1,Haji Bagh Mosque,Herat,2,Fersi,1,Haji Bagh,32,Village,15,2,0,TRUE
+3215361,63.38391549,33.81440835,3,Shura-E- Ankishafi Shash Yar,Herat,5,Fersi,2,Shash Yar,32,Village,15,5,0,TRUE
+3215362,63.10249105,33.7092821,1,Shura-E- Ankishafi,Herat,2,Fersi,1,Dahn-E-Khob Aab,32,Village,15,2,0,TRUE
+3215363,63.54358733,33.83906243,1,Payezak Village School,Herat,2,Fersi,1,Dahan-E-Peyazak,32,Village,15,2,0,TRUE
+3215364,63.32019687,33.85731371,2,Mosque,Herat,3,Fersi,1,Arkh,32,District,15,3,0,TRUE
+3216389,63.73794786,34.33618934,3,Asadullah-E-Chashti School,Herat,4,Chisht-E-Sharif,1,Chasht-E- Sharif Center,32,Building,16,4,0,TRUE
+3216390,63.74048648,34.35460399,1,Sar Tagab Mosque,Herat,2,Chisht-E-Sharif,1,Sar Tagab Village,32,Building,16,2,0,TRUE
+3216391,63.71612886,34.33191717,1,Kabotar Khan Mosque,Herat,2,Chisht-E-Sharif,1,Kabotar Khan,32,Village,16,2,0,TRUE
+3216392,63.6293418,34.36378226,1,Sony Mosque,Herat,2,Chisht-E-Sharif,1,Sony Village,32,Village,16,2,0,TRUE
+3216393,63.77554101,34.33522005,1,Deh Zabr Mosque,Herat,2,Chisht-E-Sharif,1,Deh Zabr,32,Building,16,2,0,TRUE
+3216394,63.56079533,34.3567349,2,Asfar-E-Dwat School,Herat,3,Chisht-E-Sharif,1,Asfar-E-Dwat,32,Building,16,3,0,TRUE
+3216395,63.67490371,34.35080724,1,Tagaab Ghaza Mosque,Herat,2,Chisht-E-Sharif,1,Tagab Ghaza,32,Building,16,2,0,TRUE
+3216396,63.50490736,34.36923437,1,Arwej School,Herat,2,Chisht-E-Sharif,1,Arwej,32,Building,16,2,0,TRUE
+3216397,63.83922969,34.35181552,1,Salma School,Herat,2,Chisht-E-Sharif,1,Salma,32,Building,16,2,0,TRUE
+3216398,63.90652062,34.3341915,1,Shir Khanj Mosque,Herat,2,Chisht-E-Sharif,1,Shir Khaj,32,Building,16,2,0,TRUE
+3216399,64.05049028,34.36511846,2,Dara Takht Clinic,Herat,3,Chisht-E-Sharif,1,Dar Takht Village,32,Village,16,3,0,TRUE
+3216400,64.05448888,34.47076111,1,Bagh-E-Besmellah Open Space,Herat,2,Chisht-E-Sharif,1,Daragag Village,32,Village,16,2,0,TRUE
+3216401,63.98197222,34.29294722,1,Bagh-E-Haji Mohammad Rahim Open Space,Herat,2,Chisht-E-Sharif,1,Kharzar,32,Village,16,2,0,TRUE
+3216402,63.46655347,34.36799216,1,Rghwaja Mosque,Herat,2,Chisht-E-Sharif,1,Rghwaja,32,Building,16,2,0,TRUE
+3216403,63.93347818,34.31367799,1,Margha Mosque Open Space,Herat,3,Chisht-E-Sharif,2,Margha,32,Village,16,3,0,TRUE
+3216404,63.90336936,34.42480171,1,Cheshwi Open Space,Herat,2,Chisht-E-Sharif,1,Cheshwi,32,Village,16,2,0,TRUE
+3216470,63.9870676,34.37343721,1,Rubatak Mosque,Herat,2,Chisht-E-Sharif,1,Rubatak,32,Village,16,2,0,TRUE
+3216483,64.050541686,34.365095925,2,Shir Khan School,Herat,3,Chisht-E-Sharif,1,Dara Takht,32,Building,16,3,0,TRUE
+3301001,62.11794905,32.37732837,4,Merman Nazo High School,Farah,5,Farah,1,Farah City,33,Building,1,5,0,TRUE
+3301002,62.12217407,32.37460146,4,Abu Nasr Farahi High School,Farah,5,Farah,1,Farah City,33,Building,1,5,0,TRUE
+3301003,62.10666666,32.37472222,4,Agriculture Institute,Farah,6,Farah,2,Farah City,33,Building,1,6,0,TRUE
+3301004,62.1100756,32.40300748,3,Qala-E-Behbod Mosque,Farah,5,Farah,2,Qala-E-Behbod,33,Building,1,5,0,TRUE
+3301005,62.1311743,32.38838896,3,Mosque,Farah,5,Farah,2,Chahar Burjak,33,Building,1,5,0,TRUE
+3301006,62.12194444,32.38361111,4,Askar Abad Mosque,Farah,5,Farah,1,Askar Abad,33,Building,1,5,0,TRUE
+3301007,62.06993643,32.33644003,2,Shor Abad Mosque,Farah,4,Farah,2,Shor Abad,33,Building,1,4,0,TRUE
+3301008,62.09878202,32.323056,3,Girls High School,Farah,5,Farah,2,Kahdanak,33,Building,1,5,0,TRUE
+3301009,62.15353985,32.40172827,3,Secondary School,Farah,4,Farah,1,Karji,33,Building,1,4,0,TRUE
+3301010,62.09027146,32.37807939,2,Chahar Bagh High School,Farah,4,Farah,2,Chahar Bagh,33,Building,1,4,0,TRUE
+3301011,62.1034964,32.38732693,2,Yazdeh Village Boys High School,Farah,4,Farah,2,Yazdeh Village,33,Building,1,4,0,TRUE
+3301012,62.01622067,32.23983508,2,Shir Ali Khan Girls High School,Farah,4,Farah,2,Nawda,33,Building,1,4,0,TRUE
+3301013,61.81425644,32.07295916,3,Secondary School,Farah,4,Farah,1,Tajag,33,Building,1,4,0,TRUE
+3301014,62.13511298,32.41154281,3,Girls High School,Farah,4,Farah,1,Qala-E-Zaman,33,Building,1,4,0,TRUE
+3301015,62.03144961,32.34977833,2,Molla Moeen High School,Farah,4,Farah,2,Dar Abad Bala,33,Building,1,4,0,TRUE
+3301016,62.02308883,32.38542335,3,Boys High School,Farah,5,Farah,2,Ruj,33,Building,1,5,0,TRUE
+3301018,61.98301329,32.37155417,3,Secondary School,Farah,4,Farah,1,Kariz Shaikh Ha,33,Building,1,4,0,TRUE
+3301019,62.26230555,32.49847222,2,Shamalgah High School,Farah,4,Farah,2,Shamalgah,33,Building,1,4,0,TRUE
+3301020,61.99301842,32.20782869,3,Shaheed Benafsha Girls High School,Farah,4,Farah,1,Towisak,33,Building,1,4,0,TRUE
+3301021,61.97342315,32.22133251,3,Kok Sheeb Mosque,Farah,4,Farah,1,Kok Sheeb,33,Building,1,4,0,TRUE
+3301022,62.00820125,32.28035796,3,Girls Primary School,Farah,4,Farah,1,Kok Ulya,33,Building,1,4,0,TRUE
+3301023,62.03900785,32.37837612,3,Boys High School,Farah,4,Farah,1,Ginehkan,33,Building,1,4,0,TRUE
+3301024,62.0252258,32.33669987,4,Girls High School,Farah,5,Farah,1,Dar Abad Payen,33,Building,1,5,0,TRUE
+3301025,62.11806938,32.41074288,2,Secondary School,Farah,4,Farah,2,Regi Kalan,33,Building,1,4,0,TRUE
+3301026,62.20400833,32.46806666,2,Sor Shurab High School,Farah,4,Farah,2,Sor Shurab,33,Building,1,4,0,TRUE
+3301027,62.06882933,32.39318095,3,Primary School,Farah,4,Farah,1,Barank Toot,33,Building,1,4,0,TRUE
+3301028,62.16791318,32.44646088,3,Boys High School,Farah,4,Farah,1,Dehak Kalan,33,Building,1,4,0,TRUE
+3301029,62.12644207,32.37901793,2,Malalai Maiwand Girls High School,Farah,4,Farah,2,Nahia 1,33,Building,1,4,0,TRUE
+3301030,62.1025,32.36805555,2,Mahboba Popal Girls High School,Farah,4,Farah,2,Nahia 4,33,Building,1,4,0,TRUE
+3301031,61.92575396,32.07098589,3,Takht Mosque,Farah,4,Farah,1,Takht,33,Building,1,4,0,TRUE
+3301032,62.11838048,32.36062887,3,Boys High School,Farah,5,Farah,2,Qala-E-Arbab,33,Building,1,5,0,TRUE
+3301033,62.11456154,32.3731526,2,Tawfiq Merzaye High School,Farah,4,Farah,2,Nahia 3,33,Building,1,4,0,TRUE
+3301034,62.07623693,32.36831305,4,Girls High School,Farah,5,Farah,1,Bagh-E-Pul,33,Building,1,5,0,TRUE
+3301035,62.10462594,32.35572093,3,Qala-E-Mohammad Mosque,Farah,4,Farah,1,Qala-E-Mohammad,33,Building,1,4,0,TRUE
+3301036,61.96818638,32.358606635,1,Kariz Shaikh Ha Western Tent,Farah,3,Farah,2,Amir Abad (Kuchi),33,Village,1,3,0,TRUE
+3301246,62.047366056,32.283767259,3,Kariz Male School,Farah,4,Farah,1,Karizak,33,Building,1,4,0,TRUE
+3301247,62.086483843,32.354502063,2,Sang Zor Mosque,Farah,3,Farah,1,Sang Zor,33,Building,1,3,0,TRUE
+3302039,62.0345693,32.4731256,2,Qala Masaw Madrassa,Farah,3,Pushtrud,1,Qala-E-Masaw,33,Building,2,3,0,TRUE
+3302040,62.04417694,32.45730227,1,Masaw Agriculture High School,Farah,2,Pushtrud,1,Masaw,33,Building,2,2,0,TRUE
+3302041,62.00302702,32.41413729,3,Rokin Secondary School,Farah,4,Pushtrud,1,Rokin,33,Building,2,4,0,TRUE
+3302042,62.13953171,32.49169223,1,Khwaja Abdullah Bedar High School,Farah,2,Pushtrud,1,Chin Farsi,33,Building,2,2,0,TRUE
+3302043,62.1266819,32.51396093,2,Dokeen Primary School,Farah,3,Pushtrud,1,Dokeen Village,33,Building,2,3,0,TRUE
+3302045,62.03218663,32.41691717,1,Naw Bahar Mosque,Farah,2,Pushtrud,1,Naw Bahar,33,Building,2,2,0,TRUE
+3302049,62.069448492,32.428438885,2,Khatiban Mosque,Farah,3,Pushtrud,1,Khatiban Village,33,Building,2,3,0,TRUE
+3302050,62.10070674,32.44507882,2,Baland Deh Village Mosque,Farah,3,Pushtrud,1,Baland Deh Village,33,Village,2,3,0,TRUE
+3302231,62.1216608,32.47621659,1,Gajgin School,Farah,2,Pushtrud,1,Gajgin,33,Building,2,2,0,TRUE
+3302234,62.06173023,32.44085307,1,Shahr-E-Kohna Mosque,Farah,2,Pushtrud,1,Shahr-E-Kohna,33,Building,2,2,0,TRUE
+3303051,62.16007579,32.66765262,2,Khushk Aaba Mosque,Farah,3,Khak-E-Safed,1,Khushk Aaba,33,Village,3,3,0,TRUE
+3303052,62.10392498,32.65404399,2,Deh Naw High School,Farah,3,Khak-E-Safed,1,Deh Naw,33,Building,3,3,0,TRUE
+3303055,61.90357121,32.90659178,1,Kariz Sadiq Mosque,Farah,2,Khak-E-Safed,1,Kariz Sadiq,33,Village,3,2,0,TRUE
+3304072,61.29710971,32.29932536,2,Hassan Abad Ulya Mosque,Farah,3,Qala-E-Kah,1,Hassan Abad Ulya,33,Building,4,3,0,TRUE
+3304073,61.38558377,32.30081235,1,Kalatah Shirdel Mosque,Farah,2,Qala-E-Kah,1,Kalata Shirdel,33,Building,4,2,0,TRUE
+3304074,61.2565104,32.23943038,2,Jumaa Ali  Mosque,Farah,3,Qala-E-Kah,1,Juma Ali,33,Building,4,3,0,TRUE
+3304075,61.07509497,32.46001047,1,Rubat  Mosque,Farah,2,Qala-E-Kah,1,Rubat,33,Building,4,2,0,TRUE
+3304076,61.49099488,32.31405139,2,Duzd Bad  Mosque,Farah,3,Qala-E-Kah,1,Duzd Bad,33,Building,4,3,0,TRUE
+3304077,61.41855049,32.35351085,1,Chah-E-Zendan Boys High School,Farah,2,Qala-E-Kah,1,Chah-E-Zendan,33,Village,4,2,0,TRUE
+3304078,61.61525975,32.27808974,2,Malak Akhtar Mosque,Farah,3,Qala-E-Kah,1,Duzd Bar,33,Building,4,0,3,FALSE
+3304079,61.40023357,32.4157683,1,Or Mosque,Farah,2,Qala-E-Kah,1,Or,33,Village,4,2,0,TRUE
+3304080,61.51874713,32.29507163,1,Kashkak  Mosque,Farah,2,Qala-E-Kah,1,Kashkak,33,Building,4,2,0,TRUE
+3304081,61.46067297,32.36393134,1,Gang Primary School,Farah,2,Qala-E-Kah,1,Ganak,33,Building,4,2,0,TRUE
+3304082,61.39152322,32.34646992,1,Kojar Mosque,Farah,2,Qala-E-Kah,1,Kojar,33,Building,4,2,0,TRUE
+3304083,61.26587613,32.30023301,1,Joy-E-Cheshma Mosque,Farah,2,Qala-E-Kah,1,Joy-E-Cheshma,33,Building,4,2,0,TRUE
+3304084,61.46122843,32.40668272,1,Karizak Mosque,Farah,2,Qala-E-Kah,1,Karizak,33,Village,4,2,0,TRUE
+3304248,61.390737446,32.43890723,2,Angiran School,Farah,3,Qala-E-Kah,1,Anjeeran,33,Building,4,3,0,TRUE
+3304249,61.468347642,32.287586839,2,Guest Mosque,Farah,3,Qala-E-Kah,1,Guest,33,Building,4,3,0,TRUE
+3305085,61.6102524,32.13212975,2,Keen High School,Farah,3,Shib Koh,1,Keen Village,33,Building,5,3,0,TRUE
+3305086,61.56286955,32.15675938,1,Dehzak Primary School,Farah,2,Shib Koh,1,Dehzak,33,Building,5,2,0,TRUE
+3305087,61.50079758,32.15081049,1,Shoshak Primary School,Farah,2,Shib Koh,1,Shoshak,33,Building,5,2,0,TRUE
+3305088,61.455353,32.14780934,2,Du Qala Girls High School,Farah,3,Shib Koh,1,Du Qala,33,Building,5,3,0,TRUE
+3305089,61.69447103,32.13557191,1,Bajdeh Primary School,Farah,2,Shib Koh,1,Bajdeh,33,Building,5,2,0,TRUE
+3305090,61.84916666,32.17527777,1,Dawra Joy High School,Farah,2,Shib Koh,1,Dawra Joy,33,Building,5,2,0,TRUE
+3305091,61.88418603,32.16598197,2,Ilyas Abad Primary School,Farah,3,Shib Koh,1,Ilyas Abad,33,Building,5,3,0,TRUE
+3305092,61.7773784,32.31762798,1,Mohammad Abad Primary School,Farah,2,Shib Koh,1,Mohammad Abad,33,Building,5,2,0,TRUE
+3305093,61.71466207,32.3192884,1,Primary School,Farah,2,Shib Koh,1,Kariz Malham,33,Building,5,2,0,TRUE
+3305094,61.41170881,32.14500638,2,Jarag Primary School,Farah,3,Shib Koh,1,Jarag,33,Building,5,3,0,TRUE
+3305240,61.74648794,32.16375788,1,Hawzak-E- Mohammad Aslam School,Farah,2,Shib Koh,1,Hawzak Mohammad Aslam,33,Building,5,2,0,TRUE
+3305250,61.657047843,32.147598188,2,Chaka Primary School,Farah,3,Shib Koh,1,Chaka,33,Building,5,3,0,TRUE
+3305251,61.483850818,32.132917547,2,Farib Primary School,Farah,3,Shib Koh,1,Farib,33,Building,5,3,0,TRUE
+3306127,62.42233778,32.62086967,2,Grani Primary School,Farah,3,Bala Buluk,1,Grani,33,Building,6,3,0,TRUE
+3306128,62.45813061,32.63172393,1,Ganj Abad Primary School,Farah,2,Bala Buluk,1,Ganj Abad,33,Building,6,2,0,TRUE
+3306129,62.33412667,32.54818493,1,Kanisak Primary School,Farah,2,Bala Buluk,1,Kanisak,33,Building,6,2,0,TRUE
+3306130,62.57924905,32.76357594,1,Todanak Mosque,Farah,2,Bala Buluk,1,Todanak,33,Building,6,2,0,TRUE
+3306131,62.50251429,32.62113816,2,Shewan Mosque,Farah,3,Bala Buluk,1,Shewan Village,33,Building,6,3,0,TRUE
+3306132,62.4912698,32.61780017,1,Shaikh Lala Mosque,Farah,2,Bala Buluk,1,Shaikh Lala,33,Village,6,2,0,TRUE
+3306133,62.529785,32.62565913,1,Kal Qala Mosque,Farah,2,Bala Buluk,1,Kal Qala,33,Building,6,2,0,TRUE
+3306134,62.59850452,32.75348018,2,Primary School,Farah,3,Bala Buluk,1,Farah Rud,33,Building,6,3,0,TRUE
+3306135,62.52486473,32.61148454,1,Dehzak Mosque,Farah,2,Bala Buluk,1,Dehzak,33,Building,6,2,0,TRUE
+3306136,62.92185757,32.55465646,1,Chakab Mosque,Farah,2,Bala Buluk,1,Chakab,33,Building,6,2,0,TRUE
+3306149,62.57846224,32.76432537,1,Todanak Village Tent (Kuchi),Farah,2,Bala Buluk,1,Todanak Village,33,Village,6,2,0,TRUE
+3306162,62.44632689,32.86689739,2,Aab Khurma Mosque,Farah,3,Bala Buluk,1,Aab Khurma,33,Building,6,3,0,TRUE
+3306244,62.51387533,32.62319585,1,Haji Mohammd Ewaz Mosque,Farah,2,Bala Buluk,1,Khwaja Khezar,33,Building,6,2,0,TRUE
+3307062,61.60036193,32.64492685,2,Zehkan School,Farah,3,Anar Dara,1,Zehkan,33,Building,7,3,0,TRUE
+3307063,61.56688102,32.59032773,1,Kalata Alam Khan New Secondary School,Farah,2,Anar Dara,1,Kalata Alam Khan,33,Building,7,2,0,TRUE
+3307064,61.65126257,32.76068803,2,Shaikh Abdul Samad Nazari High School,Farah,3,Anar Dara,1,Anar Dara Center,33,Building,7,3,0,TRUE
+3307065,61.64947947,32.79953858,1,Kalata Mulla Haidar Primary School,Farah,2,Anar Dara,1,Kalata Mulla Haidar,33,Building,7,2,0,TRUE
+3307066,61.79102267,32.76143091,2,Kalata Sadat Mosque,Farah,3,Anar Dara,1,Kalata Sadat,33,Village,7,3,0,TRUE
+3307067,61.68626439,32.7082935,1,Gorkak Mosque,Farah,2,Anar Dara,1,Gorkak,33,Building,7,2,0,TRUE
+3307068,61.53959367,32.61747477,2,Sadka Mosque,Farah,3,Anar Dara,1,Sadkah,33,Building,7,3,0,TRUE
+3307071,61.57827189,32.63090687,1,Bujok Mosque,Farah,2,Anar Dara,1,Bujok Village,33,Building,7,2,0,TRUE
+3308108,62.94936649,32.24138994,4,Center Mosque (Sultan Bakwa),Farah,5,Bakwa,1,Bakwa District Center,33,Village,8,5,0,TRUE
+3309095,61.62028091,31.71167042,2,Ibn-E-Eman Jaweni High School,Farah,3,Lash-E-Juwayn,1,Jawin District Center,33,Building,9,3,0,TRUE
+3309096,61.60077655,31.70022861,1,Laftan Girls School,Farah,2,Lash-E-Juwayn,1,Laftan,33,Building,9,2,0,TRUE
+3309097,61.50522186,31.62775303,2,Daraq Secondary School,Farah,4,Lash-E-Juwayn,2,Daraq,33,Building,9,4,0,TRUE
+3309098,61.50595113,31.50046354,1,Deh Shaikh Mosque,Farah,2,Lash-E-Juwayn,1,Deh Shaikh,33,Building,9,2,0,TRUE
+3309099,61.669087743,31.56609036,1,Dewalak Ha Secondary School,Farah,2,Lash-E-Juwayn,1,Dewalak Ha,33,Building,9,2,0,TRUE
+3309100,61.4925271,31.58175551,2,Dombalai Ulya Primary School,Farah,3,Lash-E-Juwayn,1,Dombalai Ulya,33,Building,9,3,0,TRUE
+3309101,61.51447912,31.57149851,1,Khair Abad Mosque,Farah,2,Lash-E-Juwayn,1,Khair Abad,33,Village,9,2,0,TRUE
+3309102,61.59400971,31.49898442,1,Kando Karogh Mosque,Farah,2,Lash-E-Juwayn,1,Kando Karogh,33,Building,9,2,0,TRUE
+3309103,61.4677033,31.53374694,1,Qoch Secondary School,Farah,2,Lash-E-Juwayn,1,Qoch,33,Building,9,2,0,TRUE
+3309104,61.62042119,31.78028705,1,Char Gawak Ulya Mosque,Farah,2,Lash-E-Juwayn,1,Char Gawak,33,Building,9,2,0,TRUE
+3309105,61.54311383,31.69199783,1,Samsor Primary School,Farah,2,Lash-E-Juwayn,1,Samsor,33,Building,9,2,0,TRUE
+3309106,61.62328569,31.93153531,1,Peer Kandar Primary School,Farah,2,Lash-E-Juwayn,1,Peer Kandar,33,Building,9,2,0,TRUE
+3309107,61.58565518,31.74783562,2,Panj Deh Primary School,Farah,3,Lash-E-Juwayn,1,Panj Deh,33,Building,9,3,0,TRUE
+3309252,61.67071436,31.948599928,2,Sabz Gazi School,Farah,3,Lash-E-Juwayn,1,Sabz Gazi,33,Building,9,3,0,TRUE
+3310168,63.66244498,32.61062311,2,Qala Kohna Girls Primary School,Farah,3,Gulistan,1,Qala-E-Kohna,33,Village,10,3,0,TRUE
+3310172,63.6732466,32.61456274,2,Qala Kohna Boys Primary School,Farah,3,Gulistan,1,Qala-E-Kohna,33,Village,10,3,0,TRUE
+3310177,63.23385868,32.55547772,1,Mughol Abad Mosque,Farah,2,Gulistan,1,Mughol Abad,33,Village,10,2,0,TRUE
+3310179,63.48920004,32.81122321,2,Toot Mosque,Farah,3,Gulistan,1,Toot,33,Village,10,3,0,TRUE
+3311186,63.7967043,33.00991384,2,Rubat Larwand Primary School,Farah,3,Pur Chaman,1,Rubat Larwand,33,Building,11,2,1,TRUE
+3311187,63.9258869,32.97648092,2,Khurram Jan Primary School,Farah,3,Pur Chaman,1,Khurram Jan,33,Building,11,3,0,TRUE
+3311188,63.30637977,33.1640279,1,Farah Rud Mosque,Farah,2,Pur Chaman,1,Farah Rud,33,Building,11,2,0,TRUE
+3311189,63.8368371,32.88883985,2,Chorag Primary School,Farah,3,Pur Chaman,1,Chorag,33,Building,11,3,0,TRUE
+3311190,64.21199809,33.00457793,1,Sepawast Mosque,Farah,2,Pur Chaman,1,Sepawast,33,Building,11,2,0,TRUE
+3311191,63.53866753,33.1584699,2,Nezagan Primary School,Farah,3,Pur Chaman,1,Nezagan,33,Building,11,3,0,TRUE
+3311192,63.59038846,33.30102571,1,Gerd Khola Mosque,Farah,2,Pur Chaman,1,Gerd Khola,33,Building,11,2,0,TRUE
+3311193,64.16078924,33.16476628,1,Wasp Mosque,Farah,2,Pur Chaman,1,Wasp,33,Building,11,2,0,TRUE
+3311194,63.86611111,33.14194444,1,Takht-E-Parcham High School,Farah,2,Pur Chaman,1,Purchaman,33,Building,11,2,0,TRUE
+3311195,64.01601197,33.10193494,1,Tolai Mosque,Farah,2,Pur Chaman,1,Tolai,33,Building,11,2,0,TRUE
+3311196,63.9618913,33.45026779,1,Lakhsar Mosque,Farah,2,Pur Chaman,1,Lakhsar,33,Building,11,2,0,TRUE
+3311197,63.6202854,33.01451077,1,Barfshar Mosque,Farah,2,Pur Chaman,1,Barfshar,33,Building,11,2,0,TRUE
+3311198,64.12027777,33.2475,1,Kot Mosque,Farah,2,Pur Chaman,1,Kot,33,Building,11,2,0,TRUE
+3311199,63.51930575,33.26250774,1,Shahr Yari Mosque,Farah,2,Pur Chaman,1,Shahr Yari,33,Village,11,2,0,TRUE
+3311200,63.309833,33.609177,1,Damana Mosque,Farah,2,Pur Chaman,1,Damana,33,Village,11,0,2,FALSE
+3311201,63.65673637,33.3113668,1,Raz Kelagai Mosque,Farah,2,Pur Chaman,1,Raz Kelagai,33,Building,11,2,0,TRUE
+3311202,63.52479168,33.32380613,1,Kesht Baj Mosque,Farah,2,Pur Chaman,1,Kesht Baj,33,Building,11,2,0,TRUE
+3311203,63.8090856,33.34990626,1,Larust Mosque,Farah,2,Pur Chaman,1,Larust,33,Building,11,2,0,TRUE
+3311204,63.85502321,33.42758509,1,Walima Mosque,Farah,2,Pur Chaman,1,Walima,33,Building,11,2,0,TRUE
+3311205,63.75555555,33.18888888,1,Kamarak Bala Mosque,Farah,2,Pur Chaman,1,Kamarak Bala,33,Building,11,2,0,TRUE
+3311206,64.12575186,32.98412754,1,Ejan Mosque,Farah,2,Pur Chaman,1,Ejan,33,Building,11,2,0,TRUE
+3311207,64.12643681,32.95242711,1,Khaar Mosque,Farah,2,Pur Chaman,1,Khaar,33,Building,11,2,0,TRUE
+3311208,64.00260836,33.00137676,2,Aab Shu Mosque,Farah,3,Pur Chaman,1,Aab Shu,33,Building,11,3,0,TRUE
+3311209,63.92381624,32.88649914,2,Nar Ghar Mosque,Farah,3,Pur Chaman,1,Nar Ghar,33,Building,11,3,0,TRUE
+3311210,63.75712001,32.85543863,1,Tajgo Mosque,Farah,2,Pur Chaman,1,Tajgo Mosque,33,Building,11,2,0,TRUE
+3311211,63.78587334,32.99876741,1,Arghaman Mosque,Farah,2,Pur Chaman,1,Arghaman,33,Building,11,2,0,TRUE
+3311212,63.46842169,33.13831635,2,Khair Abad Mosque,Farah,3,Pur Chaman,1,Khair Abad,33,Building,11,3,0,TRUE
+3311213,63.84086121,33.01453635,1,Deh Turkan Mosque,Farah,2,Pur Chaman,1,Deh Turkan,33,Building,11,2,0,TRUE
+3311214,64.13805555,32.92138888,1,Dukhari Mosque ( Kochi ),Farah,2,Pur Chaman,1,Dukhari (Kochi),33,Building,11,2,0,TRUE
+3311215,63.76003546,32.85031392,1,Rud-E-Bar Zuri Mosque,Farah,2,Pur Chaman,1,Rud-E-Bar Zuri (Kuchi),33,Building,11,2,0,TRUE
+3311216,63.30060398,32.96528441,1,Kalwesht Mosque,Farah,2,Pur Chaman,1,Kalwesht,33,Building,11,0,2,FALSE
+3311217,64.26344748,33.20614098,1,Kawan Mughol Mosque,Farah,2,Pur Chaman,1,Kawan Mughol,33,Building,11,2,0,TRUE
+3311218,63.87902593,33.43812165,1,Werdari Mosque,Farah,2,Pur Chaman,1,Werdari,33,Building,11,2,0,TRUE
+3311219,63.64472222,33.35555555,1,Wery Mosque,Farah,2,Pur Chaman,1,Wery,33,Building,11,2,0,TRUE
+3311245,63.88263304,32.86664807,2,Wal Village Mosque,Farah,3,Pur Chaman,1,Wal Village,33,Building,11,3,0,TRUE
+3401001,61.87374648,30.96564667,4,Estiqlal High School,Nimroz,6,Zaranj,2,Zaranj,34,Building,1,6,0,TRUE
+3401002,61.8555322,30.96526748,4,Agriculture Department,Nimroz,7,Zaranj,3,Zaranj,34,Building,1,8,0,TRUE
+3401003,61.85831177,30.9465754,4,Rud Aaba High School,Nimroz,6,Zaranj,2,Zaranj,34,Building,1,9,0,TRUE
+3401004,61.85829083,30.96086426,4,Girls High School,Nimroz,7,Zaranj,3,Zaranj,34,Building,1,8,0,TRUE
+3401005,61.85807575,30.95482601,4,Farkhi High School,Nimroz,6,Zaranj,2,Zaranj,34,Building,1,6,0,TRUE
+3401006,61.88913335,30.95485723,3,Zaranj Primary School,Nimroz,5,Zaranj,2,Zaranj,34,Building,1,5,0,TRUE
+3401007,61.858275,30.946666,2,Zaranj Hostel,Nimroz,3,Zaranj,1,Zaranj,34,Village,1,3,0,TRUE
+3401008,61.89371427,30.96485657,3,Camp Hendi Ha,Nimroz,5,Zaranj,2,Zaranj,34,Building,1,7,0,TRUE
+3401058,61.862519036,30.938905545,2,Alhaqia Sistan,Nimroz,3,Zaranj,1,Plan 6/7 Shahri(City 6/7 Plan),34,Building,1,4,0,TRUE
+3401059,61.810487543,30.850425819,2,Firoza Gai Primary School,Nimroz,3,Zaranj,1,Firoza Gai,34,Building,1,3,0,TRUE
+3402011,61.81553352,31.11334376,2,Makaki School,Nimroz,3,Kang,1,Makaki,34,Building,2,3,0,TRUE
+3402012,61.90114786,31.18024088,1,Dasht School,Nimroz,2,Kang,1,Dasht,34,Building,2,2,0,TRUE
+3402013,61.78768858,31.32320843,1,Karki School,Nimroz,2,Kang,1,Karki,34,Building,2,2,0,TRUE
+3402014,61.7801873,31.20306659,2,Telaye School,Nimroz,3,Kang,1,Telaye,34,Building,2,3,0,TRUE
+3402015,61.83244189,31.18757628,1,Haji Nabi Jan School,Nimroz,2,Kang,1,Haji Nabi Jan,34,Building,2,2,0,TRUE
+3402016,61.80786074,31.14829375,2,Darwish School,Nimroz,4,Kang,2,Darwish,34,Building,2,4,0,TRUE
+3402017,61.8299774,31.06209376,1,Deh Raees Village School,Nimroz,2,Kang,1,Deh Raees Village,34,Building,2,2,0,TRUE
+3402018,61.82101389,31.27160914,1,Dehak-E-Naroye School,Nimroz,2,Kang,1,Dehak-E-Naroye,34,Building,2,2,0,TRUE
+3402019,61.72277777,31.40194444,1,Sar Loof Village School,Nimroz,2,Kang,1,Sar Loof Village,34,Building,2,2,0,TRUE
+3402060,61.785463941,31.419475393,2,Gargich School,Nimroz,3,Kang,1,Mullah Rasool,34,Building,2,3,0,TRUE
+3403029,62.06514172,31.17644782,2,New School,Nimroz,4,Asl-E-Chakhansur,2,Chakhan Soor,34,Building,3,4,0,TRUE
+3403030,62.32504904,31.33500508,2,Khwaja Surjo House,Nimroz,3,Asl-E-Chakhansur,1,Khwaja Surjo,34,Building,3,3,0,TRUE
+3403031,62.19142924,31.21664866,2,Sahib Dad School,Nimroz,3,Asl-E-Chakhansur,1,Sahib Dad,34,Building,3,3,0,TRUE
+3403032,62.07678051,31.21645787,2,Shah Qais School,Nimroz,3,Asl-E-Chakhansur,1,Shah Qais Village,34,Building,3,3,0,TRUE
+3403033,62.13666985,31.17062876,2,Amir Bunyad School,Nimroz,3,Asl-E-Chakhansur,1,Amir Bunyad Village,34,Building,3,3,0,TRUE
+3403034,62.15561535,31.23121654,2,Abdul Rahman House,Nimroz,3,Asl-E-Chakhansur,1,Abdul Rahman House,34,Building,3,3,0,TRUE
+3403035,62.04925291,31.18500958,1,Dasht-E-Masoom Khan,Nimroz,2,Asl-E-Chakhansur,1,Dasht,34,Building,3,2,0,TRUE
+3403036,62.02335861,31.16808355,2,Sar Gaz School,Nimroz,3,Asl-E-Chakhansur,1,Sar Gaz,34,Building,3,3,0,TRUE
+3403037,62.14721278,31.20377857,1,Haji Sediq Rooms,Nimroz,2,Asl-E-Chakhansur,1,Deh Naw,34,Building,3,2,0,TRUE
+3403038,62.38432313,31.38601012,1,Mohammad Dawood Khan House,Nimroz,2,Asl-E-Chakhansur,1,Awar Balochi,34,Village,3,2,0,TRUE
+3403061,62.039847144,31.242513384,2,Sarkanak School,Nimroz,3,Asl-E-Chakhansur,1,Haji Mir Ali,34,Building,3,3,0,TRUE
+3403062,62.200841533,31.257216463,2,Open Field,Nimroz,3,Asl-E-Chakhansur,1,"Mullah Abdullah, Sarak",34,Village,3,3,0,TRUE
+3404020,62.05777777,30.27861111,1,District Center Hospital,Nimroz,4,Char Burjak,3,Char Burjak District Center,34,Building,4,4,0,TRUE
+3404021,62.06,30.27944444,2,New School,Nimroz,3,Char Burjak,1,Char Burjak District Center,34,Building,4,3,0,TRUE
+3404022,62.27694444,30.19944444,2,Khajo School,Nimroz,4,Char Burjak,2,Khajo,34,Building,4,4,0,TRUE
+3404023,61.9430732,30.27797043,2,Karkati Mosque,Nimroz,3,Char Burjak,1,Bandar,34,Village,4,3,0,TRUE
+3404024,61.85443414,30.37172949,1,Chagni School,Nimroz,2,Char Burjak,1,Chagni,34,Building,4,2,0,TRUE
+3404025,61.85000921,30.55341485,2,Qala-E-Fatih School,Nimroz,3,Char Burjak,1,Qala-E-Fatih,34,Building,4,3,0,TRUE
+3404026,61.78729865,30.27901626,2,Haji Eid Mohammad House,Nimroz,3,Char Burjak,1,Rubat,34,Village,4,3,0,TRUE
+3404027,62.59607634,30.15261987,1,Haji Gul Mohammad House,Nimroz,2,Char Burjak,1,Rud Bar,34,Village,4,2,0,TRUE
+3404028,62.21083333,30.20861111,2,Jahan Big Village School,Nimroz,3,Char Burjak,1,Jahan Big Village,34,District,4,3,0,TRUE
+3404063,61.771187175,30.195242705,2,Karodi School,Nimroz,3,Char Burjak,1,Karodi Haji Muhammad Amin,34,Building,4,3,0,TRUE
+3404064,62.163891776,30.245990361,2,Ashkanak School,Nimroz,3,Char Burjak,1,Eshkanak Haji Joma Khan,34,Building,4,3,0,TRUE
+3405039,62.62685807,31.44082135,1,Hamid Karzai High School,Nimroz,4,Khashrod,3,Ghar Ghari,34,Building,5,4,0,TRUE
+3405040,62.75808678,31.53622785,2,Jama Mosque,Nimroz,3,Khashrod,1,Qala-E-Now,34,Village,5,0,3,FALSE
+3405041,63.00438112,31.67311151,2,Dewalak School,Nimroz,4,Khashrod,2,Dewlak,34,Village,5,0,4,FALSE
+3405042,62.88170446,31.62957679,2,Lowkhi Village School,Nimroz,3,Khashrod,1,Lowkhi Village,34,Village,5,0,3,FALSE
+3405043,62.93662182,31.66180747,1,Pusht Hassan Village Mosque,Nimroz,2,Khashrod,1,Pusht Hassan Village,34,Village,5,0,2,FALSE
+3405044,63.13647352,31.97352698,2,Dehmazang Village Mosque,Nimroz,3,Khashrod,1,Dehmazang Village,34,Village,5,2,1,TRUE
+3405045,62.79058819,31.52910791,1,Khash Village Mosque,Nimroz,2,Khashrod,1,Khash Village,34,Village,5,0,2,FALSE
+3405046,63.00343441,31.77137123,2,Manaar Village Mosque,Nimroz,3,Khashrod,1,Manaar Village,34,Building,5,2,1,TRUE
+3406047,63.42042621,32.16304705,2,Girls Primary School,Nimroz,4,Delaram,2,District Capital,34,Building,6,2,2,TRUE
+3406048,63.42869205,32.16288698,2,Boys Primary School,Nimroz,3,Delaram,1,District Capital,34,Building,6,2,1,TRUE
+3406049,63.42360641,32.1675797,2,Gulistan Health Clinic,Nimroz,3,Delaram,1,District Capital,34,Building,6,1,2,TRUE
+3406050,63.11865338,31.91816269,1,Raken Village Mosque,Nimroz,2,Delaram,1,Raken Village,34,Village,6,0,2,FALSE
+3406051,63.15784135,31.9991293,1,Astawi Village,Nimroz,2,Delaram,1,Astawi Village,34,Village,6,0,2,FALSE
+3406052,63.37767331,32.14136882,1,Gawmeshi,Nimroz,2,Delaram,1,Gawmeshi,34,Village,6,2,0,TRUE
+3406053,63.27731742,32.05208966,1,Perozi Village,Nimroz,2,Delaram,1,Perozi Village,34,Village,6,0,2,FALSE
+3406054,63.42588432,32.15816295,2,Shelagi,Nimroz,3,Delaram,1,Shelagi,34,Building,6,0,3,FALSE
+3406055,63.49609533,32.17041944,1,Kech Star,Nimroz,2,Delaram,1,Kech Star,34,Village,6,0,2,FALSE
+3406056,63.51668076,32.17608693,1,Pozagi,Nimroz,2,Delaram,1,Pozagi,34,Village,6,0,2,FALSE
+3406057,63.55801623,32.1934924,1,Dangar Abad,Nimroz,2,Delaram,1,Dangar Abad,34,Village,6,0,2,FALSE


### PR DESCRIPTION
New files have been added to the IEC website denoting open and closed polling stations:
http://www.iec.org.af/results/pdf/RunOff/runoff_total_open_PC_PS.pdf
http://www.iec.org.af/results/pdf/RunOff/closedPollingStations.pdf
http://www.iec.org.af/results/pdf/RunOff/en/OpenPC.pdf

This commit adds three variables to the planned polling centers:

- Number of closed polling stations
- Number of open polling stations
- Whether the polling center is classified as open or closed. The IEC does not classify at the polling center level but rather lists the polling station level. We decided that the IDs of polling centers cited in the open polling stations list are "open" and the rest are closed. Any intersection between the PCs in the open and closed PS lists are marked as open PC.
